### PR TITLE
Fix React Roadmap URL on Readme file

### DIFF
--- a/content/roadmaps/100-frontend/content/118-server-side-rendering/100-react-js/readme.md
+++ b/content/roadmaps/100-frontend/content/118-server-side-rendering/100-react-js/readme.md
@@ -8,5 +8,5 @@ React is the most popular front-end JavaScript library for building user interfa
 <BadgeLink badgeText='Course' colorScheme='green' href='https://egghead.io/courses/the-beginner-s-guide-to-react'>The Beginner's Guide to React</BadgeLink>
 <BadgeLink badgeText='Course' colorScheme='green' href='https://www.youtube.com/watch?v=nTeuhbP7wdE'>React JS Course for Beginners</BadgeLink>
 <BadgeLink badgeText='Course' colorScheme='green' href='https://www.youtube.com/watch?v=bMknfKXIFA8'>React Course - Beginner's Tutorial for React JavaScript Library [2022]</BadgeLink>
-<BadgeLink badgeText='Roadmap' colorScheme='yellow' href='https://roadmap.sh/frontend'>React Roadmap</BadgeLink>
+<BadgeLink badgeText='Roadmap' colorScheme='yellow' href='https://roadmap.sh/react'>React Roadmap</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=i793Qm6kv3U'>Understanding React's UI Rendering Process</BadgeLink>


### PR DESCRIPTION
Fixed React Roadmap URL on Readme file that was pointing to the same Front-end Roadmap