### PR TITLE
fix all nodejs doc redirection from .dev to .org

### DIFF
--- a/src/data/roadmaps/devops/content/100-language/102-javascript.md
+++ b/src/data/roadmaps/devops/content/100-language/102-javascript.md
@@ -13,4 +13,4 @@ Visit the following resources to learn more:
 - [Node.js Tutorial for Beginners](https://www.youtube.com/watch?v=TlB_eWDSMt4)
 - [W3Schools – Node.js Tutorial](https://www.w3schools.com/nodejs/)
 - [What is NPM?](https://www.w3schools.com/nodejs/nodejs_npm.asp)
-- [Official Documentation](https://nodejs.dev/en/learn/)
+- [Official Documentation](https://nodejs.org/en/learn/getting-started/introduction-to-nodejs)

--- a/src/data/roadmaps/full-stack/content/113-nodejs.md
+++ b/src/data/roadmaps/full-stack/content/113-nodejs.md
@@ -5,6 +5,6 @@ Node.js is an open-source and cross-platform JavaScript runtime environment. It 
 Visit the following resources to learn more:
 
 - [Official Website](https://nodejs.org/en/about/)
-- [Learn Node.js Official Website](https://nodejs.dev/en/learn/)
+- [Learn Node.js Official Website](https://nodejs.org/en/learn/getting-started/introduction-to-nodejs)
 - [Node.JS Introduction](https://www.w3schools.com/nodejs/nodejs_intro.asp)
 - [Node.js and Express.js Full Course](https://www.youtube.com/watch?v=Oe421EPjeBE)

--- a/src/data/roadmaps/nodejs/content/100-nodejs-introduction/100-what-is-nodejs.md
+++ b/src/data/roadmaps/nodejs/content/100-nodejs-introduction/100-what-is-nodejs.md
@@ -6,6 +6,6 @@ Visit the following resources to learn more:
 
 - [Official Website](https://nodejs.org/en/about/)
 - [Node.JS Introduction](https://www.w3schools.com/nodejs/nodejs_intro.asp)
-- [Official Website](https://nodejs.dev/en/learn/)
+- [Official Website](https://nodejs.org/en/learn/getting-started/introduction-to-nodejs)
 - [What is Node.js?](https://www.youtube.com/watch?v=uVwtVBpw7RQ)
 - [How Node.js Works?](https://www.youtube.com/watch?v=jOupHNvDIq8)

--- a/src/data/roadmaps/nodejs/content/100-nodejs-introduction/101-why-nodejs.md
+++ b/src/data/roadmaps/nodejs/content/100-nodejs-introduction/101-why-nodejs.md
@@ -5,6 +5,6 @@ Node.js is a cross-platform runtime, perfect for a wide range of use cases. Its 
 Visit the following resources to learn more:
 
 - [Pros of Node.js](https://www.freecodecamp.org/news/what-are-the-advantages-of-node-js/)
-- [Learn Node.js](https://nodejs.dev/en/learn/)
+- [Learn Node.js](https://nodejs.org/en/learn/getting-started/introduction-to-nodejs)
 - [Why Choose Node.js?](https://medium.com/selleo/why-choose-node-js-b0091ad6c3fc)
 - [5 Reasons to Choose Node.js](https://www.bitovi.com/blog/5-reasons-to-choose-nodejs)

--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/100-event-loop.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/100-event-loop.md
@@ -8,4 +8,5 @@ Visit the following resources to learn more:
 - [JavaScript Visualized: Event Loop](https://dev.to/lydiahallie/javascript-visualized-event-loop-3dif)
 - [The Node.js Event Loop](https://www.coursera.org/lecture/secure-full-stack-mean-developer/the-node-js-event-loop-j5fbT)
 - [The Complete Node js: The Node js Event Loop](https://www.youtube.com/watch?v=6YgsqXlUoTM)
-- [The NodeJS Event loop](https://nodejs.dev/en/learn/the-nodejs-event-loop/)
+- [The NodeJS Event loop](https://nodejs.org/en/guides/event-loop-timers-and-nexttick)
+- [Don't Block the Event Loop](https://nodejs.org/en/guides/dont-block-the-event-loop)

--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/101-event-emitter.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/101-event-emitter.md
@@ -4,5 +4,5 @@ In Node.js, an event can be described simply as a string with a corresponding ca
 
 Visit the following resources to learn more:
 
-- [What are Event Emitters?](https://nodejs.dev/en/learn/the-nodejs-event-emitter/)
+- [What are Event Emitters?](https://nodejs.org/en/learn/asynchronous-work/the-nodejs-event-emitter)
 - [Using Event Emitters in Node.js](https://www.digitalocean.com/community/tutorials/using-event-emitters-in-node-js)

--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/104-callbacks.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/104-callbacks.md
@@ -5,4 +5,4 @@ Node.js, being an asynchronous platform, doesn't wait around for things like fil
 Visit the following resources to learn more:
 
 - [What are callbacks?](https://developer.mozilla.org/en-US/docs/Glossary/Callback_function)
-- [Asynchronicity in Programming Languages](https://nodejs.dev/en/learn/javascript-asynchronous-programming-and-callbacks/)
+- [Asynchronicity in Programming Languages](https://nodejs.org/en/learn/asynchronous-work/javascript-asynchronous-programming-and-callbacks)

--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/107-set-immediate.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/107-set-immediate.md
@@ -5,4 +5,4 @@ The `setImmediate` function delays the execution of a function to be called afte
 Visit the following resources to learn more:
 
 - [Understanding setImmediate](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate)
-- [Understanding setImmediate](https://nodejs.dev/en/learn/understanding-setimmediate/)
+- [Understanding setImmediate](https://nodejs.org/en/learn/asynchronous-work/understanding-setimmediate)

--- a/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/108-process-next-tick.md
+++ b/src/data/roadmaps/nodejs/content/104-nodejs-async-programming/108-process-next-tick.md
@@ -4,6 +4,6 @@ Every time the event loop takes a full trip, we call it a tick. When we pass a f
 
 Visit the following resources to learn more:
 
-- [Understanding Process.NextTick()](https://nodejs.dev/en/learn/understanding-processnexttick/)
+- [Understanding Process.NextTick()](https://nodejs.org/en/learn/asynchronous-work/understanding-processnexttick)
 - [The Node.js process.nextTick()](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/)
 - [The process.nextTick Function](https://www.youtube.com/watch?v=-niA5XOlCWI)

--- a/src/data/roadmaps/nodejs/content/105-nodejs-working-with-files/101-path-module.md
+++ b/src/data/roadmaps/nodejs/content/105-nodejs-working-with-files/101-path-module.md
@@ -5,5 +5,5 @@ The `path` module provides utilities for working with file and directory paths. 
 Visit the following resources to learn more:
 
 - [Official Website](https://nodejs.org/api/path.html)
-- [Official Website](https://nodejs.dev/en/learn/nodejs-file-paths/)
+- [Official Website](https://nodejs.org/en/learn/manipulating-files/nodejs-file-paths)
 - [Path Module in Node.js](https://youtu.be/j95Lwxvi9JY)

--- a/src/data/roadmaps/nodejs/content/107-nodejs-apis/100-http-module.md
+++ b/src/data/roadmaps/nodejs/content/107-nodejs-apis/100-http-module.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [How To Create a Web Server in Node.js with the HTTP Module](https://www.digitalocean.com/community/tutorials/how-to-create-a-web-server-in-node-js-with-the-http-module)
 - [Node.js Http Module](https://www.geeksforgeeks.org/node-js-http-module/)
-- [The Node.js Http Module](https://nodejs.dev/en/learn/the-nodejs-http-module/)
+- [The Node.js Http Module](https://nodejs.org/docs/latest/api/http.html)


### PR DESCRIPTION
Hi, the Node.js official documentation was redirected from .dev to .org, resulting in numerous 404 errors. In this pull request, I have replaced all .dev links with their corresponding .org links.