### PR TITLE
Fix typo in "avaiability"

### DIFF
--- a/src/roadmaps/system-design/content/105-availability-patterns/101-replication.md
+++ b/src/roadmaps/system-design/content/105-availability-patterns/101-replication.md
@@ -8,4 +8,4 @@ Replication is an availability pattern that involves having multiple copies of t
 
 Visi the following links for more resources:
 
-- [Replication: Avaiability Pattern](https://github.com/donnemartin/system-design-primer#replication)
+- [Replication: Availability Pattern](https://github.com/donnemartin/system-design-primer#replication)


### PR DESCRIPTION
This is a very simple nitpick of a typo in the word "availability"