### PR TITLE
Add third OCI specification

### DIFF
--- a/src/data/roadmaps/docker/content/100-introduction/103-docker-and-oci.md
+++ b/src/data/roadmaps/docker/content/100-introduction/103-docker-and-oci.md
@@ -8,11 +8,14 @@ The [Open Container Initiative (OCI)](https://opencontainers.org/) is a Linux Fo
 
 ### OCI Specifications
 
-OCI has two main specifications:
+OCI has three main specifications:
 
 - **Runtime Specification (runtime-spec):** It defines the specification for executing a container via an isolation technology, like a container engine. The container runtime built by Docker, called 'containerd', has guided the development of the OCI runtime-spec.
 
 - **Image Specification (image-spec):** It defines the container image format, which describes the contents of a container and can be run by a compliant runtime. Docker's initial image format has led to the creation of the OCI image-spec.
+
+- **Distribution Specification (distribution-spec):** It defines defines an API protocol to facilitate and standardize the distribution of content. Docker's existing registry API served as a starting point and heavily influenced the design of the OCI Distro Spec. 
+
 
 ### Compatibility between Docker and OCI
 


### PR DESCRIPTION
The OCI-specification has three core specifications while on the description written only two are mentioned. 

I added the *Distribution Specification (distribution-spec)*.

According to the website, the distro-spec defines a standardized API protocol for distributing container images and other content. It is primarly designed to ensure interoperability and consistency across different container registries and tools, regardless of their specific implementation.

I attach below links to the website of OCI and the github repo
- [On the github repo of the OCI](https://github.com/opencontainers/distribution-spec) 
- [Website of the OCI](https://opencontainers.org/about/overview/)