### PR TITLE
Javascript 101-comparison-operations

### DIFF
--- a/content/roadmaps/106-javascript/content-paths.json
+++ b/content/roadmaps/106-javascript/content-paths.json
@@ -63,7 +63,7 @@
   "javascript-control-flow:conditional-statements:switch": "/roadmaps/106-javascript/content/107-javascript-control-flow/101-conditional-statements/101-switch.md",
   "javascript-expressions-and-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/readme.md",
   "javascript-expressions-and-operators:assignment-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/100-assignment-operators.md",
-  "javascript-expressions-and-operators:omparison-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-omparison-operators.md",
+  "javascript-expressions-and-operators:comparison-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-comparison-operators.md",
   "javascript-expressions-and-operators:arithmetic-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/102-arithmetic-operators.md",
   "javascript-expressions-and-operators:bitwise-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/103-bitwise-operators.md",
   "javascript-expressions-and-operators:logical-operators": "/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/104-logical-operators.md",

--- a/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-comparison-operators.md
+++ b/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-comparison-operators.md
@@ -1,0 +1,21 @@
+# Comparison operators
+
+Comparison operators are used in logical statements to determine equality or difference between variables or values.  The operands can be numerical, string, logical, or object values. The result returns a Boolean (`true` or `false`).
+
+Comparison operators in Javascript are as follows:
+
+
+
+| Symbol                     | Description                                                                                  | Example                   |
+| :------------------------- | -------------------------------------------------------------------------------------------- | ------------------------- |
+| `==` Not Equal             | Returns `true` if operands are equal                                                         | 3 == '3'                  |
+| `!=` Not Equal             | Returns `false` if operands are  not equal                                                   | 5 == '99'                 |
+| `===` Strict Equal         | Returns `true` if the operands are of same type AND equal.                                   | 5 === 5                   |
+| `!==` Strict Not Equal     | Returns `true` if the operands are of the same type but not equal, or are of different type. | 3 !== '3'  <br/> 10 !== 5 |
+| `>` Greater Than           | Returns `true` if the left operand is greater than the right operand.                        | 6 > 2   <br/> '20' > 10   |
+| `>=` Greater Than or Equal | Returns `true` if the left operand is greater than or equal to the right operand.            | 7 >= 4 <br/> 7 >= 7       |
+| `<` Less Than              | Returns `true` if the left operand is less than the right operand.                           | 3 < 7  <br/>  '6' < 16    |
+| `<=` Less Than or Equal    | Returns `true` if the left operand is less than or equal to the right operand.               | 5 < 9 <br/> 7 <= 7        |
+
+<BadgeLink colorScheme='yellow' badgeText='Read' href='hhttps://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#comparison_operators'>Comparison Operators - MDN</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.w3schools.com/js/js_comparisons.asp'>Comparison Operators -  W3 Schools</BadgeLink>

--- a/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-omparison-operators.md
+++ b/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-omparison-operators.md
@@ -1,1 +1,0 @@
-# Omparison operators

--- a/public/project/javascript.json
+++ b/public/project/javascript.json
@@ -11137,7 +11137,7 @@
           "x": "165",
           "y": "1792",
           "properties": {
-            "controlName": "101-javascript-expressions-and-operators:omparison-operators"
+            "controlName": "101-javascript-expressions-and-operators:comparison-operators"
           },
           "children": {
             "controls": {


### PR DESCRIPTION
#1838 

- Added content to `content\roadmaps\106-javascript\content\108-javascript-expressions-and-operators\101-comparison-operators.md`. 
- Fixed typo in the name of the file: `101-omparison-operators.md` => `101-comparison-operators.md`