### PR TITLE
Tiny little grammer correction early in the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@
 
 ![](https://i.imgur.com/waxVImv.png)
 
-Roadmaps are being made interactive and have been moved to website.
+Roadmaps are being made interactive and have been moved to the website.
 
 ### [View all Roadmaps](https://roadmap.sh)
 


### PR DESCRIPTION
We should inciude the word "the" before "website".
```diff
- Roadmaps are being made interactive and have been moved to website.
+ Roadmaps are being made interactive and have been moved to the website.
```