### PR TITLE
fix(typescript): fix template lineral type definition

### DIFF
--- a/src/data/roadmaps/typescript/content/112-advanced-types/103-template-literal-types.md
+++ b/src/data/roadmaps/typescript/content/112-advanced-types/103-template-literal-types.md
@@ -5,7 +5,7 @@ Template literal types in TypeScript are a way to manipulate string values as ty
 For example, the following is a template literal type that concatenates two strings:
 
 ```typescript
-type Name = `Mr. ` + string;
+type Name = `Mr. ${string}`;
 
 let name: Name = `Mr. Smith`;  // ok
 let name: Name = `Mrs. Smith`;  // error


### PR DESCRIPTION
There was a mistake in how literal types should be defined
([docs](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html#handbook-content))

## Before
[Playground example](https://www.typescriptlang.org/play?#code/C4TwDgpgBAcghgW2gXigAwLICcB06oDUUAzsFgJYB2A5gNwBQ9ANhMFJYhAIwBcsnUVJlxQAygnLAAFmlpQoAegVQA9gGtmrdpwBMfeEkHpsxPOMky5i5RCxYVWIA)

![image](https://github.com/kamranahmedse/developer-roadmap/assets/8749624/ebbf9e05-43e9-4019-9c63-e020d8d50ad9)

## Now
[Playground example](https://www.typescriptlang.org/play?#code/C4TwDgpgBAcghgW2gXigAwLICcB0UAkA3gM7BYCWAdgOYC+aA3AFBMA2EwUliEAjAFyweUVJlxQAygnLAAFoyhQA9EqgB7ANZsOXHgCZB8JCPTZieKTPkNFKqBCxY1WIA)

![image](https://github.com/kamranahmedse/developer-roadmap/assets/8749624/657eacc5-b406-4e8f-bcc4-c6cdcb27fcf4)
