### PR TITLE
Frontend Build-Tools Module-Bundlers Typos-Fixed

### DIFF
--- a/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/102-rollup.md
+++ b/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/102-rollup.md
@@ -4,5 +4,5 @@ Rollup is a module bundler for JavaScript which compiles small pieces of code in
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 
-<BadgeLink colorScheme='blue' badgeText='Read' href='https://rollupjs.org/'>Official Website and Docs</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://rollupjs.org/'>Official Website and Docs</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=ICYLOZuFMz8'>How to Set Up JavaScript Bundling Using Rollup</BadgeLink>

--- a/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/104-vite.md
+++ b/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/104-vite.md
@@ -4,5 +4,5 @@ Vite is a build tool that aims to provide a faster and leaner development experi
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Website' href='https://vitejs.dev'>Vite Website</BadgeLink>
-<BadgeLink colorScheme='blue' badgeText='Documentation' href='https://vitejs.dev/guide'>Vite Documentation</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Documentation' href='https://vitejs.dev/guide'>Vite Documentation</BadgeLink>
 <BadgeLink colorScheme='green' badgeText='Course' href='https://youtu.be/LQQ3CR2JTX8'>Vite Crash Course</BadgeLink>

--- a/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/readme.md
+++ b/content/roadmaps/100-frontend/content/110-build-tools/101-module-bundlers/readme.md
@@ -6,6 +6,6 @@ It usually starts with an entry file, and from there it bundles up all of the co
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 
-<BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=5IG4UmULyoA'>Module Bundlers Explained</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.freecodecamp.org/news/lets-learn-how-module-bundlers-work-and-then-write-one-ourselves-b2e3fe6c88ae/'>Let’s learn how module bundlers work</BadgeLink>
+<BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=5IG4UmULyoA'>Module Bundlers Explained</BadgeLink>
 


### PR DESCRIPTION
There are some typos in Frontend (Build Tools [Module Bundlers] Section) so I fixed this. @kamranahmedse