### PR TITLE
Update 106-cryptography.md - Bullet point

### DIFF
--- a/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/106-cryptography.md
+++ b/src/data/roadmaps/blockchain/content/101-blockchain-general-knowledge/106-cryptography.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [Cryptography](https://en.wikipedia.org/wiki/Cryptography)
 - [What is Cryptography](https://www.synopsys.com/glossary/what-is-cryptography.html)
 - [Asymmetric Encryption - Simply explained](https://youtu.be/AQDCe585Lnc)
-- [What is Cryptography?](https://www.youtube.com/watch?v=6_Cxj5WKpIw)
+- [What is Cryptography? - Youtube Video](https://www.youtube.com/watch?v=6_Cxj5WKpIw)


### PR DESCRIPTION
In blockchain roadmap > General Blockchain knowledge > Cryptography

Instead of simply putting **what is Cryptography?** in last bullet which is being repeated in second point, I have updated it to reference that this link is refer to **youtube video**

### Here is the previous state

![image](https://github.com/kamranahmedse/developer-roadmap/assets/108511809/eb0cb8b2-96e6-417c-be49-6116d4422fd6)
