### PR TITLE
Running the Node js file in CLI

### DIFF
--- a/content/roadmaps/107-nodejs/content/100-nodejs-introduction/104-running-nodejs-code.md
+++ b/content/roadmaps/107-nodejs/content/100-nodejs-introduction/104-running-nodejs-code.md
@@ -1,6 +1,8 @@
 # Running Node.js Code
 
 The usual way to run a Node.js program is to run the globally available `node` command (once you install Node.js) and pass the name of the file you want to execute.
-
+To run a Node.js programme, use the globally available node command (once Node.js is installed) and pass the name of the file to execute.
+ 
+ check if your main Node js application file is 'main.js' then use "node main.js" in the command line
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line/'>Run Node.js from Command Line</BadgeLink>


### PR DESCRIPTION
Explicitly use the CLI command to execute the Node Js file, without ever worrying about opening the file