### PR TITLE
Update 101-instanceof-operator.md

### DIFF
--- a/src/data/roadmaps/typescript/content/105-type-guards/101-instanceof-operator.md
+++ b/src/data/roadmaps/typescript/content/105-type-guards/101-instanceof-operator.md
@@ -1,6 +1,6 @@
 # instanceOf operator
 
-The `instanceof` operator is a way to narrow down the type of a variable. It is used to check if an object is an instance of a class, interface, or type.
+The `instanceof` operator is a way to narrow down the type of a variable. It is used to check if an object is an instance of a class.
 
 ```typescript
 class Bird {


### PR DESCRIPTION
instanceof is a runtime check and interface and types don't exist during runtime.

Also TypeScript has a structural type system, which means that they are matched according to the structure of the object and types - not according to instances.

For example:

interface Person {
    name: string;
    age: number
}

const person = {
    name: "Ken",
    age: 25
}

if (person instanceof Person) // Error