### PR TITLE
correct Polygon resource links and add Polygon zkEVM and CDK information

### DIFF
--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/102-evm-based/polygon.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/102-evm-based/polygon.md
@@ -1,8 +1,13 @@
 # Polygon
 
-Polygon, formerly known as the Matic Network, is a scaling solution that aims to provide multiple tools to improve the speed and reduce the cost and complexities of transactions on the Ethereum blockchain.
+Polygon, formerly known as the Matic Network, is a protocol that allows anyone to create and exchange value, powered by zero-knowledge technology. Polygon provides multiple solutions including 
+
+- [Polygon zkEVM](https://polygon.technology/polygon-zkevm), a zk powered EVM equivalent L2
+- [Polygon PoS](https://polygon.technology/polygon-pos), a proof of stake, EVM compatible side chain
+- [Polygon CDK](https://polygon.technology/polygon-cdk), a Chain Development Kit for building customizable zk powered L2s
+- [Polygon ID](https://polygon.technology/polygon-id), identity infrastructure and SDKs to facilitate trusted and secure relationships between apps and users
 
 Visit the following resources to learn more:
 
-- [Polygon whitepaper](https://polygon.technology/lightpaper-polygon.pdf)
-- [Introduction to Polygon](https://wiki.polygon.technology/docs/develop/getting-started)
+- [Introduction to Polygon](https://wiki.polygon.technology/)
+- [Polygon POL whitepaper](https://polygon.technology/papers/pol-whitepaper)

--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/103-l2-blockchains/index.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/103-l2-blockchains/index.md
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 
 - [Layer-1 and Layer-2 Blockchain Scaling Solutions](https://www.gemini.com/cryptopedia/blockchain-layer-2-network-layer-1-network)
 - [Layer 2 - Binance Academy](https://academy.binance.com/en/glossary/layer-2)
+- [Develop a ZK-powered Layer 2 with the Polgyon CDK open-source framework](https://wiki.polygon.technology/docs/cdk/)

--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/103-l2-blockchains/polygon-zkevm.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/109-blockchains/103-l2-blockchains/polygon-zkevm.md
@@ -1,0 +1,18 @@
+# Polygon zkEVM
+
+Polygon zkEVM is a decentralized Ethereum Layer 2 scalability solution that uses cryptographic zero-knowledge proofs to offer validity and quick finality to off-chain transaction computation, also known as a ZK-Rollup.
+
+The ZK-Rollup executes smart contracts transparently, by publishing zero-knowledge validity proofs, while maintaining opcode compatibility with the Ethereum Virtual Machine.
+
+Benefits of Polygon zkEVM
+
+- EVM-equivalence
+- Ethereum security
+- ZKP-powered scalability
+
+Visit the following resources to learn more:
+
+- [Introduction to Polygon zkEVM](https://wiki.polygon.technology/docs/zkevm/introduction/)
+- [Polygon zkEVM Quickstart](https://wiki.polygon.technology/docs/zkevm/develop/)
+- [Polygon zkEVM Faucet Guide](https://wiki.polygon.technology/docs/zkevm/guides/zkevm-faucet/)
+- [Polygon zkEVM Asset Bridging Guide](https://wiki.polygon.technology/docs/zkevm/bridge-to-zkevm/)


### PR DESCRIPTION
Updated the [blockchain developer roadmap](https://roadmap.sh/blockchain) to
- Correct whitepaper and intro links in the Polygon section
- Add CDK open source resource for developing L2s to L2s info section
- Create a new Polygon zkEVM page within the L2s section