### PR TITLE
[TYPO] Eliminate variants of Python Generator Expressions

### DIFF
--- a/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
+++ b/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
@@ -2,7 +2,7 @@
 
 Generator expressions are a concise way to create a generator using a single line of code in Python. They are similar to list comprehensions, but instead of creating a list, they create a generator object that produces the values on-demand, as they are needed.
 
-Generator expressions are a useful tool for efficiently generating large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This tends to use less memory, especially for large sequences.
+Generator expressions are a useful tool for efficiently producing large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This tends to use less memory, especially for large sequences.
 
 Visit the following resources to learn more:
 

--- a/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
+++ b/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
@@ -2,7 +2,7 @@
 
 Generator expressions are a concise way to create a generator using a single line of code in Python. They are similar to list comprehensions, but instead of creating a list, they create a generator object that produces the values on-demand, as they are needed.
 
-Generator expressions are a useful tool for creating generators that generate a large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This can be more efficient and use less memory, especially for large sequences.
+Generator expressions are a useful tool for efficiently generating large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This tends to use less memory, especially for large sequences.
 
 Visit the following resources to learn more:
 

--- a/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
+++ b/src/data/roadmaps/python/content/102-python-advanced-topics/107-generator-expressions.md
@@ -1,8 +1,8 @@
-# Generator Compressions
+# Generator Expressions
 
-Generator comprehensions are a concise way to create a generator using a single line of code in Python. They are similar to list comprehensions, but instead of creating a list, they create a generator object that produces the values on-demand, as they are needed.
+Generator expressions are a concise way to create a generator using a single line of code in Python. They are similar to list comprehensions, but instead of creating a list, they create a generator object that produces the values on-demand, as they are needed.
 
-Generator comprehensions are a useful tool for creating generators that generate a large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This can be more efficient and use less memory, especially for large sequences.
+Generator expressions are a useful tool for creating generators that generate a large sequence of values, as they allow you to create the generator without creating the entire sequence in memory at once. This can be more efficient and use less memory, especially for large sequences.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
1. There were some similar-sounding variants of Generator Expressions in the documentation:
* Generator comprehensions 
* Generator compressions

This PR changes all such references to [**Generator Expressions**](https://peps.python.org/pep-0289/).

2. Simplified some semi-superfluous language that previously read as "... a useful tool for creating **generators** that **generate** ..."