### PR TITLE
Add content to Node.js > relational databases > native drivers

### DIFF
--- a/content/roadmaps/107-nodejs/content/110-nodejs-databases/100-relational/104-native-drivers.md
+++ b/content/roadmaps/107-nodejs/content/110-nodejs-databases/100-relational/104-native-drivers.md
@@ -1,1 +1,14 @@
 # Native drivers
+
+- MySQL:
+  - [`mysql`](https://www.npmjs.com/package/mysql)
+  - [`mysql2`](https://www.npmjs.com/package/mysql2)
+- MariaDB:
+  - [`mariadb`](https://www.npmjs.com/package/mariadb)
+- PostgreSQL:
+  - [`pg`](https://www.npmjs.com/package/pg)
+- Microsoft SQL Server:
+  - [`tedious`](https://www.npmjs.com/package/tedious)
+  - [`mssql`](https://www.npmjs.com/package/mssql)
+- Oracle:
+  - [`oracledb`](https://www.npmjs.com/package/oracledb)


### PR DESCRIPTION
Just added an initial list with the main npm packages used to connect to the most common SQL databases without an ORM.