### PR TITLE
QA Manual Testing 103-reporting: Incorrect link

### DIFF
--- a/src/data/roadmaps/qa/content/102-qa-manual-testing/103-reporting.md
+++ b/src/data/roadmaps/qa/content/102-qa-manual-testing/103-reporting.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [Defect Management Process in Software Testing](https://www.guru99.com/defect-management-process.html)
 - [Writing clear bug reports](https://automationhacks.io/2020/07/25/writing-clear-bug-reports/)
-- [The Art Of The Bug Report](https://www.ministryoftesting.com/dojo/series/the-testing-planet-2019/lessons/the-art-of-the-bug-report)
+- [The Art Of The Bug Report](https://www.ministryoftesting.com/articles/11b82aee?s_id=15465627)


### PR DESCRIPTION
## Description

The current link is outdated
https://www.ministryoftesting.com/dojo/series/the-testing-planet-2019/lessons/the-art-of-the-bug-report
<img width="1135" alt="Screenshot 2023-08-03 at 18 23 10" src="https://github.com/Gazwai/developer-roadmap/assets/84076465/612fae68-81ab-401d-9f61-f90cc464c648">

This is the new updated link.
https://www.ministryoftesting.com/articles/11b82aee?s_id=15465627

<img width="1997" alt="Screenshot 2023-08-03 at 18 23 53" src="https://github.com/Gazwai/developer-roadmap/assets/84076465/e9135ec6-67d4-476e-aa6f-25c1839a339f">
