### PR TITLE
fix typo

### DIFF
--- a/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-comparison-operators.md
+++ b/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-comparison-operators.md
@@ -1,0 +1,1 @@
+# Comparison operators

--- a/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-omparison-operators.md
+++ b/content/roadmaps/106-javascript/content/108-javascript-expressions-and-operators/101-omparison-operators.md
@@ -1,1 +1,0 @@
-# Omparison operators


### PR DESCRIPTION
there is a typo in the content of Comparison Operators in Javascript roadmap