### PR TITLE
enhancement: Header pages links colors

### DIFF
--- a/components/global-header.tsx
+++ b/components/global-header.tsx
@@ -1,42 +1,120 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { HamburgerIcon } from '@chakra-ui/icons';
-import { Box, CloseButton, Container, Flex, IconButton, Image, Link, Stack, Text } from '@chakra-ui/react';
+import {
+  Box,
+  CloseButton,
+  Container,
+  Flex,
+  IconButton,
+  Image,
+  Link,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
 import RoadmapLogo from '../components/icons/roadmap.svg';
 import siteConfig from '../content/site.json';
 
-type MenuLinkProps = {
+interface MenuLinkProps {
+  active: boolean;
   text: string;
   link: string;
-};
-
-function MenuLink(props: MenuLinkProps) {
-  const { text, link } = props;
-
-  return <Link
-    borderBottomWidth={0}
-    borderBottomColor='gray.500'
-    _hover={{ textDecoration: 'none', borderBottomColor: 'white' }}
-    fontWeight={500}
-    href={link}
-  >
-    {text}
-  </Link>;
 }
 
-function DesktopMenuLinks() {
-  return (
-    <Stack d={['none', 'flex', 'flex']} shouldWrapChildren isInline spacing='15px' alignItems='center' color='gray.50'
-           fontSize='15px'>
-      <MenuLink text={'Roadmaps'} link={'/roadmaps'} />
-      <MenuLink text={'Guides'} link={'/guides'} />
-      <MenuLink text={'Videos'} link={'/watch'} />
-      <MenuLink text={'Thanks'} link={'/thanks'} />
+interface NavItemsProps {
+  mobile?: boolean;
+}
 
-      <Link ml='10px' bgGradient='linear(to-l, yellow.700, red.600)' p='7px 10px' rounded='4px'
-            _hover={{ textDecoration: 'none', bgGradient: 'linear(to-l, red.800, yellow.700)' }}
-            fontWeight={500} href={'/signup'}>Subscribe</Link>
-    </Stack>
+function MenuLink({ active, text, link }: MenuLinkProps) {
+  return (
+    <Link
+      color={active ? 'white' : 'gray.400'}
+      borderBottomWidth={0}
+      borderBottomColor="gray.500"
+      _hover={{ textDecoration: 'none', borderBottomColor: 'white' }}
+      fontWeight={500}
+      href={link}
+    >
+      {text}
+    </Link>
   );
+}
+
+const NavItems = ({ mobile }: NavItemsProps) => {
+  const router = useRouter();
+
+  const links: { name: string; href: string }[] = [
+    { name: 'Roadmaps', href: '/roadmaps' },
+    { name: 'Guides', href: '/guides' },
+    { name: 'Videos', href: '/watch' },
+    { name: 'Thanks', href: '/thanks' },
+  ];
+
+  return (
+    <>
+      {mobile ? (
+        <>
+          {links.map((link) => (
+            <MenuLink
+              active={router.pathname == link.href}
+              text={link.name}
+              link={link.href}
+            />
+          ))}
+          <Link
+            ml="10px"
+            bgGradient="linear(to-l, yellow.700, red.600)"
+            p="7px 10px"
+            rounded="4px"
+            _hover={{
+              textDecoration: 'none',
+              bgGradient: 'linear(to-l, red.800, yellow.700)',
+            }}
+            fontWeight={500}
+            href={'/signup'}
+          >
+            Subscribe
+          </Link>
+        </>
+      ) : (
+        <Stack
+          d={['none', 'flex', 'flex']}
+          shouldWrapChildren
+          isInline
+          spacing="15px"
+          alignItems="center"
+          color="gray.50"
+          fontSize="15px"
+        >
+          {links.map((link) => (
+            <MenuLink
+              active={router.pathname == link.href}
+              text={link.name}
+              link={link.href}
+            />
+          ))}
+          <Link
+            ml="10px"
+            bgGradient="linear(to-l, yellow.700, red.600)"
+            p="7px 10px"
+            rounded="4px"
+            _hover={{
+              textDecoration: 'none',
+              bgGradient: 'linear(to-l, red.800, yellow.700)',
+            }}
+            fontWeight={500}
+            href={'/signup'}
+          >
+            Subscribe
+          </Link>
+        </Stack>
+      )}
+    </>
+  );
+};
+
+function DesktopMenuLinks() {
+  return <NavItems />;
 }
 
 function MobileMenuLinks() {
@@ -45,15 +123,15 @@ function MobileMenuLinks() {
   return (
     <>
       <IconButton
-        rounded='5px'
+        rounded="5px"
         padding={0}
         aria-label={'Menu'}
         d={['block', 'none', 'none']}
-        icon={<HamburgerIcon color='white' w='25px' height='25px' />}
-        color='white'
-        cursor='pointer'
-        h='auto'
-        bg='transparent'
+        icon={<HamburgerIcon color="white" w="25px" height="25px" />}
+        color="white"
+        cursor="pointer"
+        h="auto"
+        bg="transparent"
         _hover={{ bg: 'transparent' }}
         _active={{ bg: 'transparent' }}
         _focus={{ bg: 'transparent' }}
@@ -61,25 +139,28 @@ function MobileMenuLinks() {
       />
 
       {isOpen && (
-        <Stack color='gray.100'
-               fontSize={['22px', '22px', '22px', '32px']}
-               alignItems='center'
-               justifyContent='center'
-               pos='fixed'
-               left={0}
-               right={0}
-               bottom={0}
-               top={0}
-               bg='gray.900'
-               spacing='12px'
-               zIndex={999}
+        <Stack
+          color="gray.100"
+          fontSize={['22px', '22px', '22px', '32px']}
+          alignItems="center"
+          justifyContent="center"
+          pos="fixed"
+          left={0}
+          right={0}
+          bottom={0}
+          top={0}
+          bg="gray.900"
+          spacing="12px"
+          zIndex={999}
         >
-          <Link href='/roadmaps'>Roadmaps</Link>
-          <Link href='/guides'>Guides</Link>
-          <Link href='/watch'>Videos</Link>
-          <Link href='/thanks'>Thanks</Link>
-          <Link href='/signup'>Subscribe</Link>
-          <CloseButton onClick={() => setIsOpen(false)} pos='fixed' top='40px' right='15px' size='lg' />
+          <CloseButton
+            onClick={() => setIsOpen(false)}
+            pos="fixed"
+            top="40px"
+            right="15px"
+            size="lg"
+          />
+          <NavItems mobile />
         </Stack>
       )}
     </>
@@ -87,27 +168,33 @@ function MobileMenuLinks() {
 }
 
 type GlobalHeaderProps = {
-  variant?: 'transparent' | 'solid'
+  variant?: 'transparent' | 'solid';
 };
 
 export function GlobalHeader(props: GlobalHeaderProps) {
   const { variant = 'solid' } = props;
 
   return (
-    <Box bg={variant === 'solid' ? 'gray.900' : 'transparent'} p='20px 0'>
-      <Container maxW='container.md'>
-        <Flex justifyContent='space-between' alignItems='center'>
+    <Box bg={variant === 'solid' ? 'gray.900' : 'transparent'} p="20px 0">
+      <Container maxW="container.md">
+        <Flex justifyContent="space-between" alignItems="center">
           <Box>
-            <Link w='100%'
-                  d='flex'
-                  href='/'
-                  alignItems='center'
-                  color='white'
-                  fontWeight={600}
-                  _hover={{ textDecoration: 'none' }}
-                  fontSize='18px'>
-              <RoadmapLogo style={{ height: '30px', width: '30px', marginRight: '10px' }} />
-              <Text d={['block', 'none', 'block']} as='span'>roadmap.sh</Text>
+            <Link
+              w="100%"
+              d="flex"
+              href="/"
+              alignItems="center"
+              color="white"
+              fontWeight={600}
+              _hover={{ textDecoration: 'none' }}
+              fontSize="18px"
+            >
+              <RoadmapLogo
+                style={{ height: '30px', width: '30px', marginRight: '10px' }}
+              />
+              <Text d={['block', 'none', 'block']} as="span">
+                roadmap.sh
+              </Text>
             </Link>
           </Box>
           <DesktopMenuLinks />


### PR DESCRIPTION
#### What roadmap does this PR target?

- [x] Code Change

#### Please acknowledge the items listed below

- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

Hi folks,
This is my first contribute to this amazing repo..hope my contribution will benefit the open-source community and deliver useful content for users.    

- By utilizing `useRouter` from `next/router` we can now highlight the current page link in the header with different color.

In this PR:
- Added new component `NavItems` that returns pages links in the header component for different views..and accepts a property `mobile` with default value `boolean` `true` that returns different layout for mobile display. 
- `MenuLink` component now accepts `active` property which utilize `useRouter` from `next/router` as a `boolean`.
- All inactive links are in `gray.400` color from `@chakra-ui` library and the active/current page link is in white color.
- You might see the code in different format coz I saved the file with `prettier` on.. which caused `prettier` to be applied.
- The Subscribe button for mobile display has now the same style as for desktop display.

## Before:

Desktop view:

![image](https://user-images.githubusercontent.com/73870784/150082453-cddb2964-9581-446d-9604-7ac1a85cd50e.png)

- Mobile view:

![image](https://user-images.githubusercontent.com/73870784/150085283-285ad3b8-83ab-47b2-a9cc-c6d7450417a9.png)


## After:

Desktop view:
Now the current page link `Roadmaps`  is in different color so user can know in which page is the current page. 

![image](https://user-images.githubusercontent.com/73870784/150083106-fa8ade61-5418-47fd-aef7-1a7cc0127a17.png)

Mobile view:

![image](https://user-images.githubusercontent.com/73870784/150085435-bcbbd13d-0ec5-4e8e-8c54-2e6fc5af6a76.png)


- Closes #1015   
