### PR TITLE
doc(PowerShell): make case and spacing consistent

### DIFF
--- a/src/data/roadmaps/devops/content/102-live-in-terminal/scripting/101-powershell.md
+++ b/src/data/roadmaps/devops/content/102-live-in-terminal/scripting/101-powershell.md
@@ -1,3 +1,3 @@
-# Powershell
+# PowerShell
 
 - [PowerShell Documentation](https://learn.microsoft.com/en-us/powershell/)

--- a/src/data/roadmaps/devops/devops.json
+++ b/src/data/roadmaps/devops/devops.json
@@ -3066,7 +3066,7 @@
                   "x": "50",
                   "y": "11",
                   "properties": {
-                    "text": "Power Shell",
+                    "text": "PowerShell",
                     "size": "17"
                   }
                 }


### PR DESCRIPTION
Make text referring to PowerShell consistent with case and spacing