### PR TITLE
Suggested fix for the build command.

### DIFF
--- a/src/data/roadmaps/typescript/content/100-typescript/102-install-configure/index.md
+++ b/src/data/roadmaps/typescript/content/100-typescript/102-install-configure/index.md
@@ -32,13 +32,13 @@ npm install --save-dev typescript
 - Compile your TypeScript code using the following command:
 
 ```bash
-tsc
+npx tsc
 ```
 
-Note: You can also compile individual TypeScript files by specifying the file name after the tsc command. For example:
+Note: You can also compile individual TypeScript files by specifying the file path after the tsc command. For example:
 
 ```bash
-tsc index.ts
+npx tsc ./src/index.ts
 ```
 
 And you're all set! You can now start writing TypeScript code in your project.


### PR DESCRIPTION
Hello !
As per my understading, the "--save-dev" option install the typescript module locally to the project.
The "tsc" command would work if we were using the "-g" option.
On my side, it's the "npx tsc" command that worked as mentionned into this documentation linked into the note : https://www.typescriptlang.org/download/
Hope I well understood...