### PR TITLE
Fix: remove <code> tag from "The For Loop" heading

### DIFF
--- a/src/data/roadmaps/javascript/content/106-javascript-loops-iterations/103-for-statement.md
+++ b/src/data/roadmaps/javascript/content/106-javascript-loops-iterations/103-for-statement.md
@@ -1,4 +1,4 @@
-# The `for` loop
+# The for loop
 
 The `for` loop is a standard control-flow construct in many programming languages, including JavaScript. It's commonly used to iterate over given sequences or iterate a known number of times and execute a piece of code for each iteration.
 


### PR DESCRIPTION
Removed unnecessary heading "code tag" that made heading hard to read.