### PR TITLE
Fixed link to "Journey to HTTP/2" article

### DIFF
--- a/content/roadmaps/100-frontend/content/100-internet/101-what-is-http.md
+++ b/content/roadmaps/100-frontend/content/100-internet/101-what-is-http.md
@@ -5,6 +5,6 @@ HTTP is the `TCP/IP` based application layer communication protocol which standa
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.cloudflare.com/en-gb/learning/ddos/glossary/hypertext-transfer-protocol-http/'>What is HTTP?</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview'>An overview of HTTP</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://kamranahmed.info/blog/2016/08/13/http-in-depth/'>Journey to HTTP/2</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://kamranahmed.info/blog/2016/08/13/http-in-depth'>Journey to HTTP/2</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.smashingmagazine.com/2021/08/http3-core-concepts-part1/'>HTTP/3 From A To Z: Core Concepts</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=iYM2zFP3Zn0'>HTTP Crash Course & Exploration</BadgeLink>


### PR DESCRIPTION
I noticed a single forwardslash broke the link for the "Journey to HTTP/2" article. Same as commit 9a212dc but for the front-end roadmap.

#### What roadmap does this PR target?

- [X] Frontend Roadmap


#### Please acknowledge the items listed below

- [X] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [X] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [X] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [X] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

<!-- Enter the details here -->
