### PR TITLE
Frontend Static Site Generators Typos Fixed

### DIFF
--- a/content/roadmaps/100-frontend/content/120-static-site-generators/107-eleventy.md
+++ b/content/roadmaps/100-frontend/content/120-static-site-generators/107-eleventy.md
@@ -3,7 +3,7 @@
 Eleventy (11ty) is a simple to use, easy to customize, highly performant and powerful static site generator with a helpful set of plugins (e.g. navigation, build-time image transformations, cache assets). Pages can be built and written with a variety of template languages (HTML, Markdown, JavaScript, Liquid, Nunjucks, Handlebars, Mustache, EJS, Haml, Pug or JS template literals). But it also offers the possibility to dynamically create pages from local data or external sources that are compiled at build time. It has zero client-side JavaScript dependencies.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='blue' badgeText='Website' href='https://www.11ty.dev/'>Official Website</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://www.11ty.dev/'>Official Website</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://11ty.rocks/'>A collection of 11ty starters, projects, plugins, and resources</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=-dM6AmNmMFA'>Introduction to Eleventy</BadgeLink>
 


### PR DESCRIPTION
There are some typos in Frontend (Static Site Generators Section) so I fixed this. @kamranahmedse