### PR TITLE
Fix typo for the content typo of 102-chatty-io.md

### DIFF
--- a/src/data/roadmaps/system-design/content/116-performance-antipatterns/102-chatty-io.md
+++ b/src/data/roadmaps/system-design/content/116-performance-antipatterns/102-chatty-io.md
@@ -1,4 +1,4 @@
-# Chat I/O
+# Chatty I/O
 
 The cumulative effect of a large number of I/O requests can have a significant impact on performance and responsiveness.
 


### PR DESCRIPTION
The content's title should be "Chatty I/O" instead of "Chat I/O"