### PR TITLE
In Go Developer roadmap "gobyexample/" url down, replacing with Working tutorial URL

### DIFF
--- a/content/roadmaps/109-golang/content/100-go-basics/100-basic-syntax.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/100-basic-syntax.md
@@ -4,5 +4,5 @@ Learn about the basic syntax of Go, such as how the go programs are executed, pa
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/doc/tutorial/getting-started'>Go Tutorial: Getting started</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/hello-world'>Go by Example: Hello World</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://golangbot.com/hello-world-gomod/'>Golangbot: Hello World</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.w3schools.com/go/go_syntax.php'>W3schools : Go Syntax</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/101-variables.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/101-variables.md
@@ -4,5 +4,5 @@ Variable is the name given to a memory location to store a value of a specific [
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/tour/basics/8'>Go Variables</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/variables'>Go by Example: Variables</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://golangbot.com/variables/'>Golangbot: Variables</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.w3schools.com/go/go_variables.php'>w3schools Go variables</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/102-data-types.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/102-data-types.md
@@ -7,4 +7,4 @@ To learn more about types in Go, visit these resources :
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.w3schools.com/go/go_data_types.php'>Basic data types</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/tour/basics/11'>Tour of Go: types</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://golangbyexample.com/all-data-types-in-golang-with-examples/'>Go types with examples</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.golangprograms.com/go-language/data-type.html'>Go types with examples</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/103-for-loop.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/103-for-loop.md
@@ -9,5 +9,5 @@ Go has only one looping construct, the `for` loop. The basic `for` loop has thre
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/tour/flowcontrol/1'>For Loop in Golang</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/doc/effective_go#for'>Effective Go: For loop</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/for'>Go by Example: For loop</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.golangprograms.com/for-range-loops.html'>Go Example: For loop</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://yourbasic.org/golang/for-loop/'>5 basic for loop patterns</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/104-range.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/104-range.md
@@ -4,5 +4,5 @@
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/tour/moretypes/16'>Go Ranges</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/range'>Go by Example: Range</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.geeksforgeeks.org/range-keyword-in-golang/'>Go Example: Range</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://yourbasic.org/golang/for-loop-range-array-slice-map-channel/'>Go ranges basic patterns</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/107-conditionals.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/107-conditionals.md
@@ -9,5 +9,5 @@ Conditional statements are used to run code only if a certain condition is true;
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://go.dev/doc/effective_go#if'>Effective Go: if statement</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://yourbasic.org/golang/if-else-statement/'>Basic conditional patterns</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/if-else'>Go by Example: If-Else</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.geeksforgeeks.org/go-decision-making-if-if-else-nested-if-if-else-if/'>Go Example: If-Else</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.golangprograms.com/golang-if-else-statements.html'>Golang programs if else</BadgeLink><BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.golangprograms.com/golang-switch-case-statements.html'>Golang programs switch case</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/108-functions.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/108-functions.md
@@ -8,5 +8,5 @@ Discover how functions work in Go, the list of resources below will cover :
  - Different types of functions in Go.
  
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://gobyexample.com/functions'>Go by Example: Functions</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.w3schools.com/go/go_functions.php'>Golang Program: Functions</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.golangprograms.com/go-language/functions.html'>Functions in go</BadgeLink>

--- a/content/roadmaps/109-golang/content/100-go-basics/116-structs.md
+++ b/content/roadmaps/109-golang/content/100-go-basics/116-structs.md
@@ -4,5 +4,5 @@ Structs are user-defined types that help us create a collection of data describi
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Website' href='https://go.dev/tour/moretypes/2'>Go Structs</BadgeLink>
-<BadgeLink badgeText='Read' href='https://gobyexample.com/structs'>Go by Example: Structs</BadgeLink>
+<BadgeLink badgeText='Read' href='https://www.golangprograms.com/go-language/struct.html'>Golang Program: Structs</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=NMTN543WVQY'>Structs in Go</BadgeLink>


### PR DESCRIPTION
Hello, 

https://gobyexample.com is down for long time, i've been following this roadmap from last few days and found website not reachable, replacing this by other good tutorial website like https://golangbot.com , https://www.golangprograms.com/ and geeksforgeek
modified filles:   101-variables.md, 102-data-types.md, 103-for-loop.md, 104-range.md, 107-conditionals.md, 108-functions.md, 116-structs.md
Hope it helps !!