### PR TITLE
Correct memory occupation from Boolean

### DIFF
--- a/src/data/roadmaps/cpp/content/104-data-types/index.md
+++ b/src/data/roadmaps/cpp/content/104-data-types/index.md
@@ -43,7 +43,7 @@ char letter = 'A';
 ```
 
 ## Boolean (bool)
-Booleans represent logical values: `true` or `false`. They usually occupy 1 byte of memory.
+Booleans represent logical values: `true` or `false`. They usually occupy 1 bit of memory.
 
 Example:
 ```cpp


### PR DESCRIPTION
Booleans occupy 1 bit (0 or 1), not 1 byte