### PR TITLE
fix: replace broken link with a valid one in frontend performance

### DIFF
--- a/src/data/best-practices/frontend-performance/content/recommended-guides.md
+++ b/src/data/best-practices/frontend-performance/content/recommended-guides.md
@@ -71,7 +71,7 @@
 - [Idle Until Urgent](https://philipwalton.com/articles/idle-until-urgent/)
 - [Browser painting and considerations for web performance](https://css-tricks.com/browser-painting-and-considerations-for-web-performance/)
 - [The Cost Of JavaScript In 2018](https://medium.com/@addyosmani/the-cost-of-javascript-in-2018-7d8950fbb5d4) ([Video](https://www.youtube.com/watch?v=i5R7giitymk))
-- [Examining Web Worker Performance](https://www.loxodrome.io/post/web-worker-performance/)
+- [Examining Web Worker Performance](https://www.jameslmilner.com/posts/web-worker-performance)
 - [Front-End Performance Checklist](https://github.com/thedaviddias/Front-End-Performance-Checklist)
 - [jankfree](http://jankfree.org/)
 - [What forces layout/reflow?](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)


### PR DESCRIPTION
This PR replaces this broken link [https://www.loxodrome.io/post/web-worker-performance](https://www.loxodrome.io/post/web-worker-performance) with another resource with similar material [https://www.jameslmilner.com/posts/web-worker-performance](https://www.jameslmilner.com/posts/web-worker-performance)