### PR TITLE
fix: introduction to blockchain links

### DIFF
--- a/src/data/roadmaps/blockchain/content/100-blockchain-basics/102-why-blockchain-matters.md
+++ b/src/data/roadmaps/blockchain/content/100-blockchain-basics/102-why-blockchain-matters.md
@@ -6,7 +6,7 @@ This decentralization enables use-cases that were previously impossible, such as
 
 Visit the following resources to learn more:
 
-- [Why Blockchain?](https://www.blockchain.education/blockchain101/blockchain)
+- [Why Blockchain?](https://chain.link/education-hub/blockchain)
 - [What Is The Blockchain And Why Does It Matter?](https://www.forbes.com/sites/theyec/2020/05/18/what-is-the-blockchain-and-why-does-it-matter/)
 - [Web3/Crypto: Why Bother?](https://continuations.com/post/671863718643105792/web3crypto-why-bother)
 - [Why is Blockchain Important and Why Does it Matter](https://www.simplilearn.com/tutorials/blockchain-tutorial/why-is-blockchain-important)

--- a/src/data/roadmaps/blockchain/content/100-blockchain-basics/index.md
+++ b/src/data/roadmaps/blockchain/content/100-blockchain-basics/index.md
@@ -4,7 +4,7 @@ A blockchain is a decentralized, distributed, and oftentimes public, digital led
 
 Visit the following resources to learn more:
 
-- [Introduction to Blockchain](https://www.blockchain.education/blockchain101/blockchain)
+- [Introduction to Blockchain](https://chain.link/education-hub/blockchain)
 - [Blockchain Explained](https://www.investopedia.com/terms/b/blockchain.asp)
 - [How does a blockchain work?](https://youtu.be/SSo_EIwHSd4)
 - [What Is a Blockchain? | Blockchain Basics for Developers](https://youtu.be/4ff9esY_4aU)

--- a/src/data/roadmaps/blockchain/content/103-smart-contracts/index.md
+++ b/src/data/roadmaps/blockchain/content/103-smart-contracts/index.md
@@ -4,6 +4,6 @@ A smart contract is a computer program or a transaction protocol that is intende
 
 Visit the following resources to learn more:
 
-- [Smart Contracts Introduction](https://www.blockchain.education/blockchain101/smart-contracts)
+- [Smart Contracts Introduction](https://chain.link/education/smart-contracts)
 - [What Is a Smart Contract?](https://chain.link/education/smart-contracts)
 - [Smart contracts - Simply Explained](https://youtu.be/ZE2HxTmxfrI)


### PR DESCRIPTION
Fixes #4934 

Change link from [fromhttps://www.blockchain.education/blockchain101/blockchain](https://www.blockchain.education/blockchain101/blockchain) to [https://chain.link/education-hub/blockchain](https://chain.link/education-hub/blockchain)