### PR TITLE
Angular RxJS Marble Diagrams broken link and typo

### DIFF
--- a/src/data/roadmaps/angular/content/101-rxjs-basics/102-marble-diagrams.md
+++ b/src/data/roadmaps/angular/content/101-rxjs-basics/102-marble-diagrams.md
@@ -4,6 +4,5 @@ Marble testing allows you to test asynchronous RxJS code synchronously and step-
 
 Visit the following resources to learn more:
 
-- [Angular Marble Testing: A Brief Introduction](https://www.altamira.ai/blog/angular-marble-testing-a-brief-introduction/)
 - [Understanding Marble Diagrams for Reactive Streams](https://medium.com/@jshvarts/read-marble-diagrams-like-a-pro-3d72934d3ef5)
 - [Interactive Diagrams](https://rxmarbles.com/#from)

--- a/src/data/roadmaps/angular/content/101-rxjs-basics/102-marble-diagrams.md
+++ b/src/data/roadmaps/angular/content/101-rxjs-basics/102-marble-diagrams.md
@@ -5,5 +5,5 @@ Marble testing allows you to test asynchronous RxJS code synchronously and step-
 Visit the following resources to learn more:
 
 - [Angular Marble Testing: A Brief Introduction](https://www.altamira.ai/blog/angular-marble-testing-a-brief-introduction/)
-- [IUnderstanding Marble Diagrams for Reactive Streams](https://medium.com/@jshvarts/read-marble-diagrams-like-a-pro-3d72934d3ef5)
+- [Understanding Marble Diagrams for Reactive Streams](https://medium.com/@jshvarts/read-marble-diagrams-like-a-pro-3d72934d3ef5)
 - [Interactive Diagrams](https://rxmarbles.com/#from)


### PR DESCRIPTION
## Description:
Removes broken link: [Angular Marble Testing: A Brief Introduction](https://www.altamira.ai/blog/angular-marble-testing-a-brief-introduction/).
Fixes typo:
```diff
-[IUnderstanding Marble Diagrams for Reactive Streams](https://medium.com/@jshvarts/read-marble-diagrams-like-a-pro-3d72934d3ef5)
+[Understanding Marble Diagrams for Reactive Streams](https://medium.com/@jshvarts/read-marble-diagrams-like-a-pro-3d72934d3ef5)
```
