### PR TITLE
feat(devops): :heavy_plus_sign: add containerd to devops / containers

### DIFF
--- a/content/roadmaps/102-devops/content-paths.json
+++ b/content/roadmaps/102-devops/content-paths.json
@@ -8,6 +8,7 @@
   "infrastructure-as-code:service-mesh:consul": "/roadmaps/102-devops/content/105-infrastructure-as-code/100-service-mesh/100-consul.md",
   "infrastructure-as-code:containers": "/roadmaps/102-devops/content/105-infrastructure-as-code/101-containers.md",
   "infrastructure-as-code:docker": "/roadmaps/102-devops/content/105-infrastructure-as-code/100-docker.md",
+  "infrastructure-as-code:containerd": "/roadmaps/102-devops/content/105-infrastructure-as-code/102-containerd.md",
   "infrastructure-as-code:lxc": "/roadmaps/102-devops/content/105-infrastructure-as-code/101-lxc.md",
   "infrastructure-as-code:configuration-management": "/roadmaps/102-devops/content/105-infrastructure-as-code/102-configuration-management/readme.md",
   "infrastructure-as-code:configuration-management:ansible": "/roadmaps/102-devops/content/105-infrastructure-as-code/102-configuration-management/100-ansible.md",

--- a/content/roadmaps/102-devops/content/105-infrastructure-as-code/102-containerd.md
+++ b/content/roadmaps/102-devops/content/105-infrastructure-as-code/102-containerd.md
@@ -1,0 +1,9 @@
+# containerd
+
+Containerd is an industry-standard core container runtime. It is currently available as a daemon for Linux and Windows, which can manage the complete container lifecycle of its host system. In 2015, Docker donated the OCI Specification to The Linux Foundation with a reference implementation called runc. Since February 28, 2019 it is an official CNCF project. Its general availability and intention to donate the project to CNCF was announced by Docker in 2017.
+
+<ResourceGroupTitle>Free Content</ResourceGroupTitle>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://cloud.google.com/learn/what-are-containers'>What are Containers?</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.docker.com/resources/what-container/'>What is a Container?</BadgeLink>
+<BadgeLink badgeText='Watch' href='https://www.youtube.com/playlist?list=PLawsLZMfND4nz-WDBZIj8-nbzGFD4S9oz'>What are Containers?</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://thenewstack.io/category/containers/'>Articles about Containers - The New Stack</BadgeLink>


### PR DESCRIPTION
adding containerd to containers due to respect kubernetes desicion to remove dockershim in version 1.24

cant afford balsamiq, you have to do this, or switch to an opensource alternative, himmeldonnernocheins