### PR TITLE
Fix Typo in UML Description

### DIFF
--- a/content/roadmaps/114-software-architect/content/112-architect-frameworks/101-uml.md
+++ b/content/roadmaps/114-software-architect/content/112-architect-frameworks/101-uml.md
@@ -1,6 +1,6 @@
 # UML
 
-The Unified Modeling Language, or UML, is modeling language that is intended to provide a standard way to visualize and describe the design of a system.
+The Unified Modeling Language, or UML, is a modeling language that is intended to provide a standard way to visualize and describe the design of a system.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Website' href='https://www.uml.org'>UML Website</BadgeLink>


### PR DESCRIPTION
This is hardly a change but I wrote the original UML Description and just noticed it was missing a word.