### PR TITLE
fix: removed duplicate link in react roadmap 103-rendering 103-refs

### DIFF
--- a/src/data/roadmaps/react/content/103-rendering/103-refs.md
+++ b/src/data/roadmaps/react/content/103-rendering/103-refs.md
@@ -6,7 +6,6 @@ In the typical React dataflow, props are the only way that parent components int
 
 Visit the following resources to learn more:
 
-- [Refs and DOM](https://react.dev/learn/referencing-values-with-refs)
 - [Referencing Values with Refs](https://react.dev/learn/referencing-values-with-refs)
 - [Manipulating the DOM with Refs](https://react.dev/learn/manipulating-the-dom-with-refs)
 - [Examples of using refs in React](https://www.robinwieruch.de/react-ref/)


### PR DESCRIPTION
removed duplicated link in react roadmap