### PR TITLE
Added exception handling when fetching topic detail with in roadmap 

### DIFF
--- a/src/components/TopicDetail/TopicDetail.tsx
+++ b/src/components/TopicDetail/TopicDetail.tsx
@@ -178,7 +178,7 @@ export function TopicDetail() {
                 {error}
               </h1>
               <p class="text-md mb-2 md:text-xl">
-                Sorry, we are facing some techinal issue. Come back later.
+                Sorry, we are currently experiencing a technical issue. Please, try again later.
               </p>
             </div>
           </div>

--- a/src/components/TopicDetail/TopicDetail.tsx
+++ b/src/components/TopicDetail/TopicDetail.tsx
@@ -92,6 +92,7 @@ export function TopicDetail() {
   useLoadTopic(({ topicId, resourceType, resourceId }) => {
     setIsLoading(true);
     setIsActive(true);
+    setError('');
     sponsorHidden.set(true);
 
     setContributionAlertMessage('');
@@ -117,6 +118,7 @@ export function TopicDetail() {
       .then(({ response }) => {
         if (!response) {
           setError('Topic not found.');
+          setIsLoading(false);
           return;
         }
 
@@ -151,6 +153,34 @@ export function TopicDetail() {
               alt="Loading"
               className="h-6 w-6 animate-spin fill-blue-600 text-gray-200 sm:h-12 sm:w-12"
             />
+          </div>
+        )}
+
+        {!isContributing && !isLoading && error && (
+          <div class="items-center justify-center gap-7 py-2 md:py-4">
+            <div className="mb-2">
+              <button
+                type="button"
+                id="close-topic"
+                className="absolute right-2.5 top-2.5 inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm text-gray-400 hover:bg-gray-200 hover:text-gray-900"
+                onClick={() => {
+                  setIsActive(false);
+                  setIsContributing(false);
+                  setError('')
+                }}
+              >
+                <img alt="Close" class="h-5 w-5" src={CloseIcon} />
+              </button>
+            </div>
+
+            <div class="text-left md:text-left">
+              <h1 class="bg-gradient-to-t from-black to-gray-600 bg-clip-text text-2xl font-extrabold leading-normal text-transparent md:text-5xl md:leading-normal">
+                {error}
+              </h1>
+              <p class="text-md mb-2 md:text-xl">
+                Sorry, we are facing some techinal issue. Come back later.
+              </p>
+            </div>
           </div>
         )}
 
@@ -190,6 +220,7 @@ export function TopicDetail() {
                 onClick={() => {
                   setIsActive(false);
                   setIsContributing(false);
+                  setError('')
                 }}
               >
                 <img alt="Close" class="h-5 w-5" src={CloseIcon} />


### PR DESCRIPTION
fixes #4223
fixes #4386

The issue is related to AppDynamics under Application Monitoring. When we click on AppDynamic it takes us to the following URL:

https://roadmap.sh/devops/monitoring/application-monitoring/app-dynamics

But the correct URL is as follows:

https://roadmap.sh/devops/application-monitoring/app-dynamics

This can be fixed in the JSON file, but we are not updating the JSON files due to implementing the Roadmap editor. One more thing that is not implemented correctly is when fetching topic detail, If we get an error we are setting the error to Topic not found but we are not hiding the loader and there is not content to be shown if some error occurs. Also, we are not resetting the error to empty due to which after an error occurs no new topic can be opened and it stays in the loading state.

I have tried an implementation for exception management that will notify the user of the issue and the user will be able to view other topics even when some topic has an issue.

Attached is a simple error message page.

![image](https://github.com/kamranahmedse/developer-roadmap/assets/43681543/aac453a4-a57f-4e58-a688-b55ba13c5c28)
