### PR TITLE
Removed duplicate sentence in SQL roadmap

### DIFF
--- a/src/data/roadmaps/sql/content/106-join-queries/index.md
+++ b/src/data/roadmaps/sql/content/106-join-queries/index.md
@@ -1,7 +1,3 @@
-# JOIN Queries
-
-Absolutely, here's a brief summary about SQL JOIN Queries:
-
 # SQL JOIN Queries
 
 JOIN clause is used to combine rows from two or more tables, based on a related column between them.


### PR DESCRIPTION
removed the sentence:
"JOIN Queries
Absolutely, here’s a brief summary about SQL JOIN Queries:"

It's the same information as the sentence below and it doesn't give the impression it's answering anything.
