### PR TITLE
fix: remove duplicate link in smart-contract

### DIFF
--- a/src/data/roadmaps/blockchain/content/103-smart-contracts/index.md
+++ b/src/data/roadmaps/blockchain/content/103-smart-contracts/index.md
@@ -4,6 +4,5 @@ A smart contract is a computer program or a transaction protocol that is intende
 
 Visit the following resources to learn more:
 
-- [Smart Contracts Introduction](https://chain.link/education/smart-contracts)
-- [What Is a Smart Contract?](https://chain.link/education/smart-contracts)
+- [What Are Smart Contracts and How Do They Work?](https://chain.link/education/smart-contracts)
 - [Smart contracts - Simply Explained](https://youtu.be/ZE2HxTmxfrI)


### PR DESCRIPTION
This PR removes duplicate link in smart contract blockchain roadmap:

```
- [Smart Contracts Introduction](https://chain.link/education/smart-contracts)
- [What Is a Smart Contract?]   (https://chain.link/education/smart-contracts)
```

also I changed the title to match it with chainlink