### PR TITLE
updated the url in consensus protocols section 

### DIFF
--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/107-consensus-protocols.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/107-consensus-protocols.md
@@ -4,6 +4,6 @@ Consensus for blockchain is a procedure in which the peers of a Blockchain netwo
 
 Visit the following resources to learn more:
 
-- [Consensus Mechanisms in Blockchain: A Beginner’s Guide](https://crypto.com/university/consensus-mechanisms-in-blockchain)
+- [Consensus Mechanisms in Blockchain: A Beginner’s Guide](https://crypto.com/university/consensus-mechanisms-explained)
 - [Consensus Mechanisms](https://ethereum.org/en/developers/docs/consensus-mechanisms/)
 - [What Is a Consensus Mechanism?](https://www.coindesk.com/learn/what-is-a-consensus-mechanism/)


### PR DESCRIPTION
updated the url in the consensus protocols section because the mentioned url which is
this https://crypto.com/university/consensus-mechanisms-in-blockchain is redirecting to the crypto.com
and not to the topic which mentioned there.
So the correct url link is https://crypto.com/university/consensus-mechanisms-explained