### PR TITLE
None English video removed from Horizontal Autoscaling node

### DIFF
--- a/src/data/roadmaps/kubernetes/content/109-autoscaling/100-horizontal-pod-autoscaler.md
+++ b/src/data/roadmaps/kubernetes/content/109-autoscaling/100-horizontal-pod-autoscaler.md
@@ -5,4 +5,3 @@ It is a feature in Kubernetes that automatically scales the number of replicas o
 Learn more from the following resources:
 
 - [Horizontal Pod Autoscaling - Documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-- [Kubernetes Horizontal Pod Autoscaling - Kubernetes Tutorials](https://www.youtube.com/watch?v=hm3jnETOoFo)


### PR DESCRIPTION
The Youtube video linked for Horizontal Autoscaling was not English which goes against our contribution guidelines.

Content before:
- [Horizontal Pod Autoscaling - Documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
- [Kubernetes Horizontal Pod Autoscaling - Kubernetes Tutorials](https://www.youtube.com/watch?v=hm3jnETOoFo)

Content after:
- [Horizontal Pod Autoscaling - Documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)

Todo: Find/Create a good Horizontal Autoscaling video.