### PR TITLE
Remove invalid resource Golang 102

### DIFF
--- a/content/roadmaps/109-golang/content/101-go-advanced/102-types-and-type-assertions.md
+++ b/content/roadmaps/109-golang/content/101-go-advanced/102-types-and-type-assertions.md
@@ -5,4 +5,3 @@ Type assertions in Golang provide access to the exact type of variable of an int
  <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink colorScheme='blue' badgeText='Official Website' href='https://go.dev/tour/methods/15'>Types Assertions </BadgeLink>
 <BadgeLink badgeText='Read' href='https://www.geeksforgeeks.org/type-assertions-in-golang/'>Type Assertion</BadgeLink>
-<BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=NoDRq6Twkts'>Type Assertion In Golang</BadgeLink>


### PR DESCRIPTION
Remove invalid resource from Golang 102-types-and-type-assertions.md The provided resource is a video about protocol buffers in Go, not types or type assertion