### PR TITLE
fix(typo): fix typo in 101-instanceof-operator.md

### DIFF
--- a/src/data/roadmaps/typescript/content/105-type-guards/101-instanceof-operator.md
+++ b/src/data/roadmaps/typescript/content/105-type-guards/101-instanceof-operator.md
@@ -1,4 +1,4 @@
-# instanceOf operator
+# instanceof operator
 
 The `instanceof` operator is a way to narrow down the type of a variable. It is used to check if an object is an instance of a class.
 


### PR DESCRIPTION
Revised spelling of the keyword: 'instanceOf' -> 'instanceof'