### PR TITLE
Java Roadmap Spark: Fixed Spark framework node

### DIFF
--- a/content/roadmaps/110-java/content/103-java-web-frameworks/103-spark.md
+++ b/content/roadmaps/110-java/content/103-java-web-frameworks/103-spark.md
@@ -2,10 +2,6 @@
 
 Spark is a micro framework for creating web applications in Kotlin and Java 8. Sinatra, a popular Ruby micro framework, was the inspiration for it.
 
-<ResourceGroupTitle>Reference Resource</ResourceGroupTitle>
-<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://www.playframework.com/'>Play Framework Website</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.baeldung.com/spark-framework-rest-api'>Intro to Spark framework</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.javatpoint.com/spark-java'>What is Spark java?</BadgeLink>
-<BadgeLink colorScheme='yellow' badgeText='Read' href='https://aws.amazon.com/big-data/what-is-spark/'>What is Apache spark?</BadgeLink>
-<BadgeLink badgeText='Watch' href='https://youtu.be/znBa13Earms'>Apache Spark Tutorial</BadgeLink>
-<BadgeLink badgeText='Watch' href='https://youtu.be/F8pyaR4uQ2g'>Apache Spark Full Course</BadgeLink>
+<ResourceGroupTitle>Free Content</ResourceGroupTitle>
+<BadgeLink colorScheme='blue' badgeText='Official Site' href='https://sparkjava.com/'>Spark Java</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.baeldung.com/spark-framework-rest-api'>Intro to Spark Java Framework</BadgeLink>

--- a/content/roadmaps/110-java/content/103-java-web-frameworks/103-spark.md
+++ b/content/roadmaps/110-java/content/103-java-web-frameworks/103-spark.md
@@ -5,3 +5,4 @@ Spark is a micro framework for creating web applications in Kotlin and Java 8. S
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Site' href='https://sparkjava.com/'>Spark Java</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.baeldung.com/spark-framework-rest-api'>Intro to Spark Java Framework</BadgeLink>
+<BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.javatpoint.com/spark-java'>What is Spark java?</BadgeLink>


### PR DESCRIPTION
- Removed `Play Framework Website` from Spark node. 
- Last three links were for Apache Spark which is a used for big-data

Spark Node fixed

Kindly review this PR. 