### PR TITLE
fix(blockchain-content): fix typo in blockchain solidity content

### DIFF
--- a/src/data/roadmaps/blockchain/content/103-smart-contracts/100-programming-languages/100-solidity.md
+++ b/src/data/roadmaps/blockchain/content/103-smart-contracts/100-programming-languages/100-solidity.md
@@ -2,8 +2,8 @@
 
 Solidity is an object-oriented programming language created specifically by Ethereum Network team for constructing smart contracts on various blockchain platforms, most notably, Ethereum.
 
-* It's used to create smart contracts that implements business logic and generate a chain of transaction records in the blochain system.
-* It acts as  a tool for creating machine-level code and compilling it on the Ethereum Vitural Machine (EVM).
+* It's used to create smart contracts that implements business logic and generate a chain of transaction records in the blockchain system.
+* It acts as a tool for creating machine-level code and compiling it on the Ethereum Vitural Machine (EVM).
 
 Like any other programming languages, Solidity also has variables, functions, classes, arithmetic operations, string manipulation, and many more.
 


### PR DESCRIPTION
### Changes
* Changed the typo 'blochain' to 'blockchain'
* Changed the typo 'compilling' to 'compiling'