### PR TITLE
Fix mongodb roadmap content - change 'InsertOne' with 'Update'

### DIFF
--- a/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
+++ b/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
@@ -316,7 +316,7 @@
           "x": "279",
           "y": "583",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/baqMYv"
+            "controlName": "ext_link:coursera.org/specializations/mathematics-machine-learning"
           },
           "children": {
             "controls": {
@@ -443,7 +443,7 @@
           "x": "278",
           "y": "688",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/LX5M7M"
+            "controlName": "ext_link:coursera.org/learn/algebra-and-differential-calculus-for-data-science?"
           },
           "children": {
             "controls": {
@@ -596,7 +596,7 @@
           "x": "903",
           "y": "582",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/3eRv4v"
+            "controlName": "ext_link:coursera.org/learn/stanford-statistics?"
           },
           "children": {
             "controls": {
@@ -736,7 +736,7 @@
           "x": "904",
           "y": "686",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/vN0JAA"
+            "controlName": "ext_link:coursera.org/learn/statistical-analysis-hypothesis-testing-sas"
           },
           "children": {
             "controls": {
@@ -862,7 +862,7 @@
           "x": "904",
           "y": "792",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/daDM6Q"
+            "controlName": "ext_link:coursera.org/learn/probability-statistics"
           },
           "children": {
             "controls": {
@@ -2157,7 +2157,7 @@
           "x": "269",
           "y": "1102",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/k0krYL"
+            "controlName": "ext_link:www.coursera.org/learn/erasmus-econometrics?"
           },
           "children": {
             "controls": {
@@ -2529,7 +2529,7 @@
           "x": "269",
           "y": "1464",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/9g97Ke"
+            "controlName": "ext_link:coursera.org/learn/linear-regression-business-statistics?"
           },
           "children": {
             "controls": {
@@ -3018,7 +3018,7 @@
           "x": "255",
           "y": "2037",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/5gqv4n"
+            "controlName": "ext_link:coursera.org/specializations/algorithms"
           },
           "children": {
             "controls": {
@@ -3375,7 +3375,7 @@
           "x": "810",
           "y": "1749",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/AWAv4R"
+            "controlName": "ext_link:coursera.org/projects/exploratory-data-analysis-python-pandas"
           },
           "children": {
             "controls": {
@@ -3437,7 +3437,7 @@
           "x": "811",
           "y": "1804",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/GmQMLE"
+            "controlName": "ext_link:coursera.org/learn/ibm-exploratory-data-analysis-for-machine-learning?"
           },
           "children": {
             "controls": {
@@ -3499,7 +3499,7 @@
           "x": "811",
           "y": "1860",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/ZQmMgR"
+            "controlName": "ext_link:coursera.org/projects/exploratory-data-analysis-seaborn"
           },
           "children": {
             "controls": {
@@ -3543,7 +3543,7 @@
                   "properties": {
                     "size": "17",
                     "color": "10027263",
-                    "text": "Course"
+                    "text": "Project"
                   }
                 }
               ]
@@ -3786,7 +3786,7 @@
           "x": "834",
           "y": "2185",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/oqGkrg"
+            "controlName": "ext_link:coursera.org/specializations/machine-learning-introduction"
           },
           "children": {
             "controls": {
@@ -4045,7 +4045,7 @@
           "x": "268",
           "y": "2445",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/Wq9MV3"
+            "controlName": "ext_link:coursera.org/specializations/deep-learning"
           },
           "children": {
             "controls": {
@@ -4560,7 +4560,7 @@
           "x": "938",
           "y": "2606",
           "properties": {
-            "controlName": "ext_link:imp.i384100.net/nLA5mx"
+            "controlName": "ext_link:coursera.org/specializations/machine-learning-engineering-for-production-mlops?"
           },
           "children": {
             "controls": {

--- a/src/data/roadmaps/ai-data-scientist/content/classic-advanced-ml.md
+++ b/src/data/roadmaps/ai-data-scientist/content/classic-advanced-ml.md
@@ -1,7 +1,7 @@
 # Classic/Advanced ML
 
 - [Open Machine Learning Course](https://mlcourse.ai/book/topic01/topic01_intro.html)
-- [Coursera: Machine Learning Specialization](https://imp.i384100.net/oqGkrg)
+- [Coursera: Machine Learning Specialization](https://www.coursera.org/specializations/machine-learning-introduction)
 - [Pattern Recognition and Machine Learning by Christopher Bishop](https://www.microsoft.com/en-us/research/uploads/prod/2006/01/Bishop-Pattern-Recognition-and-Machine-Learning-2006.pdf)
 - [Repository of notes, code and notebooks in Python for the book Pattern Recognition and Machine Learning by Christopher Bishop](https://github.com/gerdm/prml)
 

--- a/src/data/roadmaps/ai-data-scientist/content/data-understanding.md
+++ b/src/data/roadmaps/ai-data-scientist/content/data-understanding.md
@@ -1,6 +1,6 @@
 # Data Understanding, Analysis and Visualization
 
-- [Exploratory Data Analysis With Python and Pandas](https://imp.i384100.net/AWAv4R)
-- [Exploratory Data Analysis for Machine Learning](https://imp.i384100.net/GmQMLE)
-- [Exploratory Data Analysis with Seaborn](https://imp.i384100.net/ZQmMgR)
+- [Exploratory Data Analysis With Python and Pandas](https://www.coursera.org/projects/exploratory-data-analysis-python-pandas)
+- [Exploratory Data Analysis for Machine Learning](https://www.coursera.org/learn/ibm-exploratory-data-analysis-for-machine-learning?)
+- [Exploratory Data Analysis with Seaborn](https://www.coursera.org/projects/exploratory-data-analysis-seaborn)
 

--- a/src/data/roadmaps/ai-data-scientist/content/deployment-models.md
+++ b/src/data/roadmaps/ai-data-scientist/content/deployment-models.md
@@ -1,4 +1,4 @@
 # MLOps
 
-- [Machine Learning Engineering for Production (MLOps) Specialization](https://imp.i384100.net/nLA5mx)
+- [Machine Learning Engineering for Production (MLOps) Specialization](https://www.coursera.org/specializations/machine-learning-engineering-for-production-mlops?)
 

--- a/src/data/roadmaps/ai-data-scientist/content/diff-calculus.md
+++ b/src/data/roadmaps/ai-data-scientist/content/diff-calculus.md
@@ -1,4 +1,4 @@
 # Differential Calculus
 
-- [Algebra and Differential Calculus for Data Science](https://imp.i384100.net/LX5M7M)
+- [Algebra and Differential Calculus for Data Science](https://www.coursera.org/learn/algebra-and-differential-calculus-for-data-science?)
 

--- a/src/data/roadmaps/ai-data-scientist/content/fully-connected-nn.md
+++ b/src/data/roadmaps/ai-data-scientist/content/fully-connected-nn.md
@@ -3,5 +3,5 @@
 - [The Illustrated Transformer](https://jalammar.github.io/illustrated-transformer/)
 - [Attention is All you Need](https://arxiv.org/pdf/1706.03762.pdf)
 - [Deep Learning Book](https://www.deeplearningbook.org/)
-- [Deep Learning Specialization](https://imp.i384100.net/Wq9MV3)
+- [Deep Learning Specialization](https://www.coursera.org/specializations/deep-learning)
 

--- a/src/data/roadmaps/ai-data-scientist/content/hypothesis-testing.md
+++ b/src/data/roadmaps/ai-data-scientist/content/hypothesis-testing.md
@@ -1,4 +1,4 @@
 # Hypothesis Testing
 
-- [Introduction to Statistical Analysis: Hypothesis Testing](https://imp.i384100.net/vN0JAA)
+- [Introduction to Statistical Analysis: Hypothesis Testing](https://www.coursera.org/learn/statistical-analysis-hypothesis-testing-sas)
 

--- a/src/data/roadmaps/ai-data-scientist/content/learn-dsa.md
+++ b/src/data/roadmaps/ai-data-scientist/content/learn-dsa.md
@@ -2,4 +2,4 @@
 
 - [Learn Algorithms](https://leetcode.com/explore/learn/)
 - [Leetcode - Study Plans](https://leetcode.com/studyplan/)
-- [Algorithms Specialization](https://imp.i384100.net/5gqv4n)
+- [Algorithms Specialization](https://www.coursera.org/specializations/algorithms)

--- a/src/data/roadmaps/ai-data-scientist/content/linear-algebra-calc-mathana.md
+++ b/src/data/roadmaps/ai-data-scientist/content/linear-algebra-calc-mathana.md
@@ -1,4 +1,4 @@
 # Learn Algebra, Calculus, Mathematical Analysis
 
-- [Mathematics for Machine Learning Specialization](https://imp.i384100.net/baqMYv)
+- [Mathematics for Machine Learning Specialization](https://www.coursera.org/specializations/mathematics-machine-learning)
 

--- a/src/data/roadmaps/ai-data-scientist/content/probability-sampling.md
+++ b/src/data/roadmaps/ai-data-scientist/content/probability-sampling.md
@@ -1,4 +1,4 @@
 # Probability and Sampling
 
-- [Probability and Statistics: To p or not to p?](https://imp.i384100.net/daDM6Q)
+- [Probability and Statistics: To p or not to p?](https://www.coursera.org/learn/probability-statistics)
 

--- a/src/data/roadmaps/ai-data-scientist/content/regression-time-series-fitting-distr.md
+++ b/src/data/roadmaps/ai-data-scientist/content/regression-time-series-fitting-distr.md
@@ -2,11 +2,11 @@
 
 - [10 Fundamental Theorems for Econometrics](https://bookdown.org/ts_robinson1994/10EconometricTheorems/)
 - [Dougherty Intro to Econometrics 4th edition](https://www.academia.edu/33062577/Dougherty_Intro_to_Econometrics_4th_ed_small)
-- [Econometrics: Methods and Applications](https://imp.i384100.net/k0krYL)
+- [Econometrics: Methods and Applications](https://www.coursera.org/learn/erasmus-econometrics?)
 - [Kaggle - Learn Time Series](https://www.kaggle.com/learn/time-series)
 - [Time series Basics : Exploring traditional TS](https://www.kaggle.com/code/jagangupta/time-series-basics-exploring-traditional-ts#Hierarchical-time-series)
 - [How to Create an ARIMA Model for Time Series Forecasting in Python](https://machinelearningmastery.com/arima-for-time-series-forecasting-with-python)
 - [11 Classical Time Series Forecasting Methods in Python](https://machinelearningmastery.com/time-series-forecasting-methods-in-python-cheat-sheet/)
 - [Blockchain.com Data Scientist TakeHome Test](https://github.com/stalkermustang/bcdc_ds_takehome)
-- [Linear Regression for Business Statistics](https://imp.i384100.net/9g97Ke)
+- [Linear Regression for Business Statistics](https://www.coursera.org/learn/linear-regression-business-statistics?)
 

--- a/src/data/roadmaps/ai-data-scientist/content/stats-clt.md
+++ b/src/data/roadmaps/ai-data-scientist/content/stats-clt.md
@@ -1,4 +1,4 @@
 # Statistics, CLT
 
-- [Introduction to Statistics](https://imp.i384100.net/3eRv4v)
+- [Introduction to Statistics](https://www.coursera.org/learn/stanford-statistics?)
 

--- a/src/data/roadmaps/mongodb/content/101-datatypes/110-date.md
+++ b/src/data/roadmaps/mongodb/content/101-datatypes/110-date.md
@@ -20,10 +20,10 @@ When inserting a document with a Date field, you can store the date value as fol
 db.events.insertOne({ title: 'Sample Event', eventDate: new Date() });
 ```
 
-You can also specifically store the current date and time using MongoDB's `$currentDate` operator:
+You can also set the value of a field to the current date, either as a 'Date' or 'timestamp' using MongoDB's `$currentDate` operator:
 
 ```javascript
-db.events.insertOne({
+db.events.update({
   title: 'Sample Event',
   eventDate: { $currentDate: { $type: 'date' } },
 });


### PR DESCRIPTION
## Issue reference & explanation

This is a fix to the issue #4606 saying there is an error in the [MongoDB roadmap](https://roadmap.sh/mongodb) where an operator $currentDate (used to set the value of a field into the current date) is used in an insertOne() CRUD operation which is not correct according to this [mongodb source](https://database.guide/mongodb-currentdate/#:~:text=In%20MongoDB%2C%20the%20%24currentDate%20operator,be%20used%20in%20upsert%20operations) - the $currentDate can ONLY be used in an update() method and upsert() method.

## Details about changes:

I changed the text and the CRUD operation from 'InsertOne' to 'Update'

## Here is a preview:

![2023-10-19 11_56_05-Window](https://github.com/kamranahmedse/developer-roadmap/assets/71039249/cd35c00f-ccf8-44ab-9768-1038432eb125)


