### PR TITLE
fix: added link + rewritten link text react 106-state-management

### DIFF
--- a/src/data/roadmaps/react/content/106-state-management/101-zustand.md
+++ b/src/data/roadmaps/react/content/106-state-management/101-zustand.md
@@ -6,4 +6,5 @@ Zustand is often used as an alternative to other state management libraries, suc
 
 Visit the following resources to learn more:
 
-- [Zustand - Official Website](https://github.com/pmndrs/zustand)
+- [Zustand - Official Documentation](https://docs.pmnd.rs/zustand/getting-started/introduction)
+- [pmndrs/zustand](https://github.com/pmndrs/zustand)


### PR DESCRIPTION
I found more obvious such resources list, with the documentation as  the starting resource and then the link for the repo as the next one