### PR TITLE
Issue #4110 Broken Link Fix

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,7 @@ For new roadmaps, submit a roadmap by providing [a textual roadmap similar to th
 
 For the existing roadmaps, please follow the details listed for the nature of contribution:
 
-- **Fixing Typos** — Make your changes in the [roadmap JSON file](https://github.com/kamranahmedse/developer-roadmap/tree/master/public/jsons)
+- **Fixing Typos** — Make your changes in the [roadmap JSON file](https://github.com/kamranahmedse/developer-roadmap/tree/master/src/data/roadmaps)
 - **Adding or Removing Nodes** — Please open an issue with your suggestion.
 
 **Note:** Please note that our goal is not to have the biggest list of items. Our goal is to list items or skills most relevant today.


### PR DESCRIPTION
This resolves issue #4110.

As, the issue states, the link under the contributing.md docs was broken. It was linking to
```
https://github.com/kamranahmedse/developer-roadmap/tree/master/public/jsons
```
instead of

```
https://github.com/kamranahmedse/developer-roadmap/tree/master/src/data/roadmaps
```