### PR TITLE
Fix Typo in reinforcements-learning.md

### DIFF
--- a/src/data/roadmaps/game-developer/content/108-game-api-2/100-learning/105-reinforcements-learning.md
+++ b/src/data/roadmaps/game-developer/content/108-game-api-2/100-learning/105-reinforcements-learning.md
@@ -1,3 +1,3 @@
-# Reinforcements Learning
+# Reinforcement Learning
 
 `Reinforcement Learning` is a type of Machine Learning which is geared towards making decisions. It involves an agent that learns to behave in an environment, by performing certain actions and observing the results or rewards/results it gets. The main principle of reinforcement learning is to reward good behavior and penalize bad behavior. The agent learns from the consequences of its actions, rather than from being taught explicitly. In the context of game development, reinforcement learning could be used to develop an AI (Artificial Intelligence) which can improve its performance in a game based on reward-driven behavior. The AI gradually learns the optimal strategy, known as policy, to achieve the best result.


### PR DESCRIPTION
Change title from "Reinforcements" to "Reinforcement". I believe this was a typo when the document was originally created.