### PR TITLE
Update 101-prototypal-inheritance.md

### DIFF
--- a/src/data/roadmaps/javascript/content/102-javascript-datatypes/101-object/101-prototypal-inheritance.md
+++ b/src/data/roadmaps/javascript/content/102-javascript-datatypes/101-object/101-prototypal-inheritance.md
@@ -1,6 +1,6 @@
 # Prototypal Inheritance
 
-The Prototypal Inheritance is a feature in javascript used to add methods and properties in objects. It is a method by which an object can inherit the properties and methods of another object. Traditionally, in order to get and set the Prototype of an object, we use Object.getPrototypeOf and Object.
+The Prototypal Inheritance is a feature in javascript used to add methods and properties in objects. It is a method by which an object can inherit the properties and methods of another object. Traditionally, in order to get and set the Prototype of an object, we use Object.getPrototypeOf and Object.setPrototypeOf.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Added missing property name used to set the prototype of an object.
From `Object.` to `Object.setPrototypeOf`

**Before changes (last line)**
<img width="338" alt="Screenshot 2023-05-18 at 2 30 27 AM" src="https://github.com/kamranahmedse/developer-roadmap/assets/40301340/d9fde24f-bc83-4ede-ab6e-63f16a8bd432">

**After changes (last line)**
<img width="382" alt="Screenshot 2023-05-18 at 2 29 51 AM" src="https://github.com/kamranahmedse/developer-roadmap/assets/40301340/30e569c8-dff3-4b8c-a312-a7d96c58ed76">
