### PR TITLE
Clone size fix ISSUE #3312

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -16,7 +16,7 @@ For new roadmaps, submit a roadmap by providing [a textual roadmap similar to th
 
 For the existing roadmaps, please follow the details listed for the nature of contribution:
 
-- **Fixing Typos** — Make your changes in the [roadmap JSON file](https://github.com/kamranahmedse/developer-roadmap/tree/master/public/jsons)
+- **Fixing Typos** — Make your changes in the [roadmap JSON file](https://github.com/kamranahmedse/developer-roadmap/tree/master/src/data/roadmaps)
 - **Adding or Removing Nodes** — Please open an issue with your suggestion.
 
 **Note:** Please note that our goal is not to have the biggest list of items. Our goal is to list items or skills most relevant today.

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,12 @@ npm install
 npm run dev
 ```
 
+Note: Cloning the entire repository results in a ≈1.7GB download. If you don't need the entire history you can use the `depth` parameter to reduce clone size.
+
+```sh
+git clone --depth=1 https://github.com/kamranahmedse/developer-roadmap.git
+```
+
 ## Contribution
 
 > Have a look at [contribution docs](./contributing.md) for how to update any of the roadmaps


### PR DESCRIPTION
When cloned, the resulting download size is about 1.7gb due to the history associated with the repository. A way to get around this is to use the `depth` parameter along with the `clone` command. So the resulting command should look like

```sh
git clone --depth=1 https://github.com/kamranahmedse/developer-roadmap.git
```
This reduces the download size by a lot. The total number of objects goes from 47000 to 5000.

This has been mentioned somewhere in the readme so that contributors do not end up downloading such a large sized repository with mostly unneeded history. 