### PR TITLE
Correct the POSA abbreviation

### DIFF
--- a/src/data/roadmaps/software-design-architecture/content/104-design-patterns/101-posa-patterns.md
+++ b/src/data/roadmaps/software-design-architecture/content/104-design-patterns/101-posa-patterns.md
@@ -1,6 +1,6 @@
 # POSA Patterns
 
-POSA (Patterns of Scalable and Adaptable Software Architecture) is a set of design patterns for developing software systems that can scale and adapt to changing requirements. These patterns were first described in the book "Patterns of Scalable, Reliable Services" by Kevin Hoffman.
+POSA (Pattern-Oriented Software Architecture) is a set of design patterns for developing software systems that can scale and adapt to changing requirements. These patterns were first described in the book "Patterns of Scalable, Reliable Services" by Kevin Hoffman.
 
 POSA patterns are divided into four categories:
 


### PR DESCRIPTION
The correct abbreviation for POSA is Pattern-Oriented Software Architecture not Patterns of Scalable and Adaptable Software Architecture.

Thanks