### PR TITLE
Update ext_links in devops.json

### DIFF
--- a/src/data/roadmaps/devops/devops.json
+++ b/src/data/roadmaps/devops/devops.json
@@ -14438,7 +14438,7 @@
           "x": "190",
           "y": "548",
           "properties": {
-            "controlName": "ext_link:roadmap.sh/python"
+            "controlName": "ext_link:roadmap.sh/backend"
           },
           "children": {
             "controls": {
@@ -14520,7 +14520,7 @@
           "x": "190",
           "y": "585",
           "properties": {
-            "controlName": "ext_link:roadmap.sh/python"
+            "controlName": "ext_link:roadmap.sh/best-practices/aws"
           },
           "children": {
             "controls": {


### PR DESCRIPTION
Updated from 'ext_link:roadmap.sh/python' to 'ext_link:roadmap.sh/backend' and 'ext_link:roadmap.sh/best-practices/aws'.

A couple of links in the 'DevOps Roadmap' within the 'Related Roadmaps' section had incorrect links for the 'Backend Roadmap' and 'AWS Best Practices'.