### PR TITLE
Add 'learn go' course from Boot.dev to Golang resources

### DIFF
--- a/src/data/roadmaps/backend/content/103-learn-a-language/100-go.md
+++ b/src/data/roadmaps/backend/content/103-learn-a-language/100-go.md
@@ -7,6 +7,7 @@ Visit the following resources to learn more:
 - [Visit Dedicated Go Roadmap](/golang)
 - [A Tour of Go – Go Basics](https://go.dev/tour/welcome/1)
 - [Go Reference Documentation](https://go.dev/doc/)
+- [Learn Go | Boot.dev](https://boot.dev/learn/learn-golang)
 - [Go by Example - annotated example programs](https://gobyexample.com/)
 - [Learn Go | Codecademy](https://www.codecademy.com/learn/learn-go)
 - [W3Schools Go Tutorial ](https://www.w3schools.com/go/)

--- a/src/data/roadmaps/blockchain/content/109-dapps/107-supporting-languages/102-go.md
+++ b/src/data/roadmaps/blockchain/content/109-dapps/107-supporting-languages/102-go.md
@@ -7,6 +7,7 @@ Visit the following resources to learn more:
 - [Visit Dedicated Go Roadmap](/golang)
 - [A Tour of Go – Go Basics](https://go.dev/tour/welcome/1)
 - [Go Reference Documentation](https://go.dev/doc/)
+- [Learn Go | Boot.dev](https://boot.dev/learn/learn-golang)
 - [Go by Example - annotated example programs](https://gobyexample.com/)
 - [Learn Go | Codecademy](https://www.codecademy.com/learn/learn-go)
 - [W3Schools Go Tutorial ](https://www.w3schools.com/go/)

--- a/src/data/roadmaps/computer-science/content/101-pick-a-language/104-go.md
+++ b/src/data/roadmaps/computer-science/content/101-pick-a-language/104-go.md
@@ -8,6 +8,7 @@ Visit the following resources to learn more:
 - [A Tour of Go – Go Basics](https://go.dev/tour/welcome/1)
 - [Go Reference Documentation](https://go.dev/doc/)
 - [Go by Example - annotated example programs](https://gobyexample.com/)
+- [Learn Go | Boot.dev](https://boot.dev/learn/learn-golang)
 - [Learn Go | Codecademy](https://www.codecademy.com/learn/learn-go)
 - [W3Schools Go Tutorial ](https://www.w3schools.com/go/)
 - [Making a RESTful JSON API in Go](https://thenewstack.io/make-a-restful-json-api-go/)

--- a/src/data/roadmaps/devops/content/100-language/103-go.md
+++ b/src/data/roadmaps/devops/content/100-language/103-go.md
@@ -7,6 +7,7 @@ Visit the following resources to learn more:
 - [Visit Dedicated Go Roadmap](/golang)
 - [A Tour of Go – Go Basics](https://go.dev/tour/welcome/1)
 - [Go Reference Documentation](https://go.dev/doc/)
+- [Learn Go | Boot.dev](https://boot.dev/learn/learn-golang)
 - [Go by Example - annotated example programs](https://gobyexample.com/)
 - [Learn Go | Codecademy](https://www.codecademy.com/learn/learn-go)
 - [W3Schools Go Tutorial ](https://www.w3schools.com/go/)

--- a/src/data/roadmaps/software-architect/content/104-programming-languages/103-go.md
+++ b/src/data/roadmaps/software-architect/content/104-programming-languages/103-go.md
@@ -7,6 +7,7 @@ Visit the following resources to learn more:
 - [Visit Dedicated Go Roadmap](/golang)
 - [A Tour of Go – Go Basics](https://go.dev/tour/welcome/1)
 - [Go Reference Documentation](https://go.dev/doc/)
+- [Learn Go | Boot.dev](https://boot.dev/learn/learn-golang)
 - [Go by Example - annotated example programs](https://gobyexample.com/)
 - [Learn Go | Codecademy](https://www.codecademy.com/learn/learn-go)
 - [W3Schools Go Tutorial ](https://www.w3schools.com/go/)


### PR DESCRIPTION
This adds the ["Learn Go" interactive course](https://boot.dev/learn/learn-golang) from Boot.dev to the various Go resource pages.

Like all courses on Boot.dev, all the content is free to read and watch without the need to sign up. Use the "browse the exercises" link to access the content without signing in.

There are over 150  individual lessons and challenges in this course!