### PR TITLE
Fix: removed dublicate link in 108-javascript-expressions-and-operators

### DIFF
--- a/src/data/roadmaps/javascript/content/108-javascript-expressions-and-operators/104-logical-operators.md
+++ b/src/data/roadmaps/javascript/content/108-javascript-expressions-and-operators/104-logical-operators.md
@@ -5,4 +5,3 @@ There are four logical operators in JavaScript: `||` (OR), `&&` (AND), `!` (NOT)
 Visit the following resources to learn more:
 
 - [Logical Operators - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators)
-- [Logical Operators - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#binary_logical_operators)


### PR DESCRIPTION
Removed dublicate link in JS roadmap