### PR TITLE
Javascript Roadmap Add module content

### DIFF
--- a/content/roadmaps/106-javascript/content/115-javascript-modules/100-commonjs.md
+++ b/content/roadmaps/106-javascript/content/115-javascript-modules/100-commonjs.md
@@ -1,22 +1,9 @@
-# Commonjs
+# CommonJS
 
 CommonJS modules are the original way to package JavaScript code for Node.js. Node.js also supports the ESModules standard used by browsers and other JavaScript runtimes, but CJS is still widely used in backend Node.js applications. Sometimes these modules will be written with a .cjs extension.
 
-CJS imports using a syntax with a `require` statement. eg. `const circle = require('./circle.js');`
-
-CJS exports using the syntax `exports.` inside the module. eg.
-
-```
-// contents of circle.js
-const { PI } = Math.PI;
-
-exports.area = (r) => PI * r ** 2;
-
-exports.circumference = (r) => 2 * PI * r;
-```
-
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.freecodecamp.org/news/modules-in-javascript/#commonjsmodules'>Modules in Javascript: CJS Section</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://nodejs.org/api/modules'>Node.js documentation for CJS modules</BadgeLink>
+<BadgeLink colorScheme='yellow' basw2dgeText='Read' href='https://nodejs.org/api/modules'>Node.js documentation for CJS modules</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://blog.risingstack.com/node-js-at-scale-module-system-commonjs-require/'>How the CJS Module System Works</BadgeLink>
 <BadgeLink colorScheme='purple' badgeText='Watch' href='https://www.youtube.com/watch?v=XTND4rjATXA'>How to Import and Export Modules in CJS</BadgeLink>

--- a/content/roadmaps/106-javascript/content/115-javascript-modules/100-commonjs.md
+++ b/content/roadmaps/106-javascript/content/115-javascript-modules/100-commonjs.md
@@ -1,1 +1,22 @@
 # Commonjs
+
+CommonJS modules are the original way to package JavaScript code for Node.js. Node.js also supports the ESModules standard used by browsers and other JavaScript runtimes, but CJS is still widely used in backend Node.js applications. Sometimes these modules will be written with a .cjs extension.
+
+CJS imports using a syntax with a `require` statement. eg. `const circle = require('./circle.js');`
+
+CJS exports using the syntax `exports.` inside the module. eg.
+
+```
+// contents of circle.js
+const { PI } = Math.PI;
+
+exports.area = (r) => PI * r ** 2;
+
+exports.circumference = (r) => 2 * PI * r;
+```
+
+<ResourceGroupTitle>Free Content</ResourceGroupTitle>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.freecodecamp.org/news/modules-in-javascript/#commonjsmodules'>Modules in Javascript: CJS Section</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://nodejs.org/api/modules'>Node.js documentation for CJS modules</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://blog.risingstack.com/node-js-at-scale-module-system-commonjs-require/'>How the CJS Module System Works</BadgeLink>
+<BadgeLink colorScheme='purple' badgeText='Watch' href='https://www.youtube.com/watch?v=XTND4rjATXA'>How to Import and Export Modules in CJS</BadgeLink>

--- a/content/roadmaps/106-javascript/content/115-javascript-modules/101-esm.md
+++ b/content/roadmaps/106-javascript/content/115-javascript-modules/101-esm.md
@@ -1,1 +1,25 @@
 # Esm
+
+ESmodules is a standard that was introduced with ES6 (2015). The idea was to standarize how JS modules work and implement this features in browsers. This standard is widely used with frontend frameworks such as react and can also be used in the backend with Node.js. Sometimes these modules will be written with a .mjs extension.
+
+ESM imports use a syntax with a `import ... from` statement. eg. `import circle from './circle.js'` or `import {area, circumference} from './circle.js'`
+
+ESM exports use an `export default` or an `export` decalaration inside the module. eg.
+
+```
+// contents of circle.js
+const { PI } = Math.PI;
+
+const area = (r) => PI * r ** 2;
+
+const circumference = (r) => 2 * PI * r;
+
+export {area, circumference};
+```
+
+<ResourceGroupTitle>Free Content</ResourceGroupTitle>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.freecodecamp.org/news/modules-in-javascript/'>Introduction to Modules in Javascript</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules'>Full ESM module overview from MDN</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://javascript.info/modules'>Full ESM module overview from js.info</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://nodejs.org/api/esm.html'>Node.js documentation for ESModules</BadgeLink>
+<BadgeLink colorScheme='purple' badgeText='Watch' href='https://www.youtube.com/watch?v=cRHQNNcYf6s'>JavaScript ES6 Modules Simplified</BadgeLink>

--- a/content/roadmaps/106-javascript/content/115-javascript-modules/101-esm.md
+++ b/content/roadmaps/106-javascript/content/115-javascript-modules/101-esm.md
@@ -1,21 +1,6 @@
-# Esm
+# ESModules
 
-ESmodules is a standard that was introduced with ES6 (2015). The idea was to standarize how JS modules work and implement this features in browsers. This standard is widely used with frontend frameworks such as react and can also be used in the backend with Node.js. Sometimes these modules will be written with a .mjs extension.
-
-ESM imports use a syntax with a `import ... from` statement. eg. `import circle from './circle.js'` or `import {area, circumference} from './circle.js'`
-
-ESM exports use an `export default` or an `export` decalaration inside the module. eg.
-
-```
-// contents of circle.js
-const { PI } = Math.PI;
-
-const area = (r) => PI * r ** 2;
-
-const circumference = (r) => 2 * PI * r;
-
-export {area, circumference};
-```
+ESModules is a standard that was introduced with ES6 (2015). The idea was to standardize how JS modules work and implement these features in browsers. This standard is widely used with frontend frameworks such as react and can also be used in the backend with Node.js. Sometimes these modules will be written with a .mjs extension.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.freecodecamp.org/news/modules-in-javascript/'>Introduction to Modules in Javascript</BadgeLink>


### PR DESCRIPTION
Add in content with examples to the javascript roadmap in 115-javascript modules section for both 100-commonjs and 101-esm