### PR TITLE
Flutter : update 100-material-widgets.md

### DIFF
--- a/src/data/roadmaps/flutter/content/102-widgets/102-styled-widgets/100-material-widgets.md
+++ b/src/data/roadmaps/flutter/content/102-widgets/102-styled-widgets/100-material-widgets.md
@@ -2,7 +2,7 @@
 
 Material Widgets are a set of Flutter widgets that implement Material Design, Google's visual language for design. They are designed to provide a consistent look and feel on both Android and iOS devices. Some common Material Widgets include:
 
-- RaisedButton
+- ElevatedButton
 - Scaffold
 - AppBar
 - TextField


### PR DESCRIPTION
'RaisedButton' is deprecated and shouldn't be used. It is replaced by ElevatedButton