### PR TITLE
Add Bun ORM to ORMs section for Go

### DIFF
--- a/src/data/roadmaps/golang/content/103-go-orms/101-bun.md
+++ b/src/data/roadmaps/golang/content/103-go-orms/101-bun.md
@@ -1,0 +1,22 @@
+# Go Bun
+
+**Go Bun** is a powerful ORM (Object-Relational Mapping) library for Golang that offers developer-friendly features. It provides seamless integration with relational databases and simplifies database operations in your application. Go Bun is built on top of the standard `database/sql` package, making it a reliable choice for working with databases in Go.
+
+**Key features of Go Bun include:**
+
+- **Full-featured ORM capabilities:** Go Bun provides comprehensive ORM capabilities for managing database interactions efficiently.
+
+- **Developer-friendly design and syntax:** With a focus on developer experience, Go Bun offers a design and syntax that promotes smooth coding and productivity.
+
+- **Support for various database dialects and drivers:** Go Bun supports a wide range of database dialects and drivers, ensuring compatibility with different database systems.
+
+- **Efficient query building and execution:** Go Bun facilitates the construction and execution of queries, resulting in optimal performance.
+
+- **Transaction management:** Go Bun includes transaction management features that help maintain data integrity during complex database operations.
+
+- **Automatic mapping between Go structs and database tables:** Go Bun simplifies the mapping process between Go structs and database tables, reducing manual effort.
+
+To learn more about Go Bun, you can visit the following resources:
+
+- [Go Bun Official Website](https://bun.uptrace.dev/) - Access the official website of Go Bun for detailed information and resources.
+- [Go Bun on GitHub](https://github.com/uptrace/bun) - Visit the Go Bun repository on GitHub to explore the latest updates, source code, and engage in community discussions.

--- a/src/data/roadmaps/golang/content/103-go-orms/index.md
+++ b/src/data/roadmaps/golang/content/103-go-orms/index.md
@@ -1,5 +1,9 @@
 # ORMs
 
-Object–relational mapping (ORM, O/RM, and O/R mapping tool) in computer science is a programming technique for converting data between type systems using object-oriented programming languages. This creates, in effect, a "virtual object database", hence a layer of abstraction, that can be used from within the programming language.
+**Object-Relational Mapping (ORM)** is a programming technique that bridges the gap between object-oriented programming languages and relational databases, enabling the conversion of data between them. In Go, two popular ORM libraries are GORM and Bun.
 
-Most common ORM library in Go is [GORM](https://gorm.io/).
+- **GORM**: GORM is a widely used ORM library in Go, offering comprehensive features and capabilities for seamless integration with relational databases. You can learn more about GORM from its [official website](https://gorm.io/) and [GitHub repository](https://github.com/go-gorm/gorm).
+
+- **Bun**: Bun is another powerful ORM library for Go, providing efficient database operations and a developer-friendly syntax. You can explore Bun's features and documentation on its [GitHub repository](https://github.com/uptrace/bun).
+
+By utilizing ORM libraries like GORM and Bun, you can simplify your database interactions and leverage the benefits of object-oriented programming in your Go applications.


### PR DESCRIPTION
Added missing popular ORM for GO:

index.md:
- Updated info about popular ORM libraries in Go: **GORM** and **Bun**.
- Added **Bun** ORM for Go.
- Included a link to the GitHub repo of **Bun**.

101-bun.md:
- Introduced **Go Bun** as a powerful ORM library for Golang.
- Key features of **Go Bun**: **full-featured ORM capabilities**, **developer-friendly design**, **support for various database dialects**, **efficient query building**, **transaction management**, and **automatic mapping**.
- Links: **official website**, **GitHub repo** of **Go Bun**.
