### PR TITLE
fix: broken link in python and also add another similar resource

### DIFF
--- a/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
+++ b/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
@@ -5,7 +5,7 @@ A binary search tree, also called an ordered or sorted binary tree, is a rooted 
 Visit the following resources to learn more:
 
 - [Tree Data Structure | Illustrated Data Structures](https://www.youtube.com/watch?v=S2W3SXGPVyU)
-- [WRITING A BINARY SEARCH TREE IN PYTHON WITH EXAMPLES](https://blog.boot.dev/computer-science/binary-search-tree-in-python/)
+- [Writing a Binary Search Tree in Python With Examples](https://blog.boot.dev/computer-science/binary-search-tree-in-python/)
 - [How to Implement Binary Search Tree in Python](https://web.archive.org/web/20230601181553/https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/)
 - [Binary Search Tree in Python](https://www.pythonforbeginners.com/data-structures/binary-search-tree-in-python)
 - [Problem Set](https://www.geeksforgeeks.org/binary-search-tree-data-structure/?ref=gcse)

--- a/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
+++ b/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
@@ -5,5 +5,6 @@ A binary search tree, also called an ordered or sorted binary tree, is a rooted 
 Visit the following resources to learn more:
 
 - [Tree Data Structure | Illustrated Data Structures](https://www.youtube.com/watch?v=S2W3SXGPVyU)
-- [How to Implement Binary Search Tree in Python](https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/)
+- [WRITING A BINARY SEARCH TREE IN PYTHON WITH EXAMPLES](https://blog.boot.dev/computer-science/binary-search-tree-in-python/)
+- [How to Implement Binary Search Tree in Python](https://web.archive.org/web/20230601181553/https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/)
 - [Problem Set](https://www.geeksforgeeks.org/binary-search-tree-data-structure/?ref=gcse)

--- a/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
+++ b/src/data/roadmaps/python/content/101-data-structures-and-algorithms/103-binary-search-trees.md
@@ -7,4 +7,5 @@ Visit the following resources to learn more:
 - [Tree Data Structure | Illustrated Data Structures](https://www.youtube.com/watch?v=S2W3SXGPVyU)
 - [WRITING A BINARY SEARCH TREE IN PYTHON WITH EXAMPLES](https://blog.boot.dev/computer-science/binary-search-tree-in-python/)
 - [How to Implement Binary Search Tree in Python](https://web.archive.org/web/20230601181553/https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/)
+- [Binary Search Tree in Python](https://www.pythonforbeginners.com/data-structures/binary-search-tree-in-python)
 - [Problem Set](https://www.geeksforgeeks.org/binary-search-tree-data-structure/?ref=gcse)


### PR DESCRIPTION
This PR fixes issue #5043 
change this [link](https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/) to [archive version](https://web.archive.org/web/20230601181553/https://www.section.io/engineering-education/implementing-binary-search-tree-using-python/) as the site is unavailable and redirected to host provider.

also added another similar resource: [https://blog.boot.dev/computer-science/binary-search-tree-in-python/](https://blog.boot.dev/computer-science/binary-search-tree-in-python/)