### PR TITLE
Remove redundant link

### DIFF
--- a/content/roadmaps/100-frontend/content/119-graphql/101-relay-modern.md
+++ b/content/roadmaps/100-frontend/content/119-graphql/101-relay-modern.md
@@ -4,6 +4,4 @@ Relay is a JavaScript client used in the browser to fetch GraphQL data. It's a J
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Website' href='https://relay.dev/'>Official Website</BadgeLink>
-<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://relay.dev/'>Official Website</BadgeLink>
-<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://relay.dev/'>Official Website</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://relay.dev/docs/'>Introduction to Relay modern</BadgeLink>


### PR DESCRIPTION
The link for the official website of Relay is displayed thrice

#### What roadmap does this PR target?

- [ ] Code Change
- [x] Frontend Roadmap
- [ ] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [ ] Guides

#### Please acknowledge the items listed below

- [x] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

<!-- Enter the details here -->
fixes #1076 