### PR TITLE
HTML abbreviation – fixed typo.

### DIFF
--- a/content/roadmaps/100-frontend/content/101-html/100-learn-the-basics.md
+++ b/content/roadmaps/100-frontend/content/101-html/100-learn-the-basics.md
@@ -1,6 +1,6 @@
 # HTML Basics
 
-HTML stands for Hyper Text Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
+HTML stands for HyperText Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink badgeText='Read' href='https://www.w3schools.com/html/html_intro.asp'>W3Schools: Learn HTML</BadgeLink>

--- a/content/roadmaps/100-frontend/content/101-html/readme.md
+++ b/content/roadmaps/100-frontend/content/101-html/readme.md
@@ -1,6 +1,6 @@
 # HTML
 
-HTML stands for Hyper Text Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
+HTML stands for HyperText Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink badgeText='Read' href='https://www.w3schools.com/html/html_intro.asp'>W3Schools: Learn HTML</BadgeLink>

--- a/content/roadmaps/101-backend/content/101-basic-frontend/100-html.md
+++ b/content/roadmaps/101-backend/content/101-basic-frontend/100-html.md
@@ -1,6 +1,6 @@
 # HTML
 
-HTML stands for Hyper Text Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
+HTML stands for HyperText Markup Language. It is used on the frontend and gives the structure to the webpage which you can style using CSS and make interactive using JavaScript.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink badgeText='Read' href='https://www.w3schools.com/html/html_intro.asp'>W3Schools: Learn HTML</BadgeLink>


### PR DESCRIPTION
#### What roadmap does this PR target?

- [x] Frontend Roadmap
- [x] Backend Roadmap

#### Details
In all official standards, for example, starting with [RFC 1866](https://datatracker.ietf.org/doc/html/rfc1866), `HTML` stands like `HyperText Markup Language`. Not like `Hyper Text Markup Language`. `HyperText` - this is one word. But `T` in uppercase can to serve for a better understanding the stands of abbreviation, and it should be left.

Also, we can see this in [Wiki page about HTML](https://en.wikipedia.org/wiki/HTML).