### PR TITLE
[fix]: Change incorrect redirect url in 'Deep Learning Book'

### DIFF
--- a/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
+++ b/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
@@ -4107,7 +4107,7 @@
           "x": "268",
           "y": "2501",
           "properties": {
-            "controlName": "ext_link:deeplearningbook.org"
+            "controlName": "ext_link:www.deeplearningbook.org"
           },
           "children": {
             "controls": {


### PR DESCRIPTION
### What does this PR do
This PR fixes - the incorrect route link to the "Deep Learning Book"

### Fixed #4387 

### Redirect to Fixes Issue Page 
[https://roadmap.sh/ai-data-scientist](https://roadmap.sh/ai-data-scientist)

### Type of Change 
Bug Fixes (non-breaking change which fixes an issue)

### How can Check / Test Cases 
- Go to [https://roadmap.sh/ai-data-scientist](https://roadmap.sh/ai-data-scientist)
- Scroll Down and go to 'Deep Learning' Section
- See there have 'Deep Learning Book' 
- Click on 'Deep Learning Book' button / text
- See Now you are redirecting on right page [https://www.deeplearningbook.org/](https://www.deeplearningbook.org/)

### Screenshots / Videos 
https://github.com/kamranahmedse/developer-roadmap/assets/76577184/b9ecc264-8430-4214-aeaa-202f3f890f2f

