### PR TITLE
Include Python 3.10 match-case in conditionals

### DIFF
--- a/content/roadmaps/108-python/content/100-python-basics/102-conditionals.md
+++ b/content/roadmaps/108-python/content/100-python-basics/102-conditionals.md
@@ -1,9 +1,10 @@
 # Conditionals
 
-Conditional Statement in Python perform different computations or actions depending on whether a specific Boolean constraint evaluates to true or false. Conditional statements are handled by IF statements in Python.
+Conditional Statements in Python perform different actions depending on whether a specific condition evaluates to true or false. Conditional Statements are handled by IF-ELIF-ELSE statements and MATCH-CASE statements in Python.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.guru99.com/if-loop-python-conditional-structures.html'>Python Conditional Statements: IF…Else, ELIF & Switch Case</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://realpython.com/python-conditional-statements/'>Conditional Statements in Python</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://learnpython.com/blog/python-match-case-statement/'>How to use a match statement in Python</BadgeLink>
 
 


### PR DESCRIPTION
## Reason
I believe that including match-case control flow to the conditionals node would be highly valuable for new learners without being cumbersome. Match-case is highly expressive and readable, and may be preferred over an if-elif-else statement in some situations. Match-case can do things that if-elif-else cannot, it can also make it easier to reason about and read conditonal logic for a program. For that reason I've added a single quality how-to article on the subject and amended the description to include it.

## Example
From the Python docs:
```python
# point is an (x, y) tuple
match point:
    case (0, 0):
        print("Origin")
    case (0, y):
        print(f"Y={y}")
    case (x, 0):
        print(f"X={x}")
    case (x, y):
        print(f"X={x}, Y={y}")
    case _:
        raise ValueError("Not a point")
```

From the article:
```python
def file_handler_v1(command):
    match command.split():
        case ['show']:
            print('List all files and directories: ')
            # code to list files
        case ['remove', *files]:
            print('Removing files: {}'.format(files))
            # code to remove files
        case _:
            print('Command not recognized')
```

## Changes
* Added a link for a how-to on the subject
* Corrected grammar mistakes
* Changed text to include MATCH-CASE