### PR TITLE
Correct LLM abbreviation

### DIFF
--- a/src/data/roadmaps/prompt-engineering/content/100-basic-llm/100-what-are-llms.md
+++ b/src/data/roadmaps/prompt-engineering/content/100-basic-llm/100-what-are-llms.md
@@ -1,6 +1,6 @@
 # What are LLMs?
 
-LLMs, or Language Learning Models, are advanced Artificial Intelligence models specifically designed for understanding and generating human language. These models are typically based on deep learning architectures, such as Transformers, and are trained on massive amounts of text data from various sources to acquire a deep understanding of the nuances and complexities of language.
+LLMs, or Large Language Models, are advanced Artificial Intelligence models specifically designed for understanding and generating human language. These models are typically based on deep learning architectures, such as Transformers, and are trained on massive amounts of text data from various sources to acquire a deep understanding of the nuances and complexities of language.
 
 LLMs have the ability to achieve state-of-the-art performance in multiple Natural Language Processing (NLP) tasks, such as machine translation, sentiment analysis, summarization, and more. They can also generate coherent and contextually relevant text based on given input, making them highly useful for applications like chatbots, question-answering systems, and content generation.
 


### PR DESCRIPTION
The definition of LLM was changed from **Language Learning Models** to **Large Language Models**.