### PR TITLE
Adding link to Spring Boot roadmap from Java roadmap

### DIFF
--- a/src/data/roadmaps/java/content/103-java-web-frameworks/101-spring-boot.md
+++ b/src/data/roadmaps/java/content/103-java-web-frameworks/101-spring-boot.md
@@ -4,6 +4,7 @@ Spring Boot is an open source, microservice-based Java web framework. The Spring
 
 Visit the following resources to learn more:
 
+- [Visit Dedicated Spring Boot Roadmap](/spring-boot)
 - [Spring Boot](https://spring.io/projects/spring-boot/)
 - [What is Spring Boot?](https://www.ibm.com/cloud/learn/java-spring-boot)
 - [Spring Boot Tutorial](https://www.javaguides.net/2021/07/spring-boot-tutorial-for-beginners.html)


### PR DESCRIPTION
I notice we have a Spring Boot roadmap that is not linked from Spring Boot item from Java roadmap.