### PR TITLE
Correct 'CDNss' to 'CDNs'

### DIFF
--- a/src/data/roadmaps/system-design/content/108-content-delivery-networks/101-pull-cdns.md
+++ b/src/data/roadmaps/system-design/content/108-content-delivery-networks/101-pull-cdns.md
@@ -7,4 +7,4 @@ A time-to-live (TTL) determines how long content is cached. Pull CDNs minimize s
 To learn more, visit the following links:
 
 - [Introduction to CDNs](https://github.com/donnemartin/system-design-primer#content-delivery-network)
-- [The Differences Between Push And Pull CDNss](http://www.travelblogadvice.com/technical/the-differences-between-push-and-pull-cdns/)
+- [The Differences Between Push And Pull CDNs](http://www.travelblogadvice.com/technical/the-differences-between-push-and-pull-cdns/)


### PR DESCRIPTION
Hello team,

I've made some changes to fix a small issue in the codebase. This PR addresses the problem where 'CDNss' was incorrectly used instead of the correct form 'CDNs'. The unnecessary 's' at the end has been removed.