### PR TITLE
[C++] Fixed swap ADL participation

### DIFF
--- a/src/data/roadmaps/cpp/content/112-idioms/105-copy-swap.md
+++ b/src/data/roadmaps/cpp/content/112-idioms/105-copy-swap.md
@@ -16,14 +16,14 @@ class String {
 
     String(const String& other);
     
-    void swap(String& other) {
+    friend void swap(String& first, String& second) {
         using std::swap; // for arguments-dependent lookup (ADL)
-        swap(size_, other.size_);
-        swap(buffer_, other.buffer_);
+        swap(first.size_, second.size_);
+        swap(first.buffer_, second.buffer_);
     }
 
     String& operator=(String other) {
-        swap(other);
+        swap(*this, other);
         return *this;
     }
 };


### PR DESCRIPTION
The original implementation attempted to use `swap` as a member function within the `String` class, intending to benefit from Argument-Dependent Lookup (ADL). However, this approach is incorrect for achieving the desired ADL benefits. This PR addresses the issue by transforming the `swap` function into a non-member friend function, ensuring proper participation in ADL. The modified code enhances the correctness and effectiveness of the `String` class. [Reference](https://stackoverflow.com/questions/3279543/what-is-the-copy-and-swap-idiom)