### PR TITLE
fix: HATEOAS youtube video

### DIFF
--- a/src/data/roadmaps/backend/content/109-apis/104-hateoas.md
+++ b/src/data/roadmaps/backend/content/109-apis/104-hateoas.md
@@ -4,4 +4,5 @@ HATEOAS is an acronym for <b>H</b>ypermedia <b>A</b>s <b>T</b>he <b>E</b>ngine <
 
 Visit the following resources to learn more:
 
-- [Oktane17: Designing Beautiful REST + JSON APIs (3:56 - 5:57)](https://youtu.be/MiOSzpfP1Ww?t=236)
+- [REST API - Understanding HATEOAS](https://www.youtube.com/watch?v=oTJnx_xjpb0)
+- [What is HATEOAS in REST? | Spring MVC, Spring Boot Example | Tech Primers](https://www.youtube.com/watch?v=vvcANMpfr5I)


### PR DESCRIPTION
This PR fixes issue #5109 

the video belongs to [Oktaine 17 conference](www.okta.com) , but it has been removed from their archive. Consequently, I couldn't locate the correct video.

Archive link: [https://web.archive.org/web/20220328020734/https://www.youtube.com/watch?v=MiOSzpfP1Ww](https://web.archive.org/web/20220328020734/https://www.youtube.com/watch?v=MiOSzpfP1Ww)

Oktane17: [https://www.okta.com/video/oktane17-appdev-designing-beautiful-rest-plus-json-apis/](https://www.okta.com/video/oktane17-appdev-designing-beautiful-rest-plus-json-apis/)

So I just removed the broken link and added 2 other similar resources