### PR TITLE
Fixes the `===` operator format

### DIFF
--- a/content/roadmaps/106-javascript/content/105-javascript-equality-comparisons/101-value-comparison-operators.md
+++ b/content/roadmaps/106-javascript/content/105-javascript-equality-comparisons/101-value-comparison-operators.md
@@ -1,6 +1,6 @@
 # Value Comparison Operators
 
-In javascript, the `==` operator does the type conversion of the operands before comparison, whereas the === operator compares the values and the data types of the operands. The `Object.is()` method determines whether two values are the same value: `Object.is(value1, value2)`.
+In javascript, the `==` operator does the type conversion of the operands before comparison, whereas the `===` operator compares the values and the data types of the operands. The `Object.is()` method determines whether two values are the same value: `Object.is(value1, value2)`.
 
 `Object.is()` is not equivalent to the `==` operator. The `==` operator applies various coercions to both sides (if they are not the same type) before testing for equality (resulting in such behavior as `"" == false` being `true`), but `Object.is()` doesn't coerce either value.
 


### PR DESCRIPTION
Displays it in code format so that it is appears the same as the other operators.

Currently on the website, it appears like this, looking different than the other operators displayed.
<img width="740" alt="image" src="https://user-images.githubusercontent.com/73425927/207524939-d4a8cf3a-c5df-43d1-a703-7ae482585847.png">

This PR proposes to fix this anomaly.