### PR TITLE
Update next.js youtube video link to latest

### DIFF
--- a/src/data/roadmaps/react/content/110-frameworks/101-next-js.md
+++ b/src/data/roadmaps/react/content/110-frameworks/101-next-js.md
@@ -8,5 +8,5 @@ Visit the following resources to learn more:
 - [Official Docs for Getting Started](https://nextjs.org/docs/getting-started)
 - [Next.js Full course](https://www.youtube.com/watch?v=9P8mASSREYM&list=PLC3y8-rFHvwgC9mj0qv972IO5DmD-H0ZH)
 - [Mastering Next.js](https://masteringnextjs.com/)
-- [Next.js for Beginners - freeCodeCamp](https://youtu.be/1WmNXEVia8I)
+- [Next.js for Beginners - freeCodeCamp](https://youtu.be/KjY94sAKLlw?si=orve81YcY8Fm2vDy)
 - [The Next.js Handbook — freeCodeCamp](https://www.freecodecamp.org/news/the-next-js-handbook/)


### PR DESCRIPTION
Updated to latest video of NextJS from freecodecamp in React roadmap.