### PR TITLE
fix: Correct syntax error in Promise initialization example by adding space

### DIFF
--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/102-promises.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/102-promises.md
@@ -5,7 +5,7 @@ Asynchronous functions use promise behind the scenes, so understanding how promi
 Once a promise has been called, it will start in a pending state. This means that the calling function continues executing, while the promise is pending until it resolves, giving the calling function whatever data was being requested.
 
 Creating a Promise:
-The Promise API exposes a Promise constructor, which you initialize using newPromise().
+The Promise API exposes a Promise constructor, which you initialize using new Promise().
 
 Using resolve() and reject(), we can communicate back to the caller what the resulting Promise state was, and what to do with it.
 


### PR DESCRIPTION
### Description

This PR updates the content for the Promises by fixing a syntax error in the example. The original docs mistakenly used `newPromise()` instead of `new Promise()`, which caused a syntax error when initialising a new Promise.

To resolve this issue, the docs was updated to correctly use `new Promise()` with a space between new and Promise.

### Changes Made

- Replaced `newPromise()` with `new Promise()` in the example.