### PR TITLE
Add SWR Hook Library

### DIFF
--- a/content/roadmaps/103-react/content/102-react-ecosystem/103-api-calls/107-swr.md
+++ b/content/roadmaps/103-react/content/102-react-ecosystem/103-api-calls/107-swr.md
@@ -1,0 +1,14 @@
+# SWR
+
+useSWR is a React Hook library made by Vercel. 
+It fetches data from an API or other external source, then saves that data in a cache, and renders the data.
+
+The name “SWR” is derived from stale-while-revalidate, a HTTP cache invalidation strategy popularized by
+[HTTP RFC 5861](https://tools.ietf.org/html/rfc5861). SWR is a strategy to first return the data from cache (stale), then send the fetch request
+(revalidate), and finally come with the up-to-date data.
+
+<ResourceGroupTitle>Free Content</ResourceGroupTitle>
+<BadgeLink colorScheme='blue' badgeText='Official Website' href='https://swr.vercel.app/'>SWR Website</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Read' href='https://swr.vercel.app/docs/getting-started'>Official Docs</BadgeLink>
+<BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=CQ5yHU1wYOo'>Next.js Tutorial - 37 - SWR for Client-side Data Fetching</BadgeLink>
+<BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=QZNloKwHxPo'>UseSWR Tutorial - Remote Data Fetching in React</BadgeLink>


### PR DESCRIPTION
useSWR is a React Hook library made by Vercel. 
It fetches data from an API or other external source, then saves that data in a cache, and renders the data.