### PR TITLE
feat: add use-freeze-scroll hook to topic detail

### DIFF
--- a/src/components/TopicDetail/TopicDetail.tsx
+++ b/src/components/TopicDetail/TopicDetail.tsx
@@ -4,6 +4,7 @@ import { useKeydown } from '../../hooks/use-keydown';
 import { useLoadTopic } from '../../hooks/use-load-topic';
 import { useOutsideClick } from '../../hooks/use-outside-click';
 import { useToggleTopic } from '../../hooks/use-toggle-topic';
+import { useFreezeScroll } from '../../hooks/use-freeze-scroll.ts';
 import { httpGet } from '../../lib/http';
 import { isLoggedIn } from '../../lib/jwt';
 import type { ResourceType } from '../../lib/resource-progress';
@@ -64,6 +65,7 @@ export function TopicDetail(props: TopicDetailProps) {
   const [topicId, setTopicId] = useState('');
   const [resourceId, setResourceId] = useState('');
   const [resourceType, setResourceType] = useState<ResourceType>('roadmap');
+  useFreezeScroll(isActive);
 
   // Close the topic detail when user clicks outside the topic detail
   useOutsideClick(topicRef, () => {
@@ -198,6 +200,8 @@ export function TopicDetail(props: TopicDetailProps) {
   }
 
   const hasContent = topicHtml?.length > 0 || links?.length > 0 || topicTitle;
+
+  console.log("isActiveisActive",isActive);
 
   return (
     <div className={'relative z-50'}>

--- a/src/hooks/use-freeze-scroll.ts
+++ b/src/hooks/use-freeze-scroll.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+
+export function useFreezeScroll(isActive: boolean) {
+  useEffect(() => {
+    if (!isActive) return;
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.style.marginRight = scrollbarWidth + 'px';
+    document.documentElement.style.overflow = 'hidden';
+
+    return () => {
+      document.documentElement.style.overflow = 'visible';
+      document.documentElement.style.marginRight = '0';
+    };
+  }, [isActive]);
+}


### PR DESCRIPTION
The useFreezeScroll hook freezes the scroll and removes the scrollbar from the browser window when it is active, without causing any layout shifts. This is particularly useful, for example, when a modal is opened.

This pull request removes the scrollbar from the body when the topic detail is opened. It does not remove the scrollbar from the topic detail itself, so you can still scroll the content of topic while the background is locked.

I have tested this across different browsers on macOS, Linux, and Windows, and it's almost the only way to avoid layout shifts.