### PR TITLE
CMD+K Firefox bug

### DIFF
--- a/src/hooks/use-keydown.ts
+++ b/src/hooks/use-keydown.ts
@@ -13,6 +13,7 @@ export function useKeydown(keyName: string, callback: any, deps: any[] = []) {
         event.metaKey &&
         event.key.toLowerCase() === keyName.replace('mod_', '').toLowerCase()
       ) {
+        event.preventDefault();
         callback();
       }
     };


### PR DESCRIPTION
Firefox uses the `CMD+K` shortcut for its search feat.

## Before:
<img width="1440" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/54026804/b0dccaf7-bab8-450d-aaa3-26e9432b9426">

## After:
<img width="1440" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/54026804/f1628635-ab39-4c93-832a-728ca0ddc882">
