### PR TITLE
expand rust zero cost abstractions content

### DIFF
--- a/src/data/roadmaps/rust/content/100-introduction/102-memory-safety.md
+++ b/src/data/roadmaps/rust/content/100-introduction/102-memory-safety.md
@@ -1,3 +1,7 @@
 # Memory Safety and Zero-Cost Abstractions
 
 Rust, a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety. It is graced with the feature of "memory safety without garbage collection", an attribute that makes Rust one of its kind. Memory safety is ensuring that software, while accessing the system's memory, is not causing any leaks, or dangling pointers. In Rust, memory safety is accomplished through a system of ownership with a set of rules that the compiler checks at compile time. This system eliminates the need of garbage collection or manual memory management, hence ensuring swift execution of software along with a safer memory environment. This memory management feature in Rust even provides concurrent programming guaranteeing thread safety with options for shared and mutable state access that makes it harder to cause thread unsafety.
+
+<!-- Adding content on Zero-cost Abstraction -->
+
+Zero cost abstraction is another key feature of Rust. In general, abstractions in programming languages allow code to be written at a high level (like in Python), while being able to run at a low level (like in C). However, these abstractions often come with a runtime cost. Rust aims to provide abstractions that are as fast as writing the code manually at a low level. This means you can write high-level code, and the Rust compiler will optimize it to run as fast as manually written low-level code.


### PR DESCRIPTION
Add missing content on zero cost abstractions in Rust 

This commit adds the missing section on zero cost abstractions in Rust that was planned for the blog post. It covers:

- Explanation of zero cost abstractions and how Rust achieves this: 

This helps complete the blog post and provides readers with a deeper understanding of this key aspect of Rust's design.
