### PR TITLE
Update system-design.json fix typo

### DIFF
--- a/src/data/roadmaps/system-design/system-design.json
+++ b/src/data/roadmaps/system-design/system-design.json
@@ -3639,7 +3639,7 @@
                   "y": "9",
                   "properties": {
                     "size": "17",
-                    "text": "Layer 7 Load Blancing"
+                    "text": "Layer 7 Load Balancing"
                   }
                 }
               ]


### PR DESCRIPTION
Fix typo, add missing "a" in "balancing" word.