### PR TITLE
[Feature] UX Right Click mark the topic

### DIFF
--- a/components/roadmap/roadmap-page-header.tsx
+++ b/components/roadmap/roadmap-page-header.tsx
@@ -212,7 +212,18 @@ export function RoadmapPageHeader(props: RoadmapPageHeaderType) {
               New
             </Badge>
             Resources are here, try clicking any nodes.
+            
+            <Text
+            mt='5px'
+            // Loza
+            >
+              <Badge pos='relative' top={'-1px'} mr='6px' colorScheme='red'>
+              New
+            </Badge>
+              Track your progress, Left click to any node. 
+            </Text>
           </Text>
+          
         )}
       </Container>
     </Box>

--- a/components/roadmap/roadmap-page-header.tsx
+++ b/components/roadmap/roadmap-page-header.tsx
@@ -220,7 +220,7 @@ export function RoadmapPageHeader(props: RoadmapPageHeaderType) {
               <Badge pos='relative' top={'-1px'} mr='6px' colorScheme='red'>
               New
             </Badge>
-              Track your progress, Left click to any node. 
+              Track your progress, Right click to any node. 
             </Text>
           </Text>
           

--- a/pages/[roadmap]/interactive.tsx
+++ b/pages/[roadmap]/interactive.tsx
@@ -69,13 +69,19 @@ export function InteractiveRoadmapRenderer(props: RoadmapProps) {
       // will be translated to `internet:how-does-the-internet-work`
       setGroupId(removeSortingInfo(groupId));
     }
+    function markAsDone(event:MouseEvent){
+      event.preventDefault();
+      const targetGroup = (event?.target as HTMLElement)?.closest('g');
+      targetGroup?.classList?.add('done')
+    }
 
     window.addEventListener('keydown', keydownListener);
     window.addEventListener('click', clickListener);
-
+    window.addEventListener("contextmenu",markAsDone);
     return () => {
       window.removeEventListener('keydown', keydownListener);
       window.removeEventListener('click', clickListener);
+      window.removeEventListener("contextmenu",markAsDone);
     };
   }, []);
 

--- a/pages/[roadmap]/interactive.tsx
+++ b/pages/[roadmap]/interactive.tsx
@@ -72,6 +72,9 @@ export function InteractiveRoadmapRenderer(props: RoadmapProps) {
     function markAsDone(event:MouseEvent){
       event.preventDefault();
       const targetGroup = (event?.target as HTMLElement)?.closest('g');
+      if((targetGroup?.classList?.value)?.match('done'))
+      targetGroup?.classList?.remove('done')
+      else
       targetGroup?.classList?.add('done')
     }
 


### PR DESCRIPTION
As I mentioned in this Issue #3094 as a feature request to make it sample to for user to mark them, 
The solution I come up with is just putting a trigger on the Right click to do the same as the button in the group ('g') 

I followed the code structure and I didn't create new things. 

I used the groupId to identify which node I click on and apply the action to it.

LGTM