### PR TITLE
fix: exclude from inside compilerOptions to outside 

### DIFF
--- a/src/data/roadmaps/typescript/content/100-typescript/102-install-configure/100-tsconfig-json.md
+++ b/src/data/roadmaps/typescript/content/100-typescript/102-install-configure/100-tsconfig-json.md
@@ -20,8 +20,8 @@ Given below is the sample `tsconfig.json` file:
     "strict": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "exclude": ["node_modules"]
   },
+  "exclude": ["node_modules"],
   "include": ["src"]
 }
 ```


### PR DESCRIPTION
### What does this PR do
This PR fixes - exclude outside from inside compilerOptions  

### Fixed #4399 

### Redirect to Fixes Issue Page
[https://roadmap.sh/typescript](https://roadmap.sh/typescript)

### After Change
You have the example of tsconfig.json in one of the first sections (tsconfog.json).  
``` {
  "compilerOptions": {
    "target": "es5",
    "module": "commonjs",
    "strict": true,
    "outDir": "./dist",
    "rootDir": "./src",
  },
  "exclude": ["node_modules"],
  "include": ["src"]
} 
```
Now "exclude" is outside of "compilerOptions"

### Type of Change 
Bug Fixes (non-breaking change which fixes an issue)

### How can Check / Test Cases
  - Go to [https://roadmap.sh/typescript](https://roadmap.sh/typescript)
  - Click on `tsconfig.json` in introduction's section 'Installation and configuration'
  - See a side popup open
  - See Popup heading 'tsconfig.json'
  - See json changed section   

### Screenshots / Videos 
![Screenshot from 2023-08-28 00-15-10](https://github.com/kamranahmedse/developer-roadmap/assets/76577184/5fd90e16-2036-4ce7-b1fa-53e84b50b070)


