### PR TITLE
fix: removed duplicate link in react 103-rendering/104-events

### DIFF
--- a/src/data/roadmaps/react/content/103-rendering/104-events.md
+++ b/src/data/roadmaps/react/content/103-rendering/104-events.md
@@ -9,5 +9,4 @@ Visit the following resources to learn more:
 
 - [Responding to Events](https://react.dev/learn/responding-to-events)
 - [React Event Object (Synthetic Event)](https://react.dev/reference/react-dom/components/common#react-event-object)
-- [Responding to Events](https://react.dev/learn/responding-to-events)
 - [React Event Handler](https://www.robinwieruch.de/react-event-handler/)


### PR DESCRIPTION
removed duplicate link in react roadmap section 103-rendering/104-events