### PR TITLE
fix: Corrected link of Exception Handling in JavaScript roadmap

### DIFF
--- a/src/data/roadmaps/javascript/content/107-javascript-control-flow/100-exception-handling/index.md
+++ b/src/data/roadmaps/javascript/content/107-javascript-control-flow/100-exception-handling/index.md
@@ -4,5 +4,5 @@ In JavaScript, all exceptions are simply objects. While the majority of exceptio
 
 Visit the following resources to learn more:
 
-- [Throwing Exceptions in JavaScript](https://rollbar.com/guides/javascript/how-to-throw-exceptions-in-javascript)
+- [Exception handling statements](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#exception_handling_statements)
 - [try, catch, finally, throw (video)](https://youtu.be/cFTFtuEQ-10)


### PR DESCRIPTION
![image](https://github.com/kamranahmedse/developer-roadmap/assets/49965963/1fa48da3-b953-48a3-844b-e0bf572cb0f5)

I noticed that the link for Exception Handling in the JavaScript roadmap is not working. I updated the link to point to the tutorial on MDN.

Changes Made:
- Change the link for [how-to-throw-exceptions-in-javascript](https://rollbar.com/guides/javascript/how-to-throw-exceptions-in-javascript) to [Control flow and error handling](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling)

Thank you!
