### PR TITLE
Update Material UI guide to v5

### DIFF
--- a/src/data/roadmaps/frontend/content/114-css-frameworks/114-js-first/102-material-ui.md
+++ b/src/data/roadmaps/frontend/content/114-css-frameworks/114-js-first/102-material-ui.md
@@ -4,6 +4,6 @@ Material-UI is an open-source framework that features React components that impl
 
 Visit the following resources to learn more:
 
-- [Official Website](https://mui.com/)
-- [Official Documentation](https://mui.com/getting-started/installation/)
-- [Material UI React Tutorial](https://www.youtube.com/watch?v=vyJU9efvUtQ)
+- [Official Website](https://mui.com/material-ui/)
+- [Official Documentation](https://mui.com/material-ui/getting-started/)
+- [Material UI React Tutorial](https://www.youtube.com/watch?v=o1chMISeTC0)

--- a/src/data/roadmaps/react/content/107-styling/104-material-ui.md
+++ b/src/data/roadmaps/react/content/107-styling/104-material-ui.md
@@ -4,6 +4,6 @@ Material-UI is an open-source framework that features React components that impl
 
 Visit the following resources to learn more:
 
-- [Official Website](https://mui.com/)
-- [Official Documentation](https://mui.com/getting-started/installation/)
-- [Material UI React Tutorial](https://www.youtube.com/watch?v=vyJU9efvUtQ)
+- [Official Website](https://mui.com/material-ui/)
+- [Official Documentation](https://mui.com/material-ui/getting-started/)
+- [Material UI React Tutorial](https://www.youtube.com/watch?v=o1chMISeTC0)


### PR DESCRIPTION
This is a continuation of https://github.com/kamranahmedse/developer-roadmap/pull/1093.

The introduction guide of @adriantwarog is awesome, but it covers Material UI v4. I have updated the YouTube link to a more recent introduction tutorial.