### PR TITLE
Fix DBA Link that 404s

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Python Roadmap](https://roadmap.sh/python)
 - [Go Roadmap](https://roadmap.sh/golang)
 - [Java Roadmap](https://roadmap.sh/java)
-- [DBA Roadmap](https://roadmap.sh/dba)
+- [DBA Roadmap](https://roadmap.sh/postgresql-dba)
 
 ![](https://i.imgur.com/waxVImv.png)
 


### PR DESCRIPTION
#### What roadmap does this PR target?

- [ ] Code Change
- [ ] Frontend Roadmap
- [ ] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [ ] Guides

#### Please acknowledge the items listed below

- [ ] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [X] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [X] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [X] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

<!-- Enter the details here -->

The link, `https://roadmap.sh/dba`, to the DBA guide in the GitHub README doc does not work. This update fixes the link in the README to be the same one on the website homepage.