### PR TITLE
Fix : typo in suggestion links of docker.json

### DIFF
--- a/src/data/roadmaps/docker/docker.json
+++ b/src/data/roadmaps/docker/docker.json
@@ -4186,7 +4186,7 @@
                   "x": "23",
                   "y": "52",
                   "properties": {
-                    "controlName": "ext_link:roadmap.sh/best-practices"
+                    "controlName": "ext_link:roadmap.sh/devops"
                   },
                   "children": {
                     "controls": {


### PR DESCRIPTION
Fix : typo for route(controlName) in devops suggestion block  of docker roadmap

<img width="643" alt="devops-path-issue" src="https://github.com/kamranahmedse/developer-roadmap/assets/61598260/db5990e2-9293-49e9-b501-a3e9e7d6e1a2">
