### PR TITLE
Update 104-running-scripts.md

### DIFF
--- a/src/roadmaps/nodejs/content/102-nodejs-npm/104-running-scripts.md
+++ b/src/roadmaps/nodejs/content/102-nodejs-npm/104-running-scripts.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [Example of Running Scripts](https://riptutorial.com/node-js/example/4592/running-scripts)
 - [Introduction to NPM Scripts](https://www.geeksforgeeks.org/introduction-to-npm-scripts/)
-- [Running Scripts](https://docs.npmjs.com/downloading-and-installing-packages-locally)
+- [Running Scripts](https://learn.microsoft.com/en-us/shows/beginners-series-to-nodejs/how-to-use-npm-scripts-for-your-development-task-automation-7-of-26)


### PR DESCRIPTION
* [Node.js Developer Roadmap](https://roadmap.sh/nodejs/) ➡️ `npm` ➡️ `Running Scripts` ➡️ `Running Scripts` directs to  [`npm docs - Downloading and installing packages locally`](https://docs.npmjs.com/downloading-and-installing-packages-locally) which is not relevent to the `NPM SCRIPTS` section.
* Replaced it with [How to use npm scripts for your development task automation.](https://learn.microsoft.com/en-us/shows/beginners-series-to-nodejs/how-to-use-npm-scripts-for-your-development-task-automation-7-of-26)
#3295