### PR TITLE
Corrected Grammar Errors

### DIFF
--- a/contributing/readme.md
+++ b/contributing/readme.md
@@ -1,7 +1,7 @@
 ## The Goal
 
 * For the roadmaps, we encourage you to discuss and contribute with new roadmaps. For the existing ones, please note that our goal is to not have the biggest list of items. Our goal is to have a list of items or skills most relevant today.
-* For the resources, please note that they are *highly opinionated* and *curated*. Your opinion on value of any resource may not match the opinion of curator.  
+* For the resources, please note that they are *highly opinionated* and *curated*. Your opinion on the value of any resource may not match the opinion of the curator.  
 
 ## Contributing
 
@@ -11,7 +11,7 @@
 ## Guidelines
 
 - <p><strong>Adding everything available out there is not the goal!</strong><br /> 
-  The roadmaps represents the skillset most valuable today i.e. if you were to enter any of the listed fields today, what would you learn! There might be things that are of-course being used today but prioritize the things that are most in demand today e.g. agreed that lots of people are using angular.js today but you wouldn't want to learn that instead of React, Angular or Vue. Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included.</p>
+  The roadmaps represent the skillset most valuable today, i.e., if you were to enter any of the listed fields today, what would you learn?! There might be things that are of-course being used today but prioritize the things that are most in demand today, e.g., agreed that lots of people are using angular.js today but you wouldn't want to learn that instead of React, Angular or Vue. Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included.</p>
 - <p><strong>Do not add things you have not evaluated personally!</strong><br /> 
   Use your critical thinking to filter out non-essential stuff. Give honest arguments for why the resource should be included. Have you read this book? Can you give a short article?</p>
 - <p><strong>One item per Pull Request</strong><br />


### PR DESCRIPTION
- Changed "represents" to "represent" because the former is used with singular nouns, while the latter is used with plural nouns (e.g., roadmaps)
- Added commas to "i.e." and "e.g."
- Changed ! to an interrobang (?!)
- Added determiners (the) to "value" and "curator"