### PR TITLE
Improve readability of 'Why us typescript' section

### DIFF
--- a/src/data/roadmaps/angular/content/100-typescript-basics/101-why-use-typescript.md
+++ b/src/data/roadmaps/angular/content/100-typescript-basics/101-why-use-typescript.md
@@ -1,6 +1,11 @@
 # Why use TypeScript
 
-TypeScript extends JavaScript, providing a better developer experience. The benefits of using TypeScript over JavaScript include.Static typing – TypeScript comes with optional static typing and a type inference system, which means that a variable declared with no type may be inferred by TypeScript based on its value. Object-oriented programming – TypeScript supports object-oriented programming concepts like classes, inheritance, etc. Compile time checks – JavaScript is an interpreted programming language. There is no compilation involved. Hence, the errors get caught during the runtime. Since TypeScript compiles into JavaScript, errors get reported during the compile time rather than the runtime. Code editor support – IDEs or code editors like VS Code support autocomplete for a TypeScript codebase. They also provide inline documentation and highlight the errors. Use existing packages – You might want to use an npm package written in JavaScript. Since TypeScript is a superset of JavaScript, you can import and use that package. Moreover, the TypeScript community creates and maintains type definitions for popular packages that can be utilized in your project.
+TypeScript extends JavaScript, providing a better developer experience. The benefits of using TypeScript over JavaScript include:
+- **Static typing** – TypeScript comes with optional static typing and a type inference system, which means that a variable declared with no type may be inferred by TypeScript based on its value.
+- **Object-oriented programming** – TypeScript supports object-oriented programming concepts like classes, inheritance, etc.
+- **ompile time checks** – JavaScript is an interpreted programming language. There is no compilation involved. Hence, the errors get caught during the runtime. Since TypeScript compiles into JavaScript, errors get reported during the compile time rather than the runtime.
+- **Code editor support** – IDEs or code editors like VS Code support autocomplete for a TypeScript codebase. They also provide inline documentation and highlight the errors.
+- **Integration with existing JavaScript Packages** – You might want to use an npm package written in JavaScript. Since TypeScript is a superset of JavaScript, you can import and use that package. Moreover, the TypeScript community creates and maintains type definitions for popular packages that can be utilized in your project.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
I've updated the 101-why-use-typescript.md file for readability, making adjustments to the text structure. 

There was also an error in a sentence: "JavaScript include.Static typing"...