### PR TITLE
feat: Add english as a defautl html lang

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,10 @@ const withMDX = require('@next/mdx')({
 });
 
 let nextConfig = {
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
   reactStrictMode: true,
   poweredByHeader: false,
   env: loadConfig(process.env.NODE_ENV),
@@ -44,7 +48,7 @@ let nextConfig = {
     // Transforms SVGs to components
     config.module.rules.push({
       test: /\.svg$/,
-      use: ['@svgr/webpack']
+      use: ['@svgr/webpack'],
     });
 
     return config;
@@ -57,9 +61,8 @@ let nextConfig = {
         destination: '/nodejs',
         permanent: true,
       },
-    ]
+    ];
   },
-
 };
 
 nextConfig = withMDX(nextConfig);


### PR DESCRIPTION
Adding a default locale to the html generated by next.js, this PR will boost the lighthouse metrics, look below for further information in the screenshot.

<img width="1594" alt="Capture" src="https://user-images.githubusercontent.com/22391354/189523553-d07e11b2-f613-4c34-9f31-c1f1177319e7.PNG">
