### PR TITLE
Fix typo in code review 102-documentation.md

### DIFF
--- a/src/data/roadmaps/code-review/content/102-documentation.md
+++ b/src/data/roadmaps/code-review/content/102-documentation.md
@@ -2,4 +2,4 @@
 
 - New features reasonably documented?
 - Are the relevant kinds of does covered: README, API docs, user quide, reference docs, etc?
-- Are docs understandable, are there no signiticant typos and grammar mistakes?
+- Are docs understandable, are there no significant typos and grammar mistakes?


### PR DESCRIPTION
Not sure if that was actually on purpose, but that was still a typo 👀