### PR TITLE
fix: correct typo

### DIFF
--- a/content/roadmaps/104-angular/content/101-rxjs-basics/100-observable-pattern.md
+++ b/content/roadmaps/104-angular/content/101-rxjs-basics/100-observable-pattern.md
@@ -1,6 +1,6 @@
 # Observable Pattern
 
-The observer pattern is a software design pattern in which an object, named the subject, maintains a list of its dependents, called observers, and notifies them automatically of any state changes, usually by calling one of their methods.
+The observable pattern is a software design pattern in which an object, named the subject, maintains a list of its dependents, called observers, and notifies them automatically of any state changes, usually by calling one of their methods.
 
 Angular uses the Observer pattern which simply means — Observable objects are registered, and other objects observe (in Angular using the subscribe method) them and take action when the observable object is acted on in some way.
 


### PR DESCRIPTION
Replace erroneous “observer pattern” with the correct “observable pattern”