### PR TITLE
Fixed: Function Expression Syntax

### DIFF
--- a/src/data/roadmaps/typescript/content/106-functions/index.md
+++ b/src/data/roadmaps/typescript/content/106-functions/index.md
@@ -13,12 +13,9 @@ function name(param1: type1, param2: type2, ...): returnType {
 > Function Expression Syntax:
 
 ```typescript
-function add(a: number, b: number): number {
-  return a + b;
-}
-
-let result = add(1, 2);
-console.log(result); // 3
+let name = function(param1: type1, param2: type2, ...): returnType {
+  return value;
+};
 ```
 
 Learn more from the following links:


### PR DESCRIPTION
The syntax for Function Expression was incorrect. It was an example of a function declared using Function Declaration.