### PR TITLE
Add locale to NextJS

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -37,6 +37,11 @@ let nextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
   env: loadConfig(process.env.NODE_ENV),
+  
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+  },
 
   webpack(config, options) {
     config.resolve.modules.push(path.resolve('./'));


### PR DESCRIPTION
Hi there!
This is a small PR to add the language to NextJs, so it correctly inserts the attribute `lang="en"` to the root `<html>` element.
This should improve accessibility.

More details:
https://web.dev/html-has-lang/
https://daily-dev-tips.com/posts/nextjs-add-lang-attribute-to-html-tag/