### PR TITLE
Add learning reference to CIDR

### DIFF
--- a/src/data/roadmaps/aws/content/102-vpc/100-cidr-blocks.md
+++ b/src/data/roadmaps/aws/content/102-vpc/100-cidr-blocks.md
@@ -1,3 +1,7 @@
 # CIDR Blocks
 
 "CIDR" stands for Classless Inter-Domain Routing. In AWS VPC, a CIDR block is the IP address block from which private IPv4 addresses and public IPv4 addresses are allocated when you create a VPC. The CIDR block can range from /28 (16 IP addresses) to /16 (65,536 IP addresses). It represents a network segment and is associated with a network boundary. Upon creation, you cannot change the CIDR block of your VPC, but you can add additional CIDR blocks to it if needed. A VPC's CIDR block should not overlap with any of the existing network's CIDR blocks.
+
+## References
+
+- [cidr.xyz: Interactive CIDR range visualizer](https://cidr.xyz/)


### PR DESCRIPTION
I don't remember seeing learning references on *roadmap* so far, but I believe it could help learners finding good, organized learning material more quickly.