### PR TITLE
fix: navigation dropdown menu in navigation bar that is not 100% hidden

### DIFF
--- a/src/components/NavigationDropdown.tsx
+++ b/src/components/NavigationDropdown.tsx
@@ -61,6 +61,7 @@ export function NavigationDropdown() {
           'absolute left-0 top-full z-[999] mt-2 w-48 min-w-[320px] -translate-y-1 rounded-lg bg-slate-800 py-2 opacity-0 shadow-xl transition-all duration-100',
           {
             'translate-y-2.5 opacity-100': isOpen,
+            hidden: !isOpen,
           },
         )}
       >


### PR DESCRIPTION
## Fix
- fix: fix navigation dropdown menu in navigation, that is not hidden if not open which it still can be click, but not anymore

### Screenshot (before fix)
- navigation open
<img width="842" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/83328527/6d27bb93-9a4a-481e-b7dc-a02d592d1a67">

- navigation closed
<img width="817" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/83328527/b669011a-ac3f-4e78-8101-cc1ba5dd41d5">

_**notice the link in the bottom left corner? it means the links is not 100% disappear which makes it still can be clicked even though the navigation dropdown is not opened.**_

### Screenshot (after fix)
- navigation open
<img width="783" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/83328527/7b162bed-6c84-450c-ad48-78418015c996">

- navigation closed 
<img width="764" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/83328527/36493f7d-7d8e-4e3d-bbfd-277dbe9fa758">
