### PR TITLE
Create 104-opentofu.md

### DIFF
--- a/src/data/roadmaps/devops/content/110-infrastructure-provisioning/104-opentofu.md
+++ b/src/data/roadmaps/devops/content/110-infrastructure-provisioning/104-opentofu.md
@@ -1,0 +1,9 @@
+# OpenTofu
+
+Previously named OpenTF, OpenTofu is a fork of Terraform that is open-source, community-driven, and managed by the Linux Foundation.
+
+Visit the following resources to learn more:
+
+- [OpenTofu Website](https://opentofu.org/)
+- [OpenTofu Documentation](https://opentofu.org/docs/)
+- [OpenTofu GitHub](https://github.com/opentofu/opentofu?tab=readme-ov-file)


### PR DESCRIPTION
Add OpenTofu as an alternative to Terraform, which is an Open-source infrastructure-provisioning tool that is maintened by Linux Foundation.