### PR TITLE
Fixed the issue of npx link broken.

### DIFF
--- a/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
+++ b/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
@@ -3,7 +3,7 @@
 npx is a very powerful command that's been available in npm starting version 5.2, released in July 2017. If you don't want to install npm, you can install npx as a standalone package. npx lets you run code built with Node.js and published through the npm registry.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink badgeText='Read' colorScheme="yellow" href='[https://nodejs.dev/en/learn/the-npx-nodejs-package-runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)'>Introduction to the npx Node.js Package Runner</BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b'>Introduction to the npx Node.js Package Runner</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/npm-vs-npx-whats-the-difference/'>npm vs npx — What’s the Difference?</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation:</BadgeLink>
 

--- a/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
+++ b/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
@@ -3,7 +3,7 @@
 npx is a very powerful command that's been available in npm starting version 5.2, released in July 2017. If you don't want to install npm, you can install npx as a standalone package. npx lets you run code built with Node.js and published through the npm registry.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink badgeText='Read' colorScheme="yellow" href='[https://nodejs.dev/en/learn/the-npx-nodejs-package-runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)'>The npx Node.js Package Runner</BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='[https://nodejs.dev/en/learn/the-npx-nodejs-package-runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)'>Introduction to the npx Node.js Package Runner</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/npm-vs-npx-whats-the-difference/'>npm vs npx — What’s the Difference?</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation:</BadgeLink>
 

--- a/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
+++ b/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
@@ -6,4 +6,6 @@ npx is a very powerful command that's been available in npm starting version 5.2
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://nodejs.dev/en/learn/the-npx-nodejs-package-runner'>The npx Node.js Package Runner</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/npm-vs-npx-whats-the-difference/'>npm vs npx — What’s the Difference?</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation:</BadgeLink>
-<BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Link to the official documentation [npx](https://docs.npmjs.com/cli/v7/commands/npx)</BadgeLink>
+
+
+Link to the official documentation [npx](https://docs.npmjs.com/cli/v7/commands/npx)

--- a/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
+++ b/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
@@ -3,9 +3,7 @@
 npx is a very powerful command that's been available in npm starting version 5.2, released in July 2017. If you don't want to install npm, you can install npx as a standalone package. npx lets you run code built with Node.js and published through the npm registry.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink badgeText='Read' colorScheme="yellow" href='https://nodejs.dev/en/learn/the-npx-nodejs-package-runner'>The npx Node.js Package Runner</BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='[https://nodejs.dev/en/learn/the-npx-nodejs-package-runner](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b)'>The npx Node.js Package Runner</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/npm-vs-npx-whats-the-difference/'>npm vs npx — What’s the Difference?</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation:</BadgeLink>
 
-
-Link to the official documentation [npx](https://docs.npmjs.com/cli/v7/commands/npx)

--- a/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
+++ b/content/roadmaps/107-nodejs/content/102-nodejs-npm/100-npx.md
@@ -5,4 +5,5 @@ npx is a very powerful command that's been available in npm starting version 5.2
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://nodejs.dev/en/learn/the-npx-nodejs-package-runner'>The npx Node.js Package Runner</BadgeLink>
 <BadgeLink badgeText='Read' colorScheme="yellow" href='https://www.freecodecamp.org/news/npm-vs-npx-whats-the-difference/'>npm vs npx — What’s the Difference?</BadgeLink>
-<BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation</BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Official Documentation:</BadgeLink>
+<BadgeLink badgeText='Read' colorScheme="yellow" href='https://docs.npmjs.com/cli/v7/commands/npx/'>Link to the official documentation [npx](https://docs.npmjs.com/cli/v7/commands/npx)</BadgeLink>


### PR DESCRIPTION
The npx node js package manager link was broken, that page didn't exist on the node js docs, added a new link to a good article for introduction to npx on medium.