### PR TITLE
Frontend Build-Tools Linters-Formatters Typos-Fixed

### DIFF
--- a/content/roadmaps/100-frontend/content/110-build-tools/102-linters-formatters/100-prettier.md
+++ b/content/roadmaps/100-frontend/content/110-build-tools/102-linters-formatters/100-prettier.md
@@ -3,4 +3,4 @@
 Prettier is an opinionated code formatter with support for JavaScript, HTML, CSS, and more.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='blue' badgeText='Website' href='https://prettier.io'>Prettier Website</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://prettier.io'>Prettier Website</BadgeLink>


### PR DESCRIPTION
There are some typos in Frontend (Build Tools [Linters Formatters] Section) so I fixed this. @kamranahmedse