### PR TITLE
Link updated for Event Loop resource

### DIFF
--- a/content/roadmaps/107-nodejs/content/104-nodejs-async-programming/100-event-loop.md
+++ b/content/roadmaps/107-nodejs/content/104-nodejs-async-programming/100-event-loop.md
@@ -4,7 +4,7 @@ The Event Loop is one of the most critical aspects of Node.js. Why is this so im
 
 <ResourceGroupTitle>Free Content</ResourceGroupTitle>
 
-<BadgeLink colorScheme="yellow" badgeText="Read" href="https://nodejs.dev/en/learn/the-nodejs-event-loop/">The Node.JS Event Loop</BadgeLink>
+<BadgeLink colorScheme="yellow" badgeText="Read" href="https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#what-is-the-event-loop">The Node.JS Event Loop</BadgeLink>
 <BadgeLink colorScheme="yellow" badgeText="Read" href="https://dev.to/lydiahallie/javascript-visualized-event-loop-3dif">JavaScript Visualized: Event Loop</BadgeLink>
 <BadgeLink badgeText='Course' colorScheme='green' href='https://www.coursera.org/lecture/secure-full-stack-mean-developer/the-node-js-event-loop-j5fbT'>The Node.js Event Loop</BadgeLink>
 <BadgeLink badgeText='Watch' href='https://www.youtube.com/watch?v=6YgsqXlUoTM'>The Complete Node js: The Node js Event Loop</BadgeLink>


### PR DESCRIPTION
Link updated for Event Loop resource redirecting to the official documentation in NodeJS roadmap.

Updated URL: https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/#what-is-the-event-loop