### PR TITLE
Removed a link

### DIFF
--- a/src/data/roadmaps/react/content/104-hooks/101-writing-your-own-hooks.md
+++ b/src/data/roadmaps/react/content/104-hooks/101-writing-your-own-hooks.md
@@ -4,7 +4,6 @@ Building your own Hooks lets you extract component logic into reusable functions
 
 Visit the following resources to learn more:
 
-- [Creating Custom Hooks](https://reactjs.org/docs/hooks-custom.html)
 - [Reusing Logic with Custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks)
 - [How to create a custom Hook (1)](https://www.freecodecamp.org/news/how-to-create-react-hooks/)
 - [How to create a custom Hook (2) followed by Examples](https://www.robinwieruch.de/react-custom-hook/)


### PR DESCRIPTION
I think there is no need to use one more link for the exact same example. The link that I have removed, redirects the user to the old react documentation which is already listed in this md file as "Reusing Logic with Custom Hooks".