### PR TITLE
Fixed typo in Java and Go meta descriptions

### DIFF
--- a/content/roadmaps.json
+++ b/content/roadmaps.json
@@ -315,7 +315,7 @@
   {
     "seo": {
       "title": "Learn to become a Go developer",
-      "description": "Community driven, articles, resources, guides, interview questions, quizzes for react development. Learn to become a modern React developer by following the steps, skills, resources and guides listed in this roadmap.",
+      "description": "Community driven, articles, resources, guides, interview questions, quizzes for Go development. Learn to become a modern Go developer by following the steps, skills, resources and guides listed in this roadmap.",
       "keywords": [
         "guide to becoming a golang developer",
         "guide to becoming a go developer",
@@ -367,7 +367,7 @@
   {
     "seo": {
       "title": "Learn to become a modern Java developer",
-      "description": "Community driven, articles, resources, guides, interview questions, quizzes for react development. Learn to become a modern React developer by following the steps, skills, resources and guides listed in this roadmap.",
+      "description": "Community driven, articles, resources, guides, interview questions, quizzes for java development. Learn to become a modern Java developer by following the steps, skills, resources and guides listed in this roadmap.",
       "keywords": [
         "guide to becoming a developer",
         "guide to becoming a java developer",

--- a/content/roadmaps/107-golang/meta.json
+++ b/content/roadmaps/107-golang/meta.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "title": "Learn to become a Go developer",
-    "description": "Community driven, articles, resources, guides, interview questions, quizzes for react development. Learn to become a modern React developer by following the steps, skills, resources and guides listed in this roadmap.",
+    "description": "Community driven, articles, resources, guides, interview questions, quizzes for Go development. Learn to become a modern React developer by following the steps, skills, resources and guides listed in this roadmap.",
     "keywords": [
       "guide to becoming a golang developer",
       "guide to becoming a go developer",

--- a/content/roadmaps/108-java/meta.json
+++ b/content/roadmaps/108-java/meta.json
@@ -1,7 +1,7 @@
 {
   "seo": {
     "title": "Learn to become a modern Java developer",
-    "description": "Community driven, articles, resources, guides, interview questions, quizzes for react development. Learn to become a modern React developer by following the steps, skills, resources and guides listed in this roadmap.",
+    "description": "Community driven, articles, resources, guides, interview questions, quizzes for java development. Learn to become a modern Java developer by following the steps, skills, resources and guides listed in this roadmap.",
     "keywords": [
       "guide to becoming a developer",
       "guide to becoming a java developer",


### PR DESCRIPTION
#### What roadmap does this PR target?

- [ ] Code Change
- [ ] Frontend Roadmap
- [ ] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [ ] Guides
- [x] Go Roadmap
- [x] Java Roadmap

#### Please acknowledge the items listed below

- [ ] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

I have not discussed this in issues yet, but it's just a simple typo fix in Go and Java roadmap meta descriptions.  
They still had the React developer meta descriptions. 
