### PR TITLE
Fix video link in Python OOP classes

### DIFF
--- a/src/data/roadmaps/python/content/102-python-advanced-topics/100-oop/102-classes.md
+++ b/src/data/roadmaps/python/content/102-python-advanced-topics/100-oop/102-classes.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [Classes in Python](https://docs.python.org/3/tutorial/classes.html)
 - [Python Classes and Objects](https://www.geeksforgeeks.org/python-classes-and-objects/)
 - [Python Classes and Objects](https://www.w3schools.com/python/python_classes.asp)
-- [Python OOP Tutorial](https://www.youtube.com/watch?v=zda-z5jzlym&list=pl-osie80tetsqhiuoqkhwlxsibidseytc)
+- [Python OOP Tutorial](https://www.youtube.com/watch?v=ZDa-Z5JzLYM&list=PL-osiE80TeTsqhIuOqKhwlXsIBIdSeYtc)


### PR DESCRIPTION
From [original link](https://www.youtube.com/watch?v=zda-z5jzlym&list=pl-osie80tetsqhiuoqkhwlxsibidseytc) to [new link](https://www.youtube.com/watch?v=ZDa-Z5JzLYM&list=PL-osiE80TeTsqhIuOqKhwlXsIBIdSeYtc).
Make the link uppercase and work.

closes #4426