### PR TITLE
Typescript roadmap: Replace deprecated link in 114-never.md

### DIFF
--- a/src/data/roadmaps/typescript/content/101-typescript-types/114-never.md
+++ b/src/data/roadmaps/typescript/content/101-typescript-types/114-never.md
@@ -25,4 +25,4 @@ function infiniteLoop(): never {
 
 Learn more from the following links:
 
-- [Never](https://www.typescriptlang.org/docs/handbook/basic-types.html#never)
+- [Never](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-never-type)


### PR DESCRIPTION
Replace a deprecated link with the [new](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-never-type) link for `never` type documentation