### PR TITLE
fix: focus disappears in navigation

### DIFF
--- a/src/components/NavigationDropdown.tsx
+++ b/src/components/NavigationDropdown.tsx
@@ -73,9 +73,9 @@ export function NavigationDropdown() {
       </button>
       <div
         className={cn(
-          'absolute pointer-events-none left-0 top-full z-[999] mt-2 w-48 min-w-[320px] -translate-y-1 rounded-lg bg-slate-800 py-2 opacity-0 shadow-xl transition-all duration-100',
+          'absolute pointer-events-none invisible left-0 top-full z-[999] mt-2 w-48 min-w-[320px] -translate-y-1 rounded-lg bg-slate-800 py-2 opacity-0 shadow-xl transition-all duration-100',
           {
-            'pointer-events-auto translate-y-2.5 opacity-100': isOpen,
+            'pointer-events-auto visible translate-y-2.5 opacity-100': isOpen,
           },
         )}
       >


### PR DESCRIPTION
Fixes #5354 

Now focus works as expected. Focus doesn't disappear, and goes to menu items if the menu is open. Otherwise it goes to next focusable element.