### PR TITLE
Official docs link of state to latest version

### DIFF
--- a/content/roadmaps/103-react/content/100-react-fundamental-topics/108-basic-hooks/100-use-state.md
+++ b/content/roadmaps/103-react/content/100-react-fundamental-topics/108-basic-hooks/100-use-state.md
@@ -3,5 +3,5 @@
 `useState` hook is used to manage the state of a component in functional components. Calling `useState` returns an array with two elements: the current state value and a function to update the state.
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
-<BadgeLink colorScheme='blue' badgeText='Official Docs' href='https://reactjs.org/docs/hooks-state.html'>Using the State Hook</BadgeLink>
+<BadgeLink colorScheme='blue' badgeText='Official Docs' href='https://beta.reactjs.org/apis/react/useState'>Using the State Hook</BadgeLink>
 <BadgeLink colorScheme='yellow' badgeText='Read' href='https://www.robinwieruch.de/react-usestate-hook/'>React useState Hook by Example</BadgeLink>


### PR DESCRIPTION
The existing link of official docs for state hook is from the previous website of React, the one i proposed is from the latest documentation of React although it is in beta, the documentation required for state hook has been completed.