### PR TITLE
Fix docker typo

### DIFF
--- a/src/data/roadmaps/docker/docker.json
+++ b/src/data/roadmaps/docker/docker.json
@@ -272,7 +272,7 @@
           "measuredH": "25",
           "x": "703",
           "y": "1150",
-          "properties": { "size": "17", "text": "Programming Lanugages" }
+          "properties": { "size": "17", "text": "Programming Languages" }
         },
         {
           "ID": "2800",

--- a/src/data/roadmaps/docker/docker.json
+++ b/src/data/roadmaps/docker/docker.json
@@ -1,1 +1,3698 @@
-{"mockup":{"controls":{"control":[{"ID":"2620","typeID":"Arrow","zOrder":"31","w":"1","h":"501","measuredW":"150","measuredH":"100","x":"1213","y":"766","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.49995786685927396,"y":0.00035566936975390927},"p2":{"x":-0.18181818181824383,"y":501.00085499312513}}},{"ID":"2625","typeID":"Label","zOrder":"32","measuredW":"104","measuredH":"40","x":"1162","y":"714","properties":{"size":"32","text":"Docker"}},{"ID":"2626","typeID":"Canvas","zOrder":"33","w":"350","h":"141","measuredW":"100","measuredH":"70","x":"1433","y":"636"},{"ID":"2627","typeID":"Label","zOrder":"34","measuredW":"314","measuredH":"25","x":"1447","y":"653","properties":{"size":"17","text":"Find the detailed version of this roadmap"}},{"ID":"2628","typeID":"Label","zOrder":"35","measuredW":"319","measuredH":"25","x":"1447","y":"681","properties":{"size":"17","text":"along with resources and other roadmaps"}},{"ID":"2629","typeID":"__group__","zOrder":"36","measuredW":"320","measuredH":"45","w":"320","h":"45","x":"1448","y":"717","properties":{"controlName":"ext_link:roadmap.sh"},"children":{"controls":{"control":[{"ID":"0","typeID":"Canvas","zOrder":"0","w":"320","h":"45","measuredW":"100","measuredH":"70","x":"0","y":"0","properties":{"borderColor":"4273622","color":"4273622"}},{"ID":"2","typeID":"Label","zOrder":"1","measuredW":"172","measuredH":"28","x":"74","y":"8","properties":{"color":"16777215","size":"20","text":"https://roadmap.sh"}}]}}},{"ID":"2670","typeID":"Arrow","zOrder":"39","w":"1","h":"101","measuredW":"150","measuredH":"100","x":"1213","y":"600","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":-0.18181818181824383,"y":0.060606060606005485},"p1":{"x":0.4999578668592744,"y":0.0003556693697539094},"p2":{"x":-0.18181818181824383,"y":101.15151515151513}}},{"ID":"2778","typeID":"Label","zOrder":"38","measuredW":"155","measuredH":"25","x":"721","y":"1101","properties":{"size":"17","text":"Linux Fundamentals"}},{"ID":"2785","typeID":"Label","zOrder":"40","measuredW":"108","measuredH":"26","x":"746","y":"1294","properties":{"text":"Prerequisites","size":"18"}},{"ID":"2786","typeID":"TextArea","zOrder":"41","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"907","properties":{"color":"16770457"}},{"ID":"2787","typeID":"Label","zOrder":"42","measuredW":"149","measuredH":"25","x":"724","y":"916","properties":{"size":"17","text":"Package Managers"}},{"ID":"2788","typeID":"TextArea","zOrder":"43","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"954","properties":{"color":"16770457"}},{"ID":"2789","typeID":"Label","zOrder":"44","measuredW":"216","measuredH":"25","x":"691","y":"963","properties":{"size":"17","text":"Users / Groups Permissions"}},{"ID":"2790","typeID":"TextArea","zOrder":"45","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"1001","properties":{"color":"16770457"}},{"ID":"2791","typeID":"Label","zOrder":"46","measuredW":"127","measuredH":"25","x":"735","y":"1010","properties":{"size":"17","text":"Shell commands"}},{"ID":"2792","typeID":"TextArea","zOrder":"47","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"1048","properties":{"color":"16770457"}},{"ID":"2793","typeID":"Label","zOrder":"48","measuredW":"108","measuredH":"25","x":"745","y":"1057","properties":{"size":"17","text":"Shell scripting"}},{"ID":"2797","typeID":"Label","zOrder":"49","measuredW":"142","measuredH":"25","x":"728","y":"1240","properties":{"size":"17","text":"Web Development"}},{"ID":"2798","typeID":"TextArea","zOrder":"50","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"1141","properties":{"color":"16770457"}},{"ID":"2799","typeID":"Label","zOrder":"51","measuredW":"194","measuredH":"25","x":"703","y":"1150","properties":{"size":"17","text":"Programming Lanugages"}},{"ID":"2800","typeID":"TextArea","zOrder":"52","w":"300","h":"44","measuredW":"200","measuredH":"140","x":"650","y":"1188","properties":{"color":"16770457"}},{"ID":"2801","typeID":"Label","zOrder":"53","measuredW":"183","measuredH":"25","x":"707","y":"1197","properties":{"size":"17","text":"Application Architecture"}},{"ID":"2822","typeID":"Arrow","zOrder":"27","w":"159","h":"23","measuredW":"150","measuredH":"100","x":"1336","y":"906","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0.4646359097735058,"y":23.353294775624022},"p1":{"x":0.5172121703355936,"y":-0.04134567000631401},"p2":{"x":159.51104906422256,"y":0.2084809210585945}}},{"ID":"2823","typeID":"Arrow","zOrder":"28","w":"157","h":"64","measuredW":"150","measuredH":"100","x":"1336","y":"855","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0.4646359097735058,"y":63.67107299659381},"p1":{"x":0.4603346517294317,"y":-0.10421022711848146},"p2":{"x":157.13722200221582,"y":0.1711990879144878}}},{"ID":"2824","typeID":"Arrow","zOrder":"29","w":"169","h":"24","measuredW":"150","measuredH":"100","x":"1328","y":"940","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0.15624119275003068,"y":0.628973320155751},"p1":{"x":0.5012965221560048,"y":0.04743407560804315},"p2":{"x":168.69796259522582,"y":24.367243940222806}}},{"ID":"2825","typeID":"Arrow","zOrder":"30","w":"152","h":"72","measuredW":"150","measuredH":"100","x":"1340","y":"946","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0.025376502783501564,"y":-0.0299157903291416},"p1":{"x":0.5934120757823323,"y":0.11641742644399297},"p2":{"x":151.95030847121234,"y":71.77835283537365}}},{"ID":"2826","typeID":"Canvas","zOrder":"59","w":"327","h":"126","measuredW":"100","measuredH":"70","x":"636","y":"620"},{"ID":"2827","typeID":"Label","zOrder":"60","measuredW":"268","measuredH":"25","x":"659","y":"641","properties":{"size":"17","text":"Roadmap was made in partnership"}},{"ID":"2834","typeID":"Canvas","zOrder":"123","w":"327","h":"129","measuredW":"100","measuredH":"70","x":"636","y":"736"},{"ID":"2836","typeID":"__group__","zOrder":"124","measuredW":"202","measuredH":"26","w":"202","h":"26","x":"659","y":"758","properties":{"controlName":"ext_link:roadmap.sh/kubernetes"},"children":{"controls":{"control":[{"ID":"0","typeID":"Label","zOrder":"0","measuredW":"169","measuredH":"25","x":"33","y":"0","properties":{"size":"17","text":"Kubernetes Roadmap"}},{"ID":"1","typeID":"__group__","zOrder":"1","measuredW":"24","measuredH":"24","w":"24","h":"24","x":"0","y":"2","children":{"controls":{"control":[{"ID":"0","typeID":"Icon","zOrder":"0","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"16777215","icon":{"ID":"circle","size":"small"}}},{"ID":"1","typeID":"Icon","zOrder":"1","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"10066329","icon":{"ID":"check-circle","size":"small"}}}]}}}]}}},{"ID":"2837","typeID":"__group__","zOrder":"125","measuredW":"174","measuredH":"26","w":"174","h":"26","x":"659","y":"788","properties":{"controlName":"ext_link:roadmap.sh/best-practices"},"children":{"controls":{"control":[{"ID":"0","typeID":"Label","zOrder":"0","measuredW":"141","measuredH":"25","x":"33","y":"0","properties":{"size":"17","text":"DevOps Roadmap"}},{"ID":"1","typeID":"__group__","zOrder":"1","measuredW":"24","measuredH":"24","w":"24","h":"24","x":"0","y":"2","children":{"controls":{"control":[{"ID":"0","typeID":"Icon","zOrder":"0","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"16777215","icon":{"ID":"circle","size":"small"}}},{"ID":"1","typeID":"Icon","zOrder":"1","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"10066329","icon":{"ID":"check-circle","size":"small"}}}]}}}]}}},{"ID":"2838","typeID":"Label","zOrder":"61","measuredW":"31","measuredH":"25","x":"659","y":"669","properties":{"size":"17","text":"with"}},{"ID":"2840","typeID":"Label","zOrder":"63","measuredW":"144","measuredH":"25","x":"763","y":"669","properties":{"size":"17","text":". Checkout his free"}},{"ID":"2841","typeID":"__group__","zOrder":"126","measuredW":"180","measuredH":"26","w":"180","h":"26","x":"659","y":"819","properties":{"controlName":"ext_link:roadmap.sh/backend"},"children":{"controls":{"control":[{"ID":"0","typeID":"Label","zOrder":"0","measuredW":"147","measuredH":"25","x":"33","y":"0","properties":{"size":"17","text":"Backend Roadmap"}},{"ID":"1","typeID":"__group__","zOrder":"1","measuredW":"24","measuredH":"24","w":"24","h":"24","x":"0","y":"2","children":{"controls":{"control":[{"ID":"0","typeID":"Icon","zOrder":"0","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"16777215","icon":{"ID":"circle","size":"small"}}},{"ID":"1","typeID":"Icon","zOrder":"1","measuredW":"24","measuredH":"24","x":"0","y":"0","properties":{"color":"10066329","icon":{"ID":"check-circle","size":"small"}}}]}}}]}}},{"ID":"2848","typeID":"Label","zOrder":"68","measuredW":"245","measuredH":"25","x":"1488","y":"1177","properties":{"size":"17","text":"Just get the basic idea of these."}},{"ID":"2849","typeID":"Arrow","zOrder":"26","w":"153","h":"2","measuredW":"150","measuredH":"100","x":"1350","y":"1098","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":153.43623321529276,"y":2.1515151515150137},"p1":{"x":0.4999578668592745,"y":0.00035566936975391084},"p2":{"x":0.04816647286861553,"y":-0.34845706590590453}}},{"ID":"2850","typeID":"Arrow","zOrder":"25","h":"46","measuredW":"150","measuredH":"100","x":"1342","y":"1111","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":149.95030847121234,"y":46.17526038328424},"p1":{"x":0.42265907915157874,"y":-0.08346266597689306},"p2":{"x":0.3992035647902412,"y":-0.11436732584661513}}},{"ID":"2893","typeID":"Arrow","zOrder":"24","w":"131","h":"24","measuredW":"150","measuredH":"100","x":"1363","y":"1455","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":130.95544602123732,"y":23.867029894531242},"p1":{"x":0.3512843587716724,"y":-0.055651375067110674},"p2":{"x":-0.46006702341355776,"y":-0.02669974995069424}}},{"ID":"2896","typeID":"Arrow","zOrder":"23","w":"136","h":"24","measuredW":"150","measuredH":"100","x":"1359","y":"1417","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":136.15013250346146,"y":-0.2566671811218839},"p1":{"x":0.4699759807846267,"y":0.06405124099279334},"p2":{"x":-0.04412647008598469,"y":23.637062463360053}}},{"ID":"2897","typeID":"Arrow","zOrder":"22","w":"333","h":"1","measuredW":"150","measuredH":"100","x":"857","y":"1449","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.04142925695464328,"y":0.362673214497363},"p1":{"x":0.499957866859274,"y":0.0003556693697539092},"p2":{"x":332.81818181818176,"y":0.362673214497363}}},{"ID":"2900","typeID":"Arrow","zOrder":"21","w":"161","h":"2","measuredW":"150","measuredH":"100","x":"1342","y":"1268","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":161.43623321529276,"y":2.1515151515150137},"p1":{"x":0.49995786685927457,"y":0.00035566936975390845},"p2":{"x":0.34973142699914206,"y":-0.03412281550845364}}},{"ID":"2901","typeID":"Arrow","zOrder":"20","w":"154","h":"41","measuredW":"150","measuredH":"100","x":"1345","y":"1281","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":154.37932265053473,"y":40.786503208687236},"p1":{"x":0.381694744782499,"y":-0.08021121448327811},"p2":{"x":-0.11753323068592181,"y":0.26273773164575687}}},{"ID":"2904","typeID":"Arrow","zOrder":"19","w":"1","h":"114","measuredW":"150","measuredH":"100","x":"1213","y":"1331","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.0003556693697539093},"p2":{"x":-0.18181818181824383,"y":113.97948286209976}}},{"ID":"2906","typeID":"Arrow","zOrder":"18","w":"1","h":"94","measuredW":"150","measuredH":"100","x":"768","y":"1451","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.49995786685927396,"y":0.0003556693697539094},"p2":{"x":-0.18181818181824383,"y":94.03541136954323},"stroke":"dotted"}},{"ID":"2913","typeID":"Arrow","zOrder":"17","w":"1","h":"238","measuredW":"150","measuredH":"100","x":"942","y":"1458","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.49995786685927385,"y":0.00035566936975390943},"p2":{"x":-0.18181818181824383,"y":238.04006420899805}}},{"ID":"2923","typeID":"Arrow","zOrder":"16","w":"1","h":"73","measuredW":"150","measuredH":"100","x":"766","y":"1696","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.00035566936975390943},"p2":{"x":-0.18181818181824383,"y":73.08703041995386}}},{"ID":"2924","typeID":"Arrow","zOrder":"15","w":"333","h":"1","measuredW":"150","measuredH":"100","x":"903","y":"1695","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.04142925695464328,"y":0.362673214497363},"p1":{"x":0.499957866859274,"y":0.0003556693697539092},"p2":{"x":332.81818181818176,"y":0.362673214497363}}},{"ID":"2933","typeID":"Arrow","zOrder":"14","w":"1","h":"73","measuredW":"150","measuredH":"100","x":"1211","y":"1623","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.00035566936975390943},"p2":{"x":-0.18181818181824383,"y":73.08703041995386}}},{"ID":"2934","typeID":"Arrow","zOrder":"13","w":"202","h":"169","measuredW":"150","measuredH":"100","x":"1345","y":"1700","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.4407532602174342,"y":-0.33922541684933094},"p1":{"x":0.5377224186047156,"y":0.2397621873145367},"p2":{"x":202.5,"y":168.5}}},{"ID":"2947","typeID":"Arrow","zOrder":"12","w":"1","h":"114","measuredW":"150","measuredH":"100","x":"1701","y":"1756","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.0003556693697539093},"p2":{"x":-0.18181818181824383,"y":113.97948286209976},"stroke":"dotted"}},{"ID":"2948","typeID":"Arrow","zOrder":"11","w":"1","h":"80","measuredW":"150","measuredH":"100","x":"1701","y":"1623","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.00035566936975390927},"p2":{"x":-0.18181818181824383,"y":79.5}}},{"ID":"2949","typeID":"Arrow","zOrder":"10","w":"184","h":"147","measuredW":"150","measuredH":"100","x":"1361","y":"1879","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":183.5,"y":-0.03666724399795385},"p1":{"x":0.4528877147224164,"y":0.2228100131869359},"p2":{"x":0,"y":146.5}}},{"ID":"2956","typeID":"Arrow","zOrder":"9","w":"1","h":"114","measuredW":"150","measuredH":"100","x":"1233","y":"1912","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.0003556693697539093},"p2":{"x":-0.18181818181824383,"y":113.97948286209976},"stroke":"dotted"}},{"ID":"2957","typeID":"Arrow","zOrder":"8","w":"127","h":"1","measuredW":"150","measuredH":"100","x":"984","y":"2024","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.4746082422041127,"y":0.362673214497363},"p1":{"x":0.49995786685927396,"y":0.00035566936975390927},"p2":{"x":126.69373677187127,"y":0.362673214497363}}},{"ID":"2960","typeID":"Arrow","zOrder":"7","w":"1","h":"151","measuredW":"150","measuredH":"100","x":"797","y":"1960","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0,"y":0},"p1":{"x":0.5016483571549873,"y":-0.00045943399456992786},"p2":{"x":0,"y":151}}},{"ID":"2961","typeID":"Arrow","zOrder":"6","w":"1","h":"151","measuredW":"150","measuredH":"100","x":"937","y":"1960","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0,"y":0},"p1":{"x":0.5016483571549873,"y":-0.00045943399456992786},"p2":{"x":0,"y":151}}},{"ID":"2971","typeID":"Arrow","zOrder":"5","h":"1","measuredW":"150","measuredH":"100","x":"658","y":"2024","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.16382818454974313,"y":0.362673214497363},"p1":{"x":0.4999578668592739,"y":0.0003556693697539094},"p2":{"x":149.69373677187127,"y":0.362673214497363}}},{"ID":"2972","typeID":"Arrow","zOrder":"101","w":"1","h":"175","measuredW":"150","measuredH":"100","x":"657","y":"2025","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.0003556693697539095},"p2":{"x":-0.18181818181824383,"y":175}}},{"ID":"2975","typeID":"Arrow","zOrder":"4","w":"519","h":"1","measuredW":"150","measuredH":"100","x":"658","y":"2200","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.16382818454974313,"y":0.362673214497363},"p1":{"x":0.4999578668592739,"y":0.0003556693697539094},"p2":{"x":518.6666666666667,"y":0.3626732144975904}}},{"ID":"2984","typeID":"Arrow","zOrder":"3","w":"1","h":"105","measuredW":"150","measuredH":"100","x":"861","y":"2204","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":0,"y":0},"p1":{"x":0.5016483571549873,"y":-0.0004594339945699278},"p2":{"x":0,"y":105}}},{"ID":"2987","typeID":"Arrow","zOrder":"2","w":"1","h":"85","measuredW":"150","measuredH":"100","x":"1213","y":"2200","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","stroke":"dotted","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.49995786685927385,"y":0.0003556693697539093},"p2":{"x":-0.18181818181824383,"y":84.66666666666652}}},{"ID":"2996","typeID":"Arrow","zOrder":"1","w":"340","h":"1","measuredW":"150","measuredH":"100","x":"1267","y":"2200","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0.16382818454974313,"y":0.362673214497363},"p1":{"x":0.4999578668592738,"y":0.0003556693697539093},"p2":{"x":340.33333333333326,"y":0.3626732144975904}}},{"ID":"2997","typeID":"Arrow","zOrder":"112","w":"1","h":"342","measuredW":"150","measuredH":"100","x":"1607","y":"2200","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.0003556693697539096},"p2":{"x":-0.18181818181824383,"y":342}}},{"ID":"2998","typeID":"Arrow","zOrder":"113","w":"441","h":"1","measuredW":"150","measuredH":"100","x":"1166","y":"2543","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":0,"y":0.3626732144975904},"p1":{"x":0.49995786685927374,"y":0.00035566936975390954},"p2":{"x":441.33333333333326,"y":0.3626732144975904}}},{"ID":"2999","typeID":"Arrow","zOrder":"114","w":"1","h":"161","measuredW":"150","measuredH":"100","x":"1166","y":"2544","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"4273622","p0":{"x":-0.18181818181824383,"y":0},"p1":{"x":0.4999578668592739,"y":0.00035566936975390965},"p2":{"x":-0.18181818181824383,"y":161}}},{"ID":"3000","typeID":"Arrow","zOrder":"115","w":"1","h":"81","measuredW":"150","measuredH":"100","x":"1166","y":"2729","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","stroke":"dotted","color":"10027263","p0":{"x":0,"y":0},"p1":{"x":0.49999999999999994,"y":0},"p2":{"x":0,"y":81.09090909090901}}},{"ID":"3001","typeID":"TextArea","zOrder":"116","w":"438","h":"118","measuredW":"200","measuredH":"140","x":"947","y":"2643"},{"ID":"3002","typeID":"Label","zOrder":"117","measuredW":"366","measuredH":"25","x":"983","y":"2662","properties":{"size":"17","text":"Continue Learning with following relevant tracks"}},{"ID":"3003","typeID":"__group__","zOrder":"118","measuredW":"198","measuredH":"44","w":"198","h":"44","x":"1170","y":"2699","properties":{"controlName":"ext_link:roadmap.sh/devops"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"198","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"141","measuredH":"25","x":"28","y":"9","properties":{"size":"17","text":"DevOps Roadmap"}}]}}},{"ID":"3004","typeID":"__group__","zOrder":"119","measuredW":"198","measuredH":"44","w":"198","h":"44","x":"962","y":"2699","properties":{"controlName":"ext_link:roadmap.sh/backend"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"198","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"147","measuredH":"25","x":"25","y":"9","properties":{"size":"17","text":"Backend Roadmap"}}]}}},{"ID":"3005","typeID":"Arrow","zOrder":"120","w":"45","h":"1","measuredW":"150","measuredH":"100","x":"613","y":"1387","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"16777215","p0":{"x":0.04142925695464328,"y":0.362673214497363},"p1":{"x":0.49995786685927407,"y":0.0003556693697539088},"p2":{"x":45.203968575995304,"y":0.362673214497363}}},{"ID":"3006","typeID":"Arrow","zOrder":"121","w":"45","h":"1","measuredW":"150","measuredH":"100","x":"1754","y":"1371","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","color":"16777215","p0":{"x":0.04142925695464328,"y":0.362673214497363},"p1":{"x":0.49995786685927407,"y":0.0003556693697539088},"p2":{"x":45.203968575995304,"y":0.362673214497363}}},{"ID":"3007","typeID":"Arrow","zOrder":"122","w":"169","h":"1","measuredW":"150","measuredH":"100","x":"1081","y":"2882","properties":{"curvature":"0","leftArrow":"false","rightArrow":"false","stroke":"dotted","color":"16777215","p0":{"x":0,"y":0},"p1":{"x":0.4999999999999999,"y":0},"p2":{"x":168.6400000000001,"y":0}}},{"ID":"3008","typeID":"__group__","zOrder":"37","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1065","y":"909","properties":{"controlName":"100-introduction"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"93","measuredH":"25","x":"102","y":"12","properties":{"size":"17","text":"Introduction"}}]}}},{"ID":"3009","typeID":"__group__","zOrder":"58","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1065","y":"1081","properties":{"controlName":"101-underlying-technologies"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"189","measuredH":"25","x":"54","y":"12","properties":{"size":"17","text":"Underlying Technologies"}}]}}},{"ID":"3010","typeID":"__group__","zOrder":"69","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1065","y":"1249","properties":{"controlName":"102-installation-setup"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"145","measuredH":"25","x":"76","y":"12","properties":{"size":"17","text":"Installation / Setup"}}]}}},{"ID":"3011","typeID":"__group__","zOrder":"77","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1065","y":"1304","properties":{"controlName":"103-docker-basics"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"131","measuredH":"25","x":"83","y":"13","properties":{"size":"17","text":"Basics of Docker"}}]}}},{"ID":"3012","typeID":"__group__","zOrder":"72","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1076","y":"1423","properties":{"controlName":"104-data-persistence"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"132","measuredH":"25","x":"83","y":"12","properties":{"size":"17","text":"Data Persistence"}}]}}},{"ID":"3013","typeID":"__group__","zOrder":"76","measuredW":"340","measuredH":"50","w":"340","h":"50","x":"633","y":"1423","properties":{"controlName":"105-using-third-party-images"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"340","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"260","measuredH":"25","x":"40","y":"12","properties":{"size":"17","text":"Using 3rd Party Container Images"}}]}}},{"ID":"3014","typeID":"__group__","zOrder":"81","measuredW":"338","measuredH":"50","w":"338","h":"50","x":"633","y":"1671","properties":{"controlName":"106-building-container-images"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"338","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"205","measuredH":"25","x":"66","y":"12","properties":{"size":"17","text":"Building Container Images"}}]}}},{"ID":"3015","typeID":"__group__","zOrder":"85","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1076","y":"1672","properties":{"controlName":"107-container-registries"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"159","measuredH":"25","x":"69","y":"12","properties":{"size":"17","text":"Container Registries"}}]}}},{"ID":"3016","typeID":"__group__","zOrder":"89","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1460","y":"1842","properties":{"controlName":"108-running-containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"153","measuredH":"25","x":"72","y":"12","properties":{"size":"17","text":"Running Containers"}}]}}},{"ID":"3017","typeID":"__group__","zOrder":"93","measuredW":"298","measuredH":"50","w":"298","h":"50","x":"1089","y":"2000","properties":{"controlName":"109-container-security"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"298","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"142","measuredH":"25","x":"78","y":"12","properties":{"size":"17","text":"Container Security"}}]}}},{"ID":"3018","typeID":"__group__","zOrder":"96","measuredW":"267","measuredH":"50","w":"267","h":"50","x":"735","y":"2000","properties":{"controlName":"110-docker-cli"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"267","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"87","measuredH":"25","x":"90","y":"12","properties":{"size":"17","text":"Docker CLI"}}]}}},{"ID":"3019","typeID":"__group__","zOrder":"102","measuredW":"265","measuredH":"50","w":"265","h":"50","x":"737","y":"2176","properties":{"controlName":"111-developer-experience"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"265","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"173","measuredH":"25","x":"46","y":"12","properties":{"size":"17","text":"Developer Experience"}}]}}},{"ID":"3020","typeID":"__group__","zOrder":"107","measuredW":"265","measuredH":"50","w":"265","h":"50","x":"1089","y":"2176","properties":{"controlName":"112-deploying-containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"265","h":"50","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16776960"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"166","measuredH":"25","x":"42","y":"12","properties":{"size":"17","text":"Deploying Containers"}}]}}},{"ID":"3021","typeID":"__group__","zOrder":"54","measuredW":"299","measuredH":"44","w":"299","h":"44","x":"1484","y":"836","properties":{"controlName":"100-introduction:what-are-containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"299","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"167","measuredH":"25","x":"66","y":"9","properties":{"size":"17","text":"What are Containers?"}}]}}},{"ID":"3022","typeID":"__group__","zOrder":"55","measuredW":"299","measuredH":"44","w":"299","h":"44","x":"1484","y":"887","properties":{"controlName":"101-introduction:need-for-containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"299","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"223","measuredH":"25","x":"38","y":"9","properties":{"size":"17","text":"Why do we need Containers?"}}]}}},{"ID":"3023","typeID":"__group__","zOrder":"56","measuredW":"299","measuredH":"44","w":"299","h":"44","x":"1484","y":"937","properties":{"controlName":"102-introduction:bare-metal-vm-containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"299","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"254","measuredH":"25","x":"23","y":"9","properties":{"size":"17","text":"Bare Metal vs VMs vs Containers"}}]}}},{"ID":"3024","typeID":"__group__","zOrder":"57","measuredW":"299","measuredH":"44","w":"299","h":"44","x":"1484","y":"987","properties":{"controlName":"103-introduction:docker-and-oci"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"299","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"124","measuredH":"25","x":"88","y":"9","properties":{"size":"17","text":"Docker and OCI"}}]}}},{"ID":"3025","typeID":"__group__","zOrder":"65","measuredW":"182","measuredH":"44","w":"182","h":"44","x":"1484","y":"1079","properties":{"controlName":"100-underlying-technologies:namespaces"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"182","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"102","measuredH":"25","x":"40","y":"9","properties":{"size":"17","text":"Namespaces"}}]}}},{"ID":"3026","typeID":"__group__","zOrder":"66","measuredW":"107","measuredH":"44","w":"107","h":"44","x":"1674","y":"1079","properties":{"controlName":"101-underlying-technologies:cgroups"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"107","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"63","measuredH":"25","x":"22","y":"9","properties":{"size":"17","text":"cgroups"}}]}}},{"ID":"3027","typeID":"__group__","zOrder":"67","measuredW":"299","measuredH":"44","w":"299","h":"44","x":"1484","y":"1128","properties":{"controlName":"102-underlying-technologies:union-filesystems"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"299","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"140","measuredH":"25","x":"80","y":"9","properties":{"size":"17","text":"Union Filesystems"}}]}}},{"ID":"3028","typeID":"__group__","zOrder":"70","measuredW":"316","measuredH":"44","w":"316","h":"44","x":"1476","y":"1247","properties":{"controlName":"100-installation-setup:docker-desktop"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"316","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"281","measuredH":"25","x":"21","y":"10","properties":{"size":"17","text":"Docker Desktop ( Win / Mac / Linux)"}}]}}},{"ID":"3029","typeID":"__group__","zOrder":"71","measuredW":"316","measuredH":"44","w":"316","h":"44","x":"1476","y":"1296","properties":{"controlName":"101-installation-setup:docker-engine"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"316","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"181","measuredH":"25","x":"71","y":"10","properties":{"size":"17","text":"Docker Engine ( Linux )"}}]}}},{"ID":"3030","typeID":"__group__","zOrder":"73","measuredW":"309","measuredH":"44","w":"309","h":"44","x":"1483","y":"1401","properties":{"controlName":"100-data-persistence:ephemeral-container-fs"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"309","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"242","measuredH":"25","x":"34","y":"10","properties":{"size":"17","text":"Ephemeral container filesystem"}}]}}},{"ID":"3031","typeID":"__group__","zOrder":"74","measuredW":"152","measuredH":"44","w":"152","h":"44","x":"1483","y":"1450","properties":{"controlName":"101-data-persistence:volume-mounts"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"152","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"118","measuredH":"25","x":"17","y":"10","properties":{"size":"17","text":"Volume Mounts"}}]}}},{"ID":"3032","typeID":"__group__","zOrder":"75","measuredW":"152","measuredH":"44","w":"152","h":"44","x":"1640","y":"1451","properties":{"controlName":"102-data-persistence:bind-mounts"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"152","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"97","measuredH":"25","x":"27","y":"9","properties":{"size":"17","text":"Bind Mounts"}}]}}},{"ID":"3034","typeID":"__group__","zOrder":"78","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1501","properties":{"controlName":"100-using-third-party-images:databases"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"83","measuredH":"25","x":"94","y":"10","properties":{"size":"17","text":"Databases"}}]}}},{"ID":"3035","typeID":"__group__","zOrder":"79","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1549","properties":{"controlName":"101-using-third-party-images:interactive-test-environments"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"228","measuredH":"25","x":"22","y":"10","properties":{"size":"17","text":"Interactive Test Environments"}}]}}},{"ID":"3036","typeID":"__group__","zOrder":"80","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1597","properties":{"controlName":"102-using-third-party-images:command-line-utilities"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"179","measuredH":"25","x":"46","y":"10","properties":{"size":"17","text":"Command Line Utilities"}}]}}},{"ID":"3037","typeID":"__group__","zOrder":"82","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1746","properties":{"controlName":"100-building-container-images:dockerfiles"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"86","measuredH":"25","x":"93","y":"10","properties":{"size":"17","text":"Dockerfiles"}}]}}},{"ID":"3038","typeID":"__group__","zOrder":"83","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1794","properties":{"controlName":"101-building-container-images:efficient-layer-caching"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"168","measuredH":"25","x":"52","y":"10","properties":{"size":"17","text":"Efficient layer caching"}}]}}},{"ID":"3039","typeID":"__group__","zOrder":"84","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"633","y":"1842","properties":{"controlName":"102-building-container-images:image-size-and-security"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"182","measuredH":"25","x":"45","y":"10","properties":{"size":"17","text":"Image size and security"}}]}}},{"ID":"3040","typeID":"__group__","zOrder":"86","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"1089","y":"1597","properties":{"controlName":"100-container-registries:dockerhub"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"84","measuredH":"25","x":"94","y":"10","properties":{"size":"17","text":"Dockerhub"}}]}}},{"ID":"3041","typeID":"__group__","zOrder":"87","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"1089","y":"1549","properties":{"controlName":"101-container-registries:dockerhub-alt"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"231","measuredH":"25","x":"20","y":"10","properties":{"size":"17","text":"Others (ghcr, ecr, gcr, act, etc)"}}]}}},{"ID":"3042","typeID":"__group__","zOrder":"88","measuredW":"272","measuredH":"44","w":"272","h":"44","x":"1089","y":"1501","properties":{"controlName":"102-container-registries:image-tagging-best-practices"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"272","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"231","measuredH":"25","x":"20","y":"9","properties":{"size":"17","text":"Image Tagging Best Practices"}}]}}},{"ID":"3043","typeID":"__group__","zOrder":"90","measuredW":"174","measuredH":"44","w":"174","h":"44","x":"1615","y":"1728","properties":{"controlName":"100-running-containers:docker-run"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"174","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"83","measuredH":"25","x":"45","y":"9","properties":{"size":"17","text":"docker run"}}]}}},{"ID":"3044","typeID":"__group__","zOrder":"91","measuredW":"174","measuredH":"44","w":"174","h":"44","x":"1615","y":"1680","properties":{"controlName":"101-running-containers:docker-compose"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"174","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"129","measuredH":"25","x":"22","y":"9","properties":{"size":"17","text":"docker compose"}}]}}},{"ID":"3045","typeID":"__group__","zOrder":"92","measuredW":"273","measuredH":"44","w":"273","h":"44","x":"1517","y":"1598","properties":{"controlName":"102-running-containers:runtime-config-options"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"273","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"236","measuredH":"25","x":"20","y":"9","properties":{"size":"17","text":"Runtime Configuration Options"}}]}}},{"ID":"3046","typeID":"__group__","zOrder":"94","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1124","y":"1892","properties":{"controlName":"100-container-security:image-security"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"116","measuredH":"25","x":"52","y":"9","properties":{"size":"17","text":"Image Security"}}]}}},{"ID":"3047","typeID":"__group__","zOrder":"95","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1124","y":"1844","properties":{"controlName":"101-container-security:runtime-security"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"131","measuredH":"25","x":"44","y":"9","properties":{"size":"17","text":"Runtime Security"}}]}}},{"ID":"3048","typeID":"__group__","zOrder":"97","measuredW":"122","measuredH":"44","w":"122","h":"44","x":"737","y":"1926","properties":{"controlName":"100-docker-cli:images"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"122","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"58","measuredH":"25","x":"32","y":"9","properties":{"size":"17","text":"Images"}}]}}},{"ID":"3049","typeID":"__group__","zOrder":"98","measuredW":"126","measuredH":"44","w":"126","h":"44","x":"875","y":"1926","properties":{"controlName":"101-docker-cli:containers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"126","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"85","measuredH":"25","x":"20","y":"9","properties":{"size":"17","text":"Containers"}}]}}},{"ID":"3050","typeID":"__group__","zOrder":"99","measuredW":"122","measuredH":"44","w":"122","h":"44","x":"737","y":"2081","properties":{"controlName":"102-docker-cli:volumes"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"122","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"65","measuredH":"25","x":"28","y":"9","properties":{"size":"17","text":"Volumes"}}]}}},{"ID":"3051","typeID":"__group__","zOrder":"100","measuredW":"126","measuredH":"44","w":"126","h":"44","x":"875","y":"2081","properties":{"controlName":"102-docker-cli:networks"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"126","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"72","measuredH":"25","x":"27","y":"9","properties":{"size":"17","text":"Networks"}}]}}},{"ID":"3052","typeID":"__group__","zOrder":"103","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"752","y":"2272","properties":{"controlName":"100-developer-experience:hot-reloading"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"110","measuredH":"25","x":"55","y":"9","properties":{"size":"17","text":"Hot Reloading"}}]}}},{"ID":"3053","typeID":"__group__","zOrder":"104","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"752","y":"2320","properties":{"controlName":"101-developer-experience:debuggers"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"86","measuredH":"25","x":"67","y":"9","properties":{"size":"17","text":"Debuggers"}}]}}},{"ID":"3054","typeID":"__group__","zOrder":"105","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"752","y":"2368","properties":{"controlName":"102-developer-experience:tests"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"41","measuredH":"25","x":"89","y":"9","properties":{"size":"17","text":"Tests"}}]}}},{"ID":"3055","typeID":"__group__","zOrder":"106","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"752","y":"2416","properties":{"controlName":"103-developer-experience:continuous-integration"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"176","measuredH":"25","x":"22","y":"9","properties":{"size":"17","text":"Continuous Integration"}}]}}},{"ID":"3056","typeID":"__group__","zOrder":"108","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1102","y":"2272","properties":{"controlName":"100-deploying-containers:paas-options"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"104","measuredH":"25","x":"58","y":"9","properties":{"size":"17","text":"PaaS Options"}}]}}},{"ID":"3057","typeID":"__group__","zOrder":"109","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1102","y":"2320","properties":{"controlName":"101-deploying-containers:kubernetes"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"90","measuredH":"25","x":"65","y":"9","properties":{"size":"17","text":"Kubernetes"}}]}}},{"ID":"3058","typeID":"__group__","zOrder":"110","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1102","y":"2368","properties":{"controlName":"102-deploying-containers:docker-swarm"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"111","measuredH":"25","x":"54","y":"9","properties":{"size":"17","text":"Docker Swarm"}}]}}},{"ID":"3059","typeID":"__group__","zOrder":"111","measuredW":"219","measuredH":"44","w":"219","h":"44","x":"1102","y":"2416","properties":{"controlName":"103-deploying-containers:nomad"},"children":{"controls":{"control":[{"ID":"0","typeID":"TextArea","zOrder":"0","w":"219","h":"44","measuredW":"200","measuredH":"140","x":"0","y":"0","properties":{"color":"16770457"}},{"ID":"1","typeID":"Label","zOrder":"1","measuredW":"56","measuredH":"25","x":"77","y":"9","properties":{"size":"17","text":"Nomad"}}]}}},{"ID":"3060","typeID":"__group__","zOrder":"62","measuredW":"70","measuredH":"25","w":"70","h":"25","x":"693","y":"669","properties":{"controlName":"ext_link:twitter.com/sidpalas"},"children":{"controls":{"control":[{"ID":"0","typeID":"Label","zOrder":"0","measuredW":"70","measuredH":"25","x":"0","y":"0","properties":{"size":"17","text":"{color:purple}Sid Palas{color}"}}]}}},{"ID":"3061","typeID":"__group__","zOrder":"64","measuredW":"268","measuredH":"25","w":"268","h":"25","x":"659","y":"697","properties":{"controlName":"ext_link:courses.devopsdirective.com/docker-beginner-to-pro"},"children":{"controls":{"control":[{"ID":"0","typeID":"Label","zOrder":"0","measuredW":"268","measuredH":"25","x":"0","y":"0","properties":{"size":"17","text":"{color:purple}course covering this topic in depth.{color}"}}]}}},{"ID":"3063","typeID":"Canvas","zOrder":"0","w":"327","h":"393","measuredW":"100","measuredH":"70","x":"635","y":"892"}]},"attributes":{"name":"New Wireframe 9 copy 5","order":1000147.9446306123,"parentID":null,"notes":null},"branchID":"Master","resourceID":"A3B84AD1-CEAB-4958-B7C6-199A90A297E8","mockupH":"2283","mockupW":"1186","measuredW":"1799","measuredH":"2883","version":"1.0"},"groupOffset":{"x":0,"y":0},"dependencies":[],"projectID":"file:///Users/kamranahmed/Desktop/AWS%20Roadmap.bmpr"}
+{
+  "mockup": {
+    "controls": {
+      "control": [
+        {
+          "ID": "2620",
+          "typeID": "Arrow",
+          "zOrder": "31",
+          "w": "1",
+          "h": "501",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1213",
+          "y": "766",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.49995786685927396, "y": 0.00035566936975390927 },
+            "p2": { "x": -0.18181818181824383, "y": 501.00085499312513 }
+          }
+        },
+        {
+          "ID": "2625",
+          "typeID": "Label",
+          "zOrder": "32",
+          "measuredW": "104",
+          "measuredH": "40",
+          "x": "1162",
+          "y": "714",
+          "properties": { "size": "32", "text": "Docker" }
+        },
+        {
+          "ID": "2626",
+          "typeID": "Canvas",
+          "zOrder": "33",
+          "w": "350",
+          "h": "141",
+          "measuredW": "100",
+          "measuredH": "70",
+          "x": "1433",
+          "y": "636"
+        },
+        {
+          "ID": "2627",
+          "typeID": "Label",
+          "zOrder": "34",
+          "measuredW": "314",
+          "measuredH": "25",
+          "x": "1447",
+          "y": "653",
+          "properties": {
+            "size": "17",
+            "text": "Find the detailed version of this roadmap"
+          }
+        },
+        {
+          "ID": "2628",
+          "typeID": "Label",
+          "zOrder": "35",
+          "measuredW": "319",
+          "measuredH": "25",
+          "x": "1447",
+          "y": "681",
+          "properties": {
+            "size": "17",
+            "text": "along with resources and other roadmaps"
+          }
+        },
+        {
+          "ID": "2629",
+          "typeID": "__group__",
+          "zOrder": "36",
+          "measuredW": "320",
+          "measuredH": "45",
+          "w": "320",
+          "h": "45",
+          "x": "1448",
+          "y": "717",
+          "properties": { "controlName": "ext_link:roadmap.sh" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Canvas",
+                  "zOrder": "0",
+                  "w": "320",
+                  "h": "45",
+                  "measuredW": "100",
+                  "measuredH": "70",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "borderColor": "4273622", "color": "4273622" }
+                },
+                {
+                  "ID": "2",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "172",
+                  "measuredH": "28",
+                  "x": "74",
+                  "y": "8",
+                  "properties": {
+                    "color": "16777215",
+                    "size": "20",
+                    "text": "https://roadmap.sh"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "2670",
+          "typeID": "Arrow",
+          "zOrder": "39",
+          "w": "1",
+          "h": "101",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1213",
+          "y": "600",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": -0.18181818181824383, "y": 0.060606060606005485 },
+            "p1": { "x": 0.4999578668592744, "y": 0.0003556693697539094 },
+            "p2": { "x": -0.18181818181824383, "y": 101.15151515151513 }
+          }
+        },
+        {
+          "ID": "2778",
+          "typeID": "Label",
+          "zOrder": "38",
+          "measuredW": "155",
+          "measuredH": "25",
+          "x": "721",
+          "y": "1101",
+          "properties": { "size": "17", "text": "Linux Fundamentals" }
+        },
+        {
+          "ID": "2785",
+          "typeID": "Label",
+          "zOrder": "40",
+          "measuredW": "108",
+          "measuredH": "26",
+          "x": "746",
+          "y": "1294",
+          "properties": { "text": "Prerequisites", "size": "18" }
+        },
+        {
+          "ID": "2786",
+          "typeID": "TextArea",
+          "zOrder": "41",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "907",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2787",
+          "typeID": "Label",
+          "zOrder": "42",
+          "measuredW": "149",
+          "measuredH": "25",
+          "x": "724",
+          "y": "916",
+          "properties": { "size": "17", "text": "Package Managers" }
+        },
+        {
+          "ID": "2788",
+          "typeID": "TextArea",
+          "zOrder": "43",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "954",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2789",
+          "typeID": "Label",
+          "zOrder": "44",
+          "measuredW": "216",
+          "measuredH": "25",
+          "x": "691",
+          "y": "963",
+          "properties": { "size": "17", "text": "Users / Groups Permissions" }
+        },
+        {
+          "ID": "2790",
+          "typeID": "TextArea",
+          "zOrder": "45",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "1001",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2791",
+          "typeID": "Label",
+          "zOrder": "46",
+          "measuredW": "127",
+          "measuredH": "25",
+          "x": "735",
+          "y": "1010",
+          "properties": { "size": "17", "text": "Shell commands" }
+        },
+        {
+          "ID": "2792",
+          "typeID": "TextArea",
+          "zOrder": "47",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "1048",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2793",
+          "typeID": "Label",
+          "zOrder": "48",
+          "measuredW": "108",
+          "measuredH": "25",
+          "x": "745",
+          "y": "1057",
+          "properties": { "size": "17", "text": "Shell scripting" }
+        },
+        {
+          "ID": "2797",
+          "typeID": "Label",
+          "zOrder": "49",
+          "measuredW": "142",
+          "measuredH": "25",
+          "x": "728",
+          "y": "1240",
+          "properties": { "size": "17", "text": "Web Development" }
+        },
+        {
+          "ID": "2798",
+          "typeID": "TextArea",
+          "zOrder": "50",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "1141",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2799",
+          "typeID": "Label",
+          "zOrder": "51",
+          "measuredW": "194",
+          "measuredH": "25",
+          "x": "703",
+          "y": "1150",
+          "properties": { "size": "17", "text": "Programming Lanugages" }
+        },
+        {
+          "ID": "2800",
+          "typeID": "TextArea",
+          "zOrder": "52",
+          "w": "300",
+          "h": "44",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "650",
+          "y": "1188",
+          "properties": { "color": "16770457" }
+        },
+        {
+          "ID": "2801",
+          "typeID": "Label",
+          "zOrder": "53",
+          "measuredW": "183",
+          "measuredH": "25",
+          "x": "707",
+          "y": "1197",
+          "properties": { "size": "17", "text": "Application Architecture" }
+        },
+        {
+          "ID": "2822",
+          "typeID": "Arrow",
+          "zOrder": "27",
+          "w": "159",
+          "h": "23",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1336",
+          "y": "906",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0.4646359097735058, "y": 23.353294775624022 },
+            "p1": { "x": 0.5172121703355936, "y": -0.04134567000631401 },
+            "p2": { "x": 159.51104906422256, "y": 0.2084809210585945 }
+          }
+        },
+        {
+          "ID": "2823",
+          "typeID": "Arrow",
+          "zOrder": "28",
+          "w": "157",
+          "h": "64",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1336",
+          "y": "855",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0.4646359097735058, "y": 63.67107299659381 },
+            "p1": { "x": 0.4603346517294317, "y": -0.10421022711848146 },
+            "p2": { "x": 157.13722200221582, "y": 0.1711990879144878 }
+          }
+        },
+        {
+          "ID": "2824",
+          "typeID": "Arrow",
+          "zOrder": "29",
+          "w": "169",
+          "h": "24",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1328",
+          "y": "940",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0.15624119275003068, "y": 0.628973320155751 },
+            "p1": { "x": 0.5012965221560048, "y": 0.04743407560804315 },
+            "p2": { "x": 168.69796259522582, "y": 24.367243940222806 }
+          }
+        },
+        {
+          "ID": "2825",
+          "typeID": "Arrow",
+          "zOrder": "30",
+          "w": "152",
+          "h": "72",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1340",
+          "y": "946",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0.025376502783501564, "y": -0.0299157903291416 },
+            "p1": { "x": 0.5934120757823323, "y": 0.11641742644399297 },
+            "p2": { "x": 151.95030847121234, "y": 71.77835283537365 }
+          }
+        },
+        {
+          "ID": "2826",
+          "typeID": "Canvas",
+          "zOrder": "59",
+          "w": "327",
+          "h": "126",
+          "measuredW": "100",
+          "measuredH": "70",
+          "x": "636",
+          "y": "620"
+        },
+        {
+          "ID": "2827",
+          "typeID": "Label",
+          "zOrder": "60",
+          "measuredW": "268",
+          "measuredH": "25",
+          "x": "659",
+          "y": "641",
+          "properties": {
+            "size": "17",
+            "text": "Roadmap was made in partnership"
+          }
+        },
+        {
+          "ID": "2834",
+          "typeID": "Canvas",
+          "zOrder": "123",
+          "w": "327",
+          "h": "129",
+          "measuredW": "100",
+          "measuredH": "70",
+          "x": "636",
+          "y": "736"
+        },
+        {
+          "ID": "2836",
+          "typeID": "__group__",
+          "zOrder": "124",
+          "measuredW": "202",
+          "measuredH": "26",
+          "w": "202",
+          "h": "26",
+          "x": "659",
+          "y": "758",
+          "properties": { "controlName": "ext_link:roadmap.sh/kubernetes" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Label",
+                  "zOrder": "0",
+                  "measuredW": "169",
+                  "measuredH": "25",
+                  "x": "33",
+                  "y": "0",
+                  "properties": { "size": "17", "text": "Kubernetes Roadmap" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "__group__",
+                  "zOrder": "1",
+                  "measuredW": "24",
+                  "measuredH": "24",
+                  "w": "24",
+                  "h": "24",
+                  "x": "0",
+                  "y": "2",
+                  "children": {
+                    "controls": {
+                      "control": [
+                        {
+                          "ID": "0",
+                          "typeID": "Icon",
+                          "zOrder": "0",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "16777215",
+                            "icon": { "ID": "circle", "size": "small" }
+                          }
+                        },
+                        {
+                          "ID": "1",
+                          "typeID": "Icon",
+                          "zOrder": "1",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "10066329",
+                            "icon": { "ID": "check-circle", "size": "small" }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "2837",
+          "typeID": "__group__",
+          "zOrder": "125",
+          "measuredW": "174",
+          "measuredH": "26",
+          "w": "174",
+          "h": "26",
+          "x": "659",
+          "y": "788",
+          "properties": { "controlName": "ext_link:roadmap.sh/best-practices" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Label",
+                  "zOrder": "0",
+                  "measuredW": "141",
+                  "measuredH": "25",
+                  "x": "33",
+                  "y": "0",
+                  "properties": { "size": "17", "text": "DevOps Roadmap" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "__group__",
+                  "zOrder": "1",
+                  "measuredW": "24",
+                  "measuredH": "24",
+                  "w": "24",
+                  "h": "24",
+                  "x": "0",
+                  "y": "2",
+                  "children": {
+                    "controls": {
+                      "control": [
+                        {
+                          "ID": "0",
+                          "typeID": "Icon",
+                          "zOrder": "0",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "16777215",
+                            "icon": { "ID": "circle", "size": "small" }
+                          }
+                        },
+                        {
+                          "ID": "1",
+                          "typeID": "Icon",
+                          "zOrder": "1",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "10066329",
+                            "icon": { "ID": "check-circle", "size": "small" }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "2838",
+          "typeID": "Label",
+          "zOrder": "61",
+          "measuredW": "31",
+          "measuredH": "25",
+          "x": "659",
+          "y": "669",
+          "properties": { "size": "17", "text": "with" }
+        },
+        {
+          "ID": "2840",
+          "typeID": "Label",
+          "zOrder": "63",
+          "measuredW": "144",
+          "measuredH": "25",
+          "x": "763",
+          "y": "669",
+          "properties": { "size": "17", "text": ". Checkout his free" }
+        },
+        {
+          "ID": "2841",
+          "typeID": "__group__",
+          "zOrder": "126",
+          "measuredW": "180",
+          "measuredH": "26",
+          "w": "180",
+          "h": "26",
+          "x": "659",
+          "y": "819",
+          "properties": { "controlName": "ext_link:roadmap.sh/backend" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Label",
+                  "zOrder": "0",
+                  "measuredW": "147",
+                  "measuredH": "25",
+                  "x": "33",
+                  "y": "0",
+                  "properties": { "size": "17", "text": "Backend Roadmap" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "__group__",
+                  "zOrder": "1",
+                  "measuredW": "24",
+                  "measuredH": "24",
+                  "w": "24",
+                  "h": "24",
+                  "x": "0",
+                  "y": "2",
+                  "children": {
+                    "controls": {
+                      "control": [
+                        {
+                          "ID": "0",
+                          "typeID": "Icon",
+                          "zOrder": "0",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "16777215",
+                            "icon": { "ID": "circle", "size": "small" }
+                          }
+                        },
+                        {
+                          "ID": "1",
+                          "typeID": "Icon",
+                          "zOrder": "1",
+                          "measuredW": "24",
+                          "measuredH": "24",
+                          "x": "0",
+                          "y": "0",
+                          "properties": {
+                            "color": "10066329",
+                            "icon": { "ID": "check-circle", "size": "small" }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "2848",
+          "typeID": "Label",
+          "zOrder": "68",
+          "measuredW": "245",
+          "measuredH": "25",
+          "x": "1488",
+          "y": "1177",
+          "properties": {
+            "size": "17",
+            "text": "Just get the basic idea of these."
+          }
+        },
+        {
+          "ID": "2849",
+          "typeID": "Arrow",
+          "zOrder": "26",
+          "w": "153",
+          "h": "2",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1350",
+          "y": "1098",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 153.43623321529276, "y": 2.1515151515150137 },
+            "p1": { "x": 0.4999578668592745, "y": 0.00035566936975391084 },
+            "p2": { "x": 0.04816647286861553, "y": -0.34845706590590453 }
+          }
+        },
+        {
+          "ID": "2850",
+          "typeID": "Arrow",
+          "zOrder": "25",
+          "h": "46",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1342",
+          "y": "1111",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 149.95030847121234, "y": 46.17526038328424 },
+            "p1": { "x": 0.42265907915157874, "y": -0.08346266597689306 },
+            "p2": { "x": 0.3992035647902412, "y": -0.11436732584661513 }
+          }
+        },
+        {
+          "ID": "2893",
+          "typeID": "Arrow",
+          "zOrder": "24",
+          "w": "131",
+          "h": "24",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1363",
+          "y": "1455",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 130.95544602123732, "y": 23.867029894531242 },
+            "p1": { "x": 0.3512843587716724, "y": -0.055651375067110674 },
+            "p2": { "x": -0.46006702341355776, "y": -0.02669974995069424 }
+          }
+        },
+        {
+          "ID": "2896",
+          "typeID": "Arrow",
+          "zOrder": "23",
+          "w": "136",
+          "h": "24",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1359",
+          "y": "1417",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 136.15013250346146, "y": -0.2566671811218839 },
+            "p1": { "x": 0.4699759807846267, "y": 0.06405124099279334 },
+            "p2": { "x": -0.04412647008598469, "y": 23.637062463360053 }
+          }
+        },
+        {
+          "ID": "2897",
+          "typeID": "Arrow",
+          "zOrder": "22",
+          "w": "333",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "857",
+          "y": "1449",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.04142925695464328, "y": 0.362673214497363 },
+            "p1": { "x": 0.499957866859274, "y": 0.0003556693697539092 },
+            "p2": { "x": 332.81818181818176, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "2900",
+          "typeID": "Arrow",
+          "zOrder": "21",
+          "w": "161",
+          "h": "2",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1342",
+          "y": "1268",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 161.43623321529276, "y": 2.1515151515150137 },
+            "p1": { "x": 0.49995786685927457, "y": 0.00035566936975390845 },
+            "p2": { "x": 0.34973142699914206, "y": -0.03412281550845364 }
+          }
+        },
+        {
+          "ID": "2901",
+          "typeID": "Arrow",
+          "zOrder": "20",
+          "w": "154",
+          "h": "41",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1345",
+          "y": "1281",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 154.37932265053473, "y": 40.786503208687236 },
+            "p1": { "x": 0.381694744782499, "y": -0.08021121448327811 },
+            "p2": { "x": -0.11753323068592181, "y": 0.26273773164575687 }
+          }
+        },
+        {
+          "ID": "2904",
+          "typeID": "Arrow",
+          "zOrder": "19",
+          "w": "1",
+          "h": "114",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1213",
+          "y": "1331",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539093 },
+            "p2": { "x": -0.18181818181824383, "y": 113.97948286209976 }
+          }
+        },
+        {
+          "ID": "2906",
+          "typeID": "Arrow",
+          "zOrder": "18",
+          "w": "1",
+          "h": "94",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "768",
+          "y": "1451",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.49995786685927396, "y": 0.0003556693697539094 },
+            "p2": { "x": -0.18181818181824383, "y": 94.03541136954323 },
+            "stroke": "dotted"
+          }
+        },
+        {
+          "ID": "2913",
+          "typeID": "Arrow",
+          "zOrder": "17",
+          "w": "1",
+          "h": "238",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "942",
+          "y": "1458",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.49995786685927385, "y": 0.00035566936975390943 },
+            "p2": { "x": -0.18181818181824383, "y": 238.04006420899805 }
+          }
+        },
+        {
+          "ID": "2923",
+          "typeID": "Arrow",
+          "zOrder": "16",
+          "w": "1",
+          "h": "73",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "766",
+          "y": "1696",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.00035566936975390943 },
+            "p2": { "x": -0.18181818181824383, "y": 73.08703041995386 }
+          }
+        },
+        {
+          "ID": "2924",
+          "typeID": "Arrow",
+          "zOrder": "15",
+          "w": "333",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "903",
+          "y": "1695",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.04142925695464328, "y": 0.362673214497363 },
+            "p1": { "x": 0.499957866859274, "y": 0.0003556693697539092 },
+            "p2": { "x": 332.81818181818176, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "2933",
+          "typeID": "Arrow",
+          "zOrder": "14",
+          "w": "1",
+          "h": "73",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1211",
+          "y": "1623",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.00035566936975390943 },
+            "p2": { "x": -0.18181818181824383, "y": 73.08703041995386 }
+          }
+        },
+        {
+          "ID": "2934",
+          "typeID": "Arrow",
+          "zOrder": "13",
+          "w": "202",
+          "h": "169",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1345",
+          "y": "1700",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.4407532602174342, "y": -0.33922541684933094 },
+            "p1": { "x": 0.5377224186047156, "y": 0.2397621873145367 },
+            "p2": { "x": 202.5, "y": 168.5 }
+          }
+        },
+        {
+          "ID": "2947",
+          "typeID": "Arrow",
+          "zOrder": "12",
+          "w": "1",
+          "h": "114",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1701",
+          "y": "1756",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539093 },
+            "p2": { "x": -0.18181818181824383, "y": 113.97948286209976 },
+            "stroke": "dotted"
+          }
+        },
+        {
+          "ID": "2948",
+          "typeID": "Arrow",
+          "zOrder": "11",
+          "w": "1",
+          "h": "80",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1701",
+          "y": "1623",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.00035566936975390927 },
+            "p2": { "x": -0.18181818181824383, "y": 79.5 }
+          }
+        },
+        {
+          "ID": "2949",
+          "typeID": "Arrow",
+          "zOrder": "10",
+          "w": "184",
+          "h": "147",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1361",
+          "y": "1879",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 183.5, "y": -0.03666724399795385 },
+            "p1": { "x": 0.4528877147224164, "y": 0.2228100131869359 },
+            "p2": { "x": 0, "y": 146.5 }
+          }
+        },
+        {
+          "ID": "2956",
+          "typeID": "Arrow",
+          "zOrder": "9",
+          "w": "1",
+          "h": "114",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1233",
+          "y": "1912",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539093 },
+            "p2": { "x": -0.18181818181824383, "y": 113.97948286209976 },
+            "stroke": "dotted"
+          }
+        },
+        {
+          "ID": "2957",
+          "typeID": "Arrow",
+          "zOrder": "8",
+          "w": "127",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "984",
+          "y": "2024",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.4746082422041127, "y": 0.362673214497363 },
+            "p1": { "x": 0.49995786685927396, "y": 0.00035566936975390927 },
+            "p2": { "x": 126.69373677187127, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "2960",
+          "typeID": "Arrow",
+          "zOrder": "7",
+          "w": "1",
+          "h": "151",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "797",
+          "y": "1960",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0, "y": 0 },
+            "p1": { "x": 0.5016483571549873, "y": -0.00045943399456992786 },
+            "p2": { "x": 0, "y": 151 }
+          }
+        },
+        {
+          "ID": "2961",
+          "typeID": "Arrow",
+          "zOrder": "6",
+          "w": "1",
+          "h": "151",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "937",
+          "y": "1960",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0, "y": 0 },
+            "p1": { "x": 0.5016483571549873, "y": -0.00045943399456992786 },
+            "p2": { "x": 0, "y": 151 }
+          }
+        },
+        {
+          "ID": "2971",
+          "typeID": "Arrow",
+          "zOrder": "5",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "658",
+          "y": "2024",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.16382818454974313, "y": 0.362673214497363 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539094 },
+            "p2": { "x": 149.69373677187127, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "2972",
+          "typeID": "Arrow",
+          "zOrder": "101",
+          "w": "1",
+          "h": "175",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "657",
+          "y": "2025",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539095 },
+            "p2": { "x": -0.18181818181824383, "y": 175 }
+          }
+        },
+        {
+          "ID": "2975",
+          "typeID": "Arrow",
+          "zOrder": "4",
+          "w": "519",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "658",
+          "y": "2200",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.16382818454974313, "y": 0.362673214497363 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539094 },
+            "p2": { "x": 518.6666666666667, "y": 0.3626732144975904 }
+          }
+        },
+        {
+          "ID": "2984",
+          "typeID": "Arrow",
+          "zOrder": "3",
+          "w": "1",
+          "h": "105",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "861",
+          "y": "2204",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": 0, "y": 0 },
+            "p1": { "x": 0.5016483571549873, "y": -0.0004594339945699278 },
+            "p2": { "x": 0, "y": 105 }
+          }
+        },
+        {
+          "ID": "2987",
+          "typeID": "Arrow",
+          "zOrder": "2",
+          "w": "1",
+          "h": "85",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1213",
+          "y": "2200",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "stroke": "dotted",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.49995786685927385, "y": 0.0003556693697539093 },
+            "p2": { "x": -0.18181818181824383, "y": 84.66666666666652 }
+          }
+        },
+        {
+          "ID": "2996",
+          "typeID": "Arrow",
+          "zOrder": "1",
+          "w": "340",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1267",
+          "y": "2200",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0.16382818454974313, "y": 0.362673214497363 },
+            "p1": { "x": 0.4999578668592738, "y": 0.0003556693697539093 },
+            "p2": { "x": 340.33333333333326, "y": 0.3626732144975904 }
+          }
+        },
+        {
+          "ID": "2997",
+          "typeID": "Arrow",
+          "zOrder": "112",
+          "w": "1",
+          "h": "342",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1607",
+          "y": "2200",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.0003556693697539096 },
+            "p2": { "x": -0.18181818181824383, "y": 342 }
+          }
+        },
+        {
+          "ID": "2998",
+          "typeID": "Arrow",
+          "zOrder": "113",
+          "w": "441",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1166",
+          "y": "2543",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": 0, "y": 0.3626732144975904 },
+            "p1": { "x": 0.49995786685927374, "y": 0.00035566936975390954 },
+            "p2": { "x": 441.33333333333326, "y": 0.3626732144975904 }
+          }
+        },
+        {
+          "ID": "2999",
+          "typeID": "Arrow",
+          "zOrder": "114",
+          "w": "1",
+          "h": "161",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1166",
+          "y": "2544",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "4273622",
+            "p0": { "x": -0.18181818181824383, "y": 0 },
+            "p1": { "x": 0.4999578668592739, "y": 0.00035566936975390965 },
+            "p2": { "x": -0.18181818181824383, "y": 161 }
+          }
+        },
+        {
+          "ID": "3000",
+          "typeID": "Arrow",
+          "zOrder": "115",
+          "w": "1",
+          "h": "81",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1166",
+          "y": "2729",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "stroke": "dotted",
+            "color": "10027263",
+            "p0": { "x": 0, "y": 0 },
+            "p1": { "x": 0.49999999999999994, "y": 0 },
+            "p2": { "x": 0, "y": 81.09090909090901 }
+          }
+        },
+        {
+          "ID": "3001",
+          "typeID": "TextArea",
+          "zOrder": "116",
+          "w": "438",
+          "h": "118",
+          "measuredW": "200",
+          "measuredH": "140",
+          "x": "947",
+          "y": "2643"
+        },
+        {
+          "ID": "3002",
+          "typeID": "Label",
+          "zOrder": "117",
+          "measuredW": "366",
+          "measuredH": "25",
+          "x": "983",
+          "y": "2662",
+          "properties": {
+            "size": "17",
+            "text": "Continue Learning with following relevant tracks"
+          }
+        },
+        {
+          "ID": "3003",
+          "typeID": "__group__",
+          "zOrder": "118",
+          "measuredW": "198",
+          "measuredH": "44",
+          "w": "198",
+          "h": "44",
+          "x": "1170",
+          "y": "2699",
+          "properties": { "controlName": "ext_link:roadmap.sh/devops" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "198",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "141",
+                  "measuredH": "25",
+                  "x": "28",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "DevOps Roadmap" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3004",
+          "typeID": "__group__",
+          "zOrder": "119",
+          "measuredW": "198",
+          "measuredH": "44",
+          "w": "198",
+          "h": "44",
+          "x": "962",
+          "y": "2699",
+          "properties": { "controlName": "ext_link:roadmap.sh/backend" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "198",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "147",
+                  "measuredH": "25",
+                  "x": "25",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Backend Roadmap" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3005",
+          "typeID": "Arrow",
+          "zOrder": "120",
+          "w": "45",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "613",
+          "y": "1387",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "16777215",
+            "p0": { "x": 0.04142925695464328, "y": 0.362673214497363 },
+            "p1": { "x": 0.49995786685927407, "y": 0.0003556693697539088 },
+            "p2": { "x": 45.203968575995304, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "3006",
+          "typeID": "Arrow",
+          "zOrder": "121",
+          "w": "45",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1754",
+          "y": "1371",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "color": "16777215",
+            "p0": { "x": 0.04142925695464328, "y": 0.362673214497363 },
+            "p1": { "x": 0.49995786685927407, "y": 0.0003556693697539088 },
+            "p2": { "x": 45.203968575995304, "y": 0.362673214497363 }
+          }
+        },
+        {
+          "ID": "3007",
+          "typeID": "Arrow",
+          "zOrder": "122",
+          "w": "169",
+          "h": "1",
+          "measuredW": "150",
+          "measuredH": "100",
+          "x": "1081",
+          "y": "2882",
+          "properties": {
+            "curvature": "0",
+            "leftArrow": "false",
+            "rightArrow": "false",
+            "stroke": "dotted",
+            "color": "16777215",
+            "p0": { "x": 0, "y": 0 },
+            "p1": { "x": 0.4999999999999999, "y": 0 },
+            "p2": { "x": 168.6400000000001, "y": 0 }
+          }
+        },
+        {
+          "ID": "3008",
+          "typeID": "__group__",
+          "zOrder": "37",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1065",
+          "y": "909",
+          "properties": { "controlName": "100-introduction" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "93",
+                  "measuredH": "25",
+                  "x": "102",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Introduction" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3009",
+          "typeID": "__group__",
+          "zOrder": "58",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1065",
+          "y": "1081",
+          "properties": { "controlName": "101-underlying-technologies" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "189",
+                  "measuredH": "25",
+                  "x": "54",
+                  "y": "12",
+                  "properties": {
+                    "size": "17",
+                    "text": "Underlying Technologies"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3010",
+          "typeID": "__group__",
+          "zOrder": "69",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1065",
+          "y": "1249",
+          "properties": { "controlName": "102-installation-setup" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "145",
+                  "measuredH": "25",
+                  "x": "76",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Installation / Setup" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3011",
+          "typeID": "__group__",
+          "zOrder": "77",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1065",
+          "y": "1304",
+          "properties": { "controlName": "103-docker-basics" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "131",
+                  "measuredH": "25",
+                  "x": "83",
+                  "y": "13",
+                  "properties": { "size": "17", "text": "Basics of Docker" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3012",
+          "typeID": "__group__",
+          "zOrder": "72",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1076",
+          "y": "1423",
+          "properties": { "controlName": "104-data-persistence" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "132",
+                  "measuredH": "25",
+                  "x": "83",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Data Persistence" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3013",
+          "typeID": "__group__",
+          "zOrder": "76",
+          "measuredW": "340",
+          "measuredH": "50",
+          "w": "340",
+          "h": "50",
+          "x": "633",
+          "y": "1423",
+          "properties": { "controlName": "105-using-third-party-images" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "340",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "260",
+                  "measuredH": "25",
+                  "x": "40",
+                  "y": "12",
+                  "properties": {
+                    "size": "17",
+                    "text": "Using 3rd Party Container Images"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3014",
+          "typeID": "__group__",
+          "zOrder": "81",
+          "measuredW": "338",
+          "measuredH": "50",
+          "w": "338",
+          "h": "50",
+          "x": "633",
+          "y": "1671",
+          "properties": { "controlName": "106-building-container-images" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "338",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "205",
+                  "measuredH": "25",
+                  "x": "66",
+                  "y": "12",
+                  "properties": {
+                    "size": "17",
+                    "text": "Building Container Images"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3015",
+          "typeID": "__group__",
+          "zOrder": "85",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1076",
+          "y": "1672",
+          "properties": { "controlName": "107-container-registries" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "159",
+                  "measuredH": "25",
+                  "x": "69",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Container Registries" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3016",
+          "typeID": "__group__",
+          "zOrder": "89",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1460",
+          "y": "1842",
+          "properties": { "controlName": "108-running-containers" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "153",
+                  "measuredH": "25",
+                  "x": "72",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Running Containers" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3017",
+          "typeID": "__group__",
+          "zOrder": "93",
+          "measuredW": "298",
+          "measuredH": "50",
+          "w": "298",
+          "h": "50",
+          "x": "1089",
+          "y": "2000",
+          "properties": { "controlName": "109-container-security" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "298",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "142",
+                  "measuredH": "25",
+                  "x": "78",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Container Security" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3018",
+          "typeID": "__group__",
+          "zOrder": "96",
+          "measuredW": "267",
+          "measuredH": "50",
+          "w": "267",
+          "h": "50",
+          "x": "735",
+          "y": "2000",
+          "properties": { "controlName": "110-docker-cli" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "267",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "87",
+                  "measuredH": "25",
+                  "x": "90",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Docker CLI" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3019",
+          "typeID": "__group__",
+          "zOrder": "102",
+          "measuredW": "265",
+          "measuredH": "50",
+          "w": "265",
+          "h": "50",
+          "x": "737",
+          "y": "2176",
+          "properties": { "controlName": "111-developer-experience" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "265",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "173",
+                  "measuredH": "25",
+                  "x": "46",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Developer Experience" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3020",
+          "typeID": "__group__",
+          "zOrder": "107",
+          "measuredW": "265",
+          "measuredH": "50",
+          "w": "265",
+          "h": "50",
+          "x": "1089",
+          "y": "2176",
+          "properties": { "controlName": "112-deploying-containers" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "265",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16776960" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "166",
+                  "measuredH": "25",
+                  "x": "42",
+                  "y": "12",
+                  "properties": { "size": "17", "text": "Deploying Containers" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3021",
+          "typeID": "__group__",
+          "zOrder": "54",
+          "measuredW": "299",
+          "measuredH": "44",
+          "w": "299",
+          "h": "44",
+          "x": "1484",
+          "y": "836",
+          "properties": {
+            "controlName": "100-introduction:what-are-containers"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "299",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "167",
+                  "measuredH": "25",
+                  "x": "66",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "What are Containers?" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3022",
+          "typeID": "__group__",
+          "zOrder": "55",
+          "measuredW": "299",
+          "measuredH": "44",
+          "w": "299",
+          "h": "44",
+          "x": "1484",
+          "y": "887",
+          "properties": {
+            "controlName": "101-introduction:need-for-containers"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "299",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "223",
+                  "measuredH": "25",
+                  "x": "38",
+                  "y": "9",
+                  "properties": {
+                    "size": "17",
+                    "text": "Why do we need Containers?"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3023",
+          "typeID": "__group__",
+          "zOrder": "56",
+          "measuredW": "299",
+          "measuredH": "44",
+          "w": "299",
+          "h": "44",
+          "x": "1484",
+          "y": "937",
+          "properties": {
+            "controlName": "102-introduction:bare-metal-vm-containers"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "299",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "254",
+                  "measuredH": "25",
+                  "x": "23",
+                  "y": "9",
+                  "properties": {
+                    "size": "17",
+                    "text": "Bare Metal vs VMs vs Containers"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3024",
+          "typeID": "__group__",
+          "zOrder": "57",
+          "measuredW": "299",
+          "measuredH": "44",
+          "w": "299",
+          "h": "44",
+          "x": "1484",
+          "y": "987",
+          "properties": { "controlName": "103-introduction:docker-and-oci" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "299",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "124",
+                  "measuredH": "25",
+                  "x": "88",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Docker and OCI" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3025",
+          "typeID": "__group__",
+          "zOrder": "65",
+          "measuredW": "182",
+          "measuredH": "44",
+          "w": "182",
+          "h": "44",
+          "x": "1484",
+          "y": "1079",
+          "properties": {
+            "controlName": "100-underlying-technologies:namespaces"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "182",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "102",
+                  "measuredH": "25",
+                  "x": "40",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Namespaces" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3026",
+          "typeID": "__group__",
+          "zOrder": "66",
+          "measuredW": "107",
+          "measuredH": "44",
+          "w": "107",
+          "h": "44",
+          "x": "1674",
+          "y": "1079",
+          "properties": {
+            "controlName": "101-underlying-technologies:cgroups"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "107",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "63",
+                  "measuredH": "25",
+                  "x": "22",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "cgroups" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3027",
+          "typeID": "__group__",
+          "zOrder": "67",
+          "measuredW": "299",
+          "measuredH": "44",
+          "w": "299",
+          "h": "44",
+          "x": "1484",
+          "y": "1128",
+          "properties": {
+            "controlName": "102-underlying-technologies:union-filesystems"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "299",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "140",
+                  "measuredH": "25",
+                  "x": "80",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Union Filesystems" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3028",
+          "typeID": "__group__",
+          "zOrder": "70",
+          "measuredW": "316",
+          "measuredH": "44",
+          "w": "316",
+          "h": "44",
+          "x": "1476",
+          "y": "1247",
+          "properties": {
+            "controlName": "100-installation-setup:docker-desktop"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "316",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "281",
+                  "measuredH": "25",
+                  "x": "21",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Docker Desktop ( Win / Mac / Linux)"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3029",
+          "typeID": "__group__",
+          "zOrder": "71",
+          "measuredW": "316",
+          "measuredH": "44",
+          "w": "316",
+          "h": "44",
+          "x": "1476",
+          "y": "1296",
+          "properties": {
+            "controlName": "101-installation-setup:docker-engine"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "316",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "181",
+                  "measuredH": "25",
+                  "x": "71",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Docker Engine ( Linux )"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3030",
+          "typeID": "__group__",
+          "zOrder": "73",
+          "measuredW": "309",
+          "measuredH": "44",
+          "w": "309",
+          "h": "44",
+          "x": "1483",
+          "y": "1401",
+          "properties": {
+            "controlName": "100-data-persistence:ephemeral-container-fs"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "309",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "242",
+                  "measuredH": "25",
+                  "x": "34",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Ephemeral container filesystem"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3031",
+          "typeID": "__group__",
+          "zOrder": "74",
+          "measuredW": "152",
+          "measuredH": "44",
+          "w": "152",
+          "h": "44",
+          "x": "1483",
+          "y": "1450",
+          "properties": { "controlName": "101-data-persistence:volume-mounts" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "152",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "118",
+                  "measuredH": "25",
+                  "x": "17",
+                  "y": "10",
+                  "properties": { "size": "17", "text": "Volume Mounts" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3032",
+          "typeID": "__group__",
+          "zOrder": "75",
+          "measuredW": "152",
+          "measuredH": "44",
+          "w": "152",
+          "h": "44",
+          "x": "1640",
+          "y": "1451",
+          "properties": { "controlName": "102-data-persistence:bind-mounts" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "152",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "97",
+                  "measuredH": "25",
+                  "x": "27",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Bind Mounts" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3034",
+          "typeID": "__group__",
+          "zOrder": "78",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1501",
+          "properties": {
+            "controlName": "100-using-third-party-images:databases"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "83",
+                  "measuredH": "25",
+                  "x": "94",
+                  "y": "10",
+                  "properties": { "size": "17", "text": "Databases" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3035",
+          "typeID": "__group__",
+          "zOrder": "79",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1549",
+          "properties": {
+            "controlName": "101-using-third-party-images:interactive-test-environments"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "228",
+                  "measuredH": "25",
+                  "x": "22",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Interactive Test Environments"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3036",
+          "typeID": "__group__",
+          "zOrder": "80",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1597",
+          "properties": {
+            "controlName": "102-using-third-party-images:command-line-utilities"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "179",
+                  "measuredH": "25",
+                  "x": "46",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Command Line Utilities"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3037",
+          "typeID": "__group__",
+          "zOrder": "82",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1746",
+          "properties": {
+            "controlName": "100-building-container-images:dockerfiles"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "86",
+                  "measuredH": "25",
+                  "x": "93",
+                  "y": "10",
+                  "properties": { "size": "17", "text": "Dockerfiles" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3038",
+          "typeID": "__group__",
+          "zOrder": "83",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1794",
+          "properties": {
+            "controlName": "101-building-container-images:efficient-layer-caching"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "168",
+                  "measuredH": "25",
+                  "x": "52",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Efficient layer caching"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3039",
+          "typeID": "__group__",
+          "zOrder": "84",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "633",
+          "y": "1842",
+          "properties": {
+            "controlName": "102-building-container-images:image-size-and-security"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "182",
+                  "measuredH": "25",
+                  "x": "45",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Image size and security"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3040",
+          "typeID": "__group__",
+          "zOrder": "86",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "1089",
+          "y": "1597",
+          "properties": { "controlName": "100-container-registries:dockerhub" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "84",
+                  "measuredH": "25",
+                  "x": "94",
+                  "y": "10",
+                  "properties": { "size": "17", "text": "Dockerhub" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3041",
+          "typeID": "__group__",
+          "zOrder": "87",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "1089",
+          "y": "1549",
+          "properties": {
+            "controlName": "101-container-registries:dockerhub-alt"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "231",
+                  "measuredH": "25",
+                  "x": "20",
+                  "y": "10",
+                  "properties": {
+                    "size": "17",
+                    "text": "Others (ghcr, ecr, gcr, act, etc)"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3042",
+          "typeID": "__group__",
+          "zOrder": "88",
+          "measuredW": "272",
+          "measuredH": "44",
+          "w": "272",
+          "h": "44",
+          "x": "1089",
+          "y": "1501",
+          "properties": {
+            "controlName": "102-container-registries:image-tagging-best-practices"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "272",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "231",
+                  "measuredH": "25",
+                  "x": "20",
+                  "y": "9",
+                  "properties": {
+                    "size": "17",
+                    "text": "Image Tagging Best Practices"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3043",
+          "typeID": "__group__",
+          "zOrder": "90",
+          "measuredW": "174",
+          "measuredH": "44",
+          "w": "174",
+          "h": "44",
+          "x": "1615",
+          "y": "1728",
+          "properties": { "controlName": "100-running-containers:docker-run" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "174",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "83",
+                  "measuredH": "25",
+                  "x": "45",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "docker run" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3044",
+          "typeID": "__group__",
+          "zOrder": "91",
+          "measuredW": "174",
+          "measuredH": "44",
+          "w": "174",
+          "h": "44",
+          "x": "1615",
+          "y": "1680",
+          "properties": {
+            "controlName": "101-running-containers:docker-compose"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "174",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "129",
+                  "measuredH": "25",
+                  "x": "22",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "docker compose" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3045",
+          "typeID": "__group__",
+          "zOrder": "92",
+          "measuredW": "273",
+          "measuredH": "44",
+          "w": "273",
+          "h": "44",
+          "x": "1517",
+          "y": "1598",
+          "properties": {
+            "controlName": "102-running-containers:runtime-config-options"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "273",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "236",
+                  "measuredH": "25",
+                  "x": "20",
+                  "y": "9",
+                  "properties": {
+                    "size": "17",
+                    "text": "Runtime Configuration Options"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3046",
+          "typeID": "__group__",
+          "zOrder": "94",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1124",
+          "y": "1892",
+          "properties": {
+            "controlName": "100-container-security:image-security"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "116",
+                  "measuredH": "25",
+                  "x": "52",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Image Security" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3047",
+          "typeID": "__group__",
+          "zOrder": "95",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1124",
+          "y": "1844",
+          "properties": {
+            "controlName": "101-container-security:runtime-security"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "131",
+                  "measuredH": "25",
+                  "x": "44",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Runtime Security" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3048",
+          "typeID": "__group__",
+          "zOrder": "97",
+          "measuredW": "122",
+          "measuredH": "44",
+          "w": "122",
+          "h": "44",
+          "x": "737",
+          "y": "1926",
+          "properties": { "controlName": "100-docker-cli:images" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "122",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "58",
+                  "measuredH": "25",
+                  "x": "32",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Images" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3049",
+          "typeID": "__group__",
+          "zOrder": "98",
+          "measuredW": "126",
+          "measuredH": "44",
+          "w": "126",
+          "h": "44",
+          "x": "875",
+          "y": "1926",
+          "properties": { "controlName": "101-docker-cli:containers" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "126",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "85",
+                  "measuredH": "25",
+                  "x": "20",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Containers" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3050",
+          "typeID": "__group__",
+          "zOrder": "99",
+          "measuredW": "122",
+          "measuredH": "44",
+          "w": "122",
+          "h": "44",
+          "x": "737",
+          "y": "2081",
+          "properties": { "controlName": "102-docker-cli:volumes" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "122",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "65",
+                  "measuredH": "25",
+                  "x": "28",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Volumes" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3051",
+          "typeID": "__group__",
+          "zOrder": "100",
+          "measuredW": "126",
+          "measuredH": "44",
+          "w": "126",
+          "h": "44",
+          "x": "875",
+          "y": "2081",
+          "properties": { "controlName": "102-docker-cli:networks" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "126",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "72",
+                  "measuredH": "25",
+                  "x": "27",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Networks" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3052",
+          "typeID": "__group__",
+          "zOrder": "103",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "752",
+          "y": "2272",
+          "properties": {
+            "controlName": "100-developer-experience:hot-reloading"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "110",
+                  "measuredH": "25",
+                  "x": "55",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Hot Reloading" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3053",
+          "typeID": "__group__",
+          "zOrder": "104",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "752",
+          "y": "2320",
+          "properties": { "controlName": "101-developer-experience:debuggers" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "86",
+                  "measuredH": "25",
+                  "x": "67",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Debuggers" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3054",
+          "typeID": "__group__",
+          "zOrder": "105",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "752",
+          "y": "2368",
+          "properties": { "controlName": "102-developer-experience:tests" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "41",
+                  "measuredH": "25",
+                  "x": "89",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Tests" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3055",
+          "typeID": "__group__",
+          "zOrder": "106",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "752",
+          "y": "2416",
+          "properties": {
+            "controlName": "103-developer-experience:continuous-integration"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "176",
+                  "measuredH": "25",
+                  "x": "22",
+                  "y": "9",
+                  "properties": {
+                    "size": "17",
+                    "text": "Continuous Integration"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3056",
+          "typeID": "__group__",
+          "zOrder": "108",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1102",
+          "y": "2272",
+          "properties": {
+            "controlName": "100-deploying-containers:paas-options"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "104",
+                  "measuredH": "25",
+                  "x": "58",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "PaaS Options" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3057",
+          "typeID": "__group__",
+          "zOrder": "109",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1102",
+          "y": "2320",
+          "properties": {
+            "controlName": "101-deploying-containers:kubernetes"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "90",
+                  "measuredH": "25",
+                  "x": "65",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Kubernetes" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3058",
+          "typeID": "__group__",
+          "zOrder": "110",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1102",
+          "y": "2368",
+          "properties": {
+            "controlName": "102-deploying-containers:docker-swarm"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "111",
+                  "measuredH": "25",
+                  "x": "54",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Docker Swarm" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3059",
+          "typeID": "__group__",
+          "zOrder": "111",
+          "measuredW": "219",
+          "measuredH": "44",
+          "w": "219",
+          "h": "44",
+          "x": "1102",
+          "y": "2416",
+          "properties": { "controlName": "103-deploying-containers:nomad" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "219",
+                  "h": "44",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": { "color": "16770457" }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "56",
+                  "measuredH": "25",
+                  "x": "77",
+                  "y": "9",
+                  "properties": { "size": "17", "text": "Nomad" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3060",
+          "typeID": "__group__",
+          "zOrder": "62",
+          "measuredW": "70",
+          "measuredH": "25",
+          "w": "70",
+          "h": "25",
+          "x": "693",
+          "y": "669",
+          "properties": { "controlName": "ext_link:twitter.com/sidpalas" },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Label",
+                  "zOrder": "0",
+                  "measuredW": "70",
+                  "measuredH": "25",
+                  "x": "0",
+                  "y": "0",
+                  "properties": {
+                    "size": "17",
+                    "text": "{color:purple}Sid Palas{color}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3061",
+          "typeID": "__group__",
+          "zOrder": "64",
+          "measuredW": "268",
+          "measuredH": "25",
+          "w": "268",
+          "h": "25",
+          "x": "659",
+          "y": "697",
+          "properties": {
+            "controlName": "ext_link:courses.devopsdirective.com/docker-beginner-to-pro"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "Label",
+                  "zOrder": "0",
+                  "measuredW": "268",
+                  "measuredH": "25",
+                  "x": "0",
+                  "y": "0",
+                  "properties": {
+                    "size": "17",
+                    "text": "{color:purple}course covering this topic in depth.{color}"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "ID": "3063",
+          "typeID": "Canvas",
+          "zOrder": "0",
+          "w": "327",
+          "h": "393",
+          "measuredW": "100",
+          "measuredH": "70",
+          "x": "635",
+          "y": "892"
+        }
+      ]
+    },
+    "attributes": {
+      "name": "New Wireframe 9 copy 5",
+      "order": 1000147.9446306123,
+      "parentID": null,
+      "notes": null
+    },
+    "branchID": "Master",
+    "resourceID": "A3B84AD1-CEAB-4958-B7C6-199A90A297E8",
+    "mockupH": "2283",
+    "mockupW": "1186",
+    "measuredW": "1799",
+    "measuredH": "2883",
+    "version": "1.0"
+  },
+  "groupOffset": { "x": 0, "y": 0 },
+  "dependencies": [],
+  "projectID": "file:///Users/kamranahmed/Desktop/AWS%20Roadmap.bmpr"
+}


### PR DESCRIPTION
I noticed this typo while viewing the roadmap today and decided to submit a PR to fix it.

I also took the liberty to format the docker.json file to allow more easy reviews in the future. Without this, it's not easy to search for the changes because the whole docker.json file is in just one line. I have noticed that the frontend.json file is formatted but others aren't, so if there's a reason for them please let me know so I can revert this change.

And thanks for the awesome project, it's been really helpful.