### PR TITLE
fix typo in rust ownership section

### DIFF
--- a/src/data/roadmaps/rust/content/101-language-basics/101-ownership/index.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/101-ownership/index.md
@@ -1,3 +1,3 @@
-# Onwnership System
+# Ownership System
 
 In Rust, the concept of `Ownership` is a key feature that governs how memory management works. Each value in Rust has its own designated owner and there can be only one owner for a value at a time. When the owner goes out of scope, the value would be automatically dropped. The three main facets of ownership include ownership rules, `borrowing` and `slices`. Ownership rules play a key role in system performance and prevention of issues like null or dangling references. `Borrowing` is a mechanism where we allow something to reference a value without taking ownership. Finally, `slices` are a data type that does not have ownership and helps in making a reference to a portion of a collection.

--- a/src/data/roadmaps/rust/rust.json
+++ b/src/data/roadmaps/rust/rust.json
@@ -4402,7 +4402,7 @@
                   "y": "13",
                   "properties": {
                     "size": "17",
-                    "text": "Onwnership System"
+                    "text": "Ownership System"
                   }
                 }
               ]


### PR DESCRIPTION
Fixing typo: `onwnership` to `ownership`.

Not sure if `rust.json` is generated or not but I spotted these two places so I gave them an update.