### PR TITLE
fix: broken link

### DIFF
--- a/src/data/roadmaps/frontend/content/101-html/index.md
+++ b/src/data/roadmaps/frontend/content/101-html/index.md
@@ -7,7 +7,7 @@ Visit the following resources to learn more:
 - [W3Schools: Learn HTML](https://www.w3schools.com/html/html_intro.asp)
 - [htmlreference.io: All HTML elements at a glance](https://htmlreference.io/)
 - [HTML For Beginners The Easy Way](https://html.com)
-- [Web Development Basics](https://www.internetingishard.com/html-and-css/)
+- [Web Development Basics](https://internetingishard.netlify.app/html-and-css/index.html)
 - [Codecademy - Learn HTML](https://www.codecademy.com/learn/learn-html)
 - [Interactive HTML Course](https://github.com/denysdovhan/learnyouhtml)
 - [HTML Full Course for Beginners | Complete All-in-One Tutorial ](https://youtu.be/mJgBOIoGihA)


### PR DESCRIPTION
Fix(#3896) the broken link of [Web Development Basics](https://internetingishard.netlify.app/html-and-css/index.html) in the `frontend` roadmap.
