### PR TITLE
removing static url error from pdf links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Roadmap 2020
 
 ### General Updates
-- Added printable PDFs for the roadmaps: [Frontend Roadmap](https://roadmap.sh/static/roadmaps/pdf/frontend.pdf), [Backend Roadmap](https://roadmap.sh/static/roadmaps/pdf/backend.pdf), [DevOps Roadmap](https://roadmap.sh/static/roadmaps/pdf/devops.pdf)
+- Added printable PDFs for the roadmaps: [Frontend Roadmap](https://roadmap.sh/roadmaps/pdf/frontend.pdf), [Backend Roadmap](https://roadmap.sh/roadmaps/pdf/backend.pdf), [DevOps Roadmap](https://roadmap.sh/roadmaps/pdf/devops.pdf)
 - Updated [the license](https://github.com/kamranahmedse/developer-roadmap/blob/master/LICENSE) with some additional details
 - Added the missing code-of-conduct, issue/pr templates.
 - Better legends in roadmaps.


### PR DESCRIPTION
#### What roadmap does this PR target?

N/A, targets the Changelog markdown file.

#### Please acknowledge the items listed below

- [ ] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [ ] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing.md) before opening this PR.

#### Enter the details about the contribution

Simple PR to fix the 3 broken URL's leading to the pdf versions of the three roadmaps.