### PR TITLE
Update 102-hibernate

### DIFF
--- a/content/roadmaps/110-java/content/104-java-orm/102-hibernate.md
+++ b/content/roadmaps/110-java/content/104-java-orm/102-hibernate.md
@@ -1,6 +1,6 @@
 # Hibernate
 
-Hibernate is an open source object-relational mapping ([ORM](https://theserverside.techtarget.com/definition/object-relational-mapping)) tool that provides a framework to map object-oriented domain models to relational databases for web applications.
+Hibernate is an open source object-relational mapping tool that provides a framework to map object-oriented domain models to relational databases for web applications.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Site' href='https://hibernate.org/'>Hibernate</BadgeLink>


### PR DESCRIPTION
Hello, the current link "https://www.theserverside.com/definition/object-relational-mapping" return page not found.
There is already a definition of ORM in the parent node.
linked to this issue #1837 