### PR TITLE
fix(blockchain-content): Fix typo in blockchain security tools content

### DIFF
--- a/src/data/roadmaps/blockchain/content/105-blockchain-security/101-tools/index.md
+++ b/src/data/roadmaps/blockchain/content/105-blockchain-security/101-tools/index.md
@@ -1,3 +1,3 @@
 # Tools
 
-Blockchain and smart contract technology is faily new, therefore, you should expect constant changes in the security landscape, as new bugs and security risks are discovered, and new best practices are developed. Keeping track of this constantly moving landscape proves difficult, so using tools to aid this mission is important. The cost of failing to property secure smart contracts can be high, and because change can be difficult, we must make use of these tools.
+Blockchain and smart contract technology is fairly new, therefore, you should expect constant changes in the security landscape, as new bugs and security risks are discovered, and new best practices are developed. Keeping track of this constantly moving landscape proves difficult, so using tools to aid this mission is important. The cost of failing to properly secure smart contracts can be high, and because change can be difficult, we must make use of these tools.


### PR DESCRIPTION
### Changes
* Changed the incorrect spelling 'faily' to 'fairly'
* Changed the incorrect spelling 'propery' to 'properly'