### PR TITLE
update link to new React Documentation

### DIFF
--- a/src/data/roadmaps/react/content/102-components/100-class-components.md
+++ b/src/data/roadmaps/react/content/102-components/100-class-components.md
@@ -6,7 +6,7 @@ Although the class components are supported in React, it is encouraged to write 
 
 Visit the following resources to learn more:
 
-- [Components and Props](https://reactjs.org/docs/components-and-props.html#function-and-class-components)
+- [Components and Props](https://react.dev/learn/thinking-in-react#props-vs-state)
 - [Is There Any Reason to Still Use React Class Components?](https://medium.com/geekculture/is-there-any-reason-to-still-use-react-class-components-9b6a1e6aa9ef)
 - [Functional Components vs Class Components in React](https://www.freecodecamp.org/news/functional-components-vs-class-components-in-react)
 - [Migrate Class Components to Functional Components with Hooks in React](https://www.robinwieruch.de/react-hooks-migration/)


### PR DESCRIPTION
The  [Components and Props] uses an old link to the Documentation of React.