### PR TITLE
Polygon(matic) Whitepaper Url Fixed

### DIFF
--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/102-evm-based/polygon.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/102-evm-based/polygon.md
@@ -4,5 +4,5 @@ Polygon, formerly known as the Matic Network, is a scaling solution that aims to
 
 Visit the following resources to learn more:
 
-- [Polygon whitepaper](https://polygon.technology/lightpaper-polygon.pdf)
+- [Polygon whitepaper](https://github.com/maticnetwork/whitepaper)
 - [Introduction to Polygon](https://wiki.polygon.technology/docs/develop/getting-started)


### PR DESCRIPTION
Fixed the URL of the Polygon(Matic) Whitepaper

### **Before:**
![polygon_Whitepaper_URL_expired](https://user-images.githubusercontent.com/121112225/230718982-d670afd3-0d16-4e7a-a791-b06a8e724061.png)

### **After:**
![polygon_whitepaper_url_fixed](https://user-images.githubusercontent.com/121112225/230718989-b95ced7e-e1ad-4169-9885-58dc4c025ce7.png)
