### PR TITLE
fix: typo in the word development

### DIFF
--- a/src/roadmaps/frontend/faqs.astro
+++ b/src/roadmaps/frontend/faqs.astro
@@ -5,7 +5,7 @@ export const faqs: FAQType[] = [
   {
     question: 'What is Frontend Development?',
     answer: [
-      "Front-end development is the devleopment of visual and interactive elements of a website that users interact with directly. It's a combination of HTML, CSS and JavaScript, where HTML provides the structure, CSS the styling and layout, and JavaScript the dynamic behaviour and interactivity.",
+      "Front-end development is the development of visual and interactive elements of a website that users interact with directly. It's a combination of HTML, CSS and JavaScript, where HTML provides the structure, CSS the styling and layout, and JavaScript the dynamic behaviour and interactivity.",
       "As a front-end developer, you'll be responsible for creating the user interface of a website, to ensure it looks good and is easy to use, with great focus on design principles and user experience. You'll be working closely with designers, back-end developers, and project managers to make sure the final product meets the client's needs and provides the best possible experience for the end-users.",
     ],
   },


### PR DESCRIPTION
Typo -
<img width="829" alt="Screenshot 2023-01-17 at 10 55 20 PM" src="https://user-images.githubusercontent.com/42834647/212986877-d806c6ad-5a73-4c97-b53f-be0312a2eef3.png">
