### PR TITLE
Fixed issue #1271 - missing read label

### DIFF
--- a/content/roadmaps/100-frontend/content/117-progressive-web-apps/readme.md
+++ b/content/roadmaps/100-frontend/content/117-progressive-web-apps/readme.md
@@ -5,5 +5,5 @@ Progressive Web Apps (PWAs) are websites that are progressively enhanced to func
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/what-are-progressive-web-apps/'>Progressive Web Apps for Beginners</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://web.dev/learn/pwa/'>Learn PWA</BadgeLink>
-<BadgeLink badgeTest='Read' colorScheme="yellow" href='https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps'>MDN Web Docs: Progressive Web Apps </BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/'>MDN Web Docs: Progressive Web Apps </BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=sFsRylCQblw'>Build a Progressive Web App</BadgeLink>


### PR DESCRIPTION
#### What roadmap does this PR target?

- [] Code Change
- [x] Frontend Roadmap
- [ ] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [ ] Guides

#### Please acknowledge the items listed below

- [] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

[Issue #1271] Fixed a typo that was causing missing "read" label on a resource link in frontend developer roadmap, pwa node.

<img width="351" alt="Capture" src="https://user-images.githubusercontent.com/96435434/169693066-2acb3e69-7b01-4556-a850-d64b72790f13.PNG">

