### PR TITLE
Update 101-esbuild.md

### DIFF
--- a/src/data/roadmaps/frontend/content/110-build-tools/101-module-bundlers/101-esbuild.md
+++ b/src/data/roadmaps/frontend/content/110-build-tools/101-module-bundlers/101-esbuild.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [Esbuild Official Website](https://esbuild.github.io/)
 - [Esbuild Documentation](https://esbuild.github.io/api/)
 - [Why are People Obsessed with esbuild?](https://www.youtube.com/watch?v=9XS_RA6zyyU)
-- [What Is ESBuild?](https://www.youtube.com/watch?v=zy8vu8cbwf0)
+- [What Is ESBuild?](https://www.youtube.com/watch?v=ZY8Vu8cbWF0)


### PR DESCRIPTION
fixing a dead youtube link caused by a change of channel name
linked to this issue: https://github.com/kamranahmedse/developer-roadmap/issues/5076