### PR TITLE
fix typo to wrong direction on 'testing your apps'

### DIFF
--- a/public/project/frontend.json
+++ b/public/project/frontend.json
@@ -10071,7 +10071,7 @@
                   "y": "115",
                   "properties": {
                     "size": "17",
-                    "text": "them with the tools listed on the left."
+                    "text": "them with the tools listed on the right."
                   }
                 },
                 {


### PR DESCRIPTION
this PR solves suggestion [#2644](https://github.com/kamranahmedse/developer-roadmap/issues/2644)

previus
![image](https://user-images.githubusercontent.com/5691247/197083449-2861f398-9af1-4eb0-bee3-12af8b0d09e7.png)

now
<img width="489" alt="image" src="https://user-images.githubusercontent.com/5691247/197083394-89ae9c78-bba0-4f6f-a3a0-863cc20e688b.png">
