### PR TITLE
Devops OS Concepts Typos Fixed

### DIFF
--- a/content/roadmaps/102-devops/content/101-os-concepts/106-posix.md
+++ b/content/roadmaps/102-devops/content/101-os-concepts/106-posix.md
@@ -9,6 +9,6 @@ So, in this case, when we want to interact with any of these streams (through a 
 POSIX also adds a standard for exit codes, filesystem semantics, and several other command line utility API conventions.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='blue' badgeText='Read' href='https://unix.stackexchange.com/a/220877'>Summary of some POSIX implementations</BadgeLink>
-<BadgeLink colorScheme='blue' badgeText='Read' href='https://www.baeldung.com/linux/posix'>A guide to POSIX</BadgeLink>
-<BadgeLink colorScheme='blue' badgeText='Documentation' href='https://pubs.opengroup.org/onlinepubs/9699919799/'>POSIX standard by IEEE</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Documentation' href='https://pubs.opengroup.org/onlinepubs/9699919799/'>POSIX standard by IEEE</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://unix.stackexchange.com/a/220877'>Summary of some POSIX implementations</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.baeldung.com/linux/posix'>A guide to POSIX</BadgeLink>

--- a/content/roadmaps/102-devops/content/101-os-concepts/110-threads-concurrency.md
+++ b/content/roadmaps/102-devops/content/101-os-concepts/110-threads-concurrency.md
@@ -9,7 +9,7 @@ Each thread has its own program counter, stack, and set of registers. But the th
 * `join`
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='yellow' badgeText='Pre-Requesite' href='https://www.geeksforgeeks.org/introduction-of-process-synchronization/'>Process Synchronization</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.geeksforgeeks.org/introduction-of-process-synchronization/'>Process Synchronization</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.geeksforgeeks.org/thread-in-operating-system/'>What is Thread in OS?</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.scaler.com/topics/operating-system/threads-in-operating-system/'>Process vs Thread & Multi-Threading</BadgeLink>
 


### PR DESCRIPTION
There are some typos in DevOps (OS Concepts Section) so I fixed this. @kamranahmedse 