### PR TITLE
Add Boot.dev's Learn HTTP course to HTTP sections

### DIFF
--- a/content/roadmaps/100-frontend/content/100-internet/101-what-is-http.md
+++ b/content/roadmaps/100-frontend/content/100-internet/101-what-is-http.md
@@ -9,3 +9,4 @@ HTTP is the `TCP/IP` based application layer communication protocol which standa
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://kamranahmed.info/blog/2016/08/13/http-in-depth'>Journey to HTTP/2</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.smashingmagazine.com/2021/08/http3-core-concepts-part1/'>HTTP/3 From A To Z: Core Concepts</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=iYM2zFP3Zn0'>HTTP Crash Course & Exploration</BadgeLink>
+<BadgeLink colorScheme='green' badgeText='Course' href='https://boot.dev/learn/learn-http'>Learn HTTP | Boot.dev </BadgeLink>

--- a/content/roadmaps/101-backend/content/100-internet/101-what-is-http.md
+++ b/content/roadmaps/101-backend/content/100-internet/101-what-is-http.md
@@ -8,3 +8,4 @@ HTTP is the `TCP/IP` based application layer communication protocol which standa
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://kamranahmed.info/blog/2016/08/13/http-in-depth'>Journey to HTTP/2</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.smashingmagazine.com/2021/08/http3-core-concepts-part1/'>HTTP/3 From A To Z: Core Concepts</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=iYM2zFP3Zn0'>HTTP Crash Course & Exploration</BadgeLink>
+<BadgeLink colorScheme='green' badgeText='Course' href='https://boot.dev/learn/learn-http'>Learn HTTP | Boot.dev </BadgeLink>

--- a/content/roadmaps/102-devops/content/103-networking-protocols/102-http.md
+++ b/content/roadmaps/102-devops/content/103-networking-protocols/102-http.md
@@ -8,3 +8,4 @@ HTTP is the `TCP/IP` based application layer communication protocol which standa
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://kamranahmed.info/blog/2016/08/13/http-in-depth'>Journey to HTTP/2</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.smashingmagazine.com/2021/08/http3-core-concepts-part1/'>HTTP/3 From A To Z: Core Concepts</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=iYM2zFP3Zn0'>HTTP Crash Course & Exploration</BadgeLink>
+<BadgeLink colorScheme='green' badgeText='Course' href='https://boot.dev/learn/learn-http'>Learn HTTP | Boot.dev </BadgeLink>


### PR DESCRIPTION
Adding Boot.dev's [Learn HTTP](https://boot.dev/learn/learn-http) course to the various HTTP sections (none of them have courses yet!)