### PR TITLE
fix: typo in fullstack chekcpoint

### DIFF
--- a/src/data/roadmaps/full-stack/content/106-external-packages.md
+++ b/src/data/roadmaps/full-stack/content/106-external-packages.md
@@ -6,5 +6,5 @@ You don't need to get into the module bundlers and build tools just yet. Just ma
 
 Regarding projects, here are a few ideas that you can try:
 
-- Create a simple webpage that shows the current time of user. You can use use [dayjs](https://day.js.org/) to get the current time and display it on the page. Here is the [sample design for homepage](https://i.imgur.com/yGIMGkr.png). 
+- Create a simple webpage that shows the current time of user. You can use [dayjs](https://day.js.org/) to get the current time and display it on the page. Here is the [sample design for homepage](https://i.imgur.com/yGIMGkr.png).
 - Install the [micromodal](https://micromodal.vercel.app/#introduction) library. Create a button on the page clicking which should open a modal and let the user select a timezone from a dropdown. Once the user selects a timezone, the modal should close and the time on the page should be updated to show the time in the selected timezone. Here is the [sample design for the modal](https://imgur.com/a/vFY6Sdl).


### PR DESCRIPTION
Fixed typo. There was two instances of "use" in the fullstack roadmap under "Checkpoint - External Packages".