### PR TITLE
Fixing typo in typescript as type

### DIFF
--- a/src/data/roadmaps/typescript/content/101-typescript-types/115-type-assertions/101-as-type.md
+++ b/src/data/roadmaps/typescript/content/101-typescript-types/115-type-assertions/101-as-type.md
@@ -9,7 +9,7 @@ Here's a simple example:
 let someValue: any = "Hello, TypeScript!";
 let strLength: number = (someValue as string).length;
 
-console.log(strLength); // Outputs: 20
+console.log(strLength); // Outputs: 18
 ```
 In this example, someValue is initially of type any, and we use the as operator to assert that it is of type string before accessing its length property. It's important to note that type assertions do not change the underlying runtime representation; they are a compile-time construct used for static type checking in TypeScript.
 


### PR DESCRIPTION
The length of this is 18 but it says 20

'let someValue: any = "Hello, TypeScript!";
let strLength: number = (someValue as string).length;

console.log(strLength); // Outputs: 20'