### PR TITLE
Add Boot.dev's "Learn python" course to relevant roadmaps

### DIFF
--- a/src/data/roadmaps/backend/content/103-learn-a-language/106-python.md
+++ b/src/data/roadmaps/backend/content/103-learn-a-language/106-python.md
@@ -16,3 +16,4 @@ Visit the following resources to learn more:
 - [An Introduction to Python for Non-Programmers](https://thenewstack.io/an-introduction-to-python-for-non-programmers/)
 - [Getting Started with Python and InfluxDB](https://thenewstack.io/getting-started-with-python-and-influxdb/)
 - [Python for Beginners - Learn Python in 1 Hour](https://www.youtube.com/watch?v=kqtD5dpn9C8&ab_channel=ProgrammingwithMosh)
+- [Learn Python | Boot.dev](https://boot.dev/learn/learn-python)

--- a/src/data/roadmaps/computer-science/content/101-pick-a-language/103-python.md
+++ b/src/data/roadmaps/computer-science/content/101-pick-a-language/103-python.md
@@ -15,3 +15,4 @@ Visit the following resources to learn more:
 - [Codecademy - Learn Python 2](https://www.codecademy.com/learn/learn-python)
 - [An Introduction to Python for Non-Programmers](https://thenewstack.io/an-introduction-to-python-for-non-programmers/)
 - [Getting Started with Python and InfluxDB](https://thenewstack.io/getting-started-with-python-and-influxdb/)
+- [Learn Python | Boot.dev](https://boot.dev/learn/learn-python)


### PR DESCRIPTION
This adds the ["Learn Python" course](https://boot.dev/learn/learn-python) from Boot.dev to relevant roadmaps.

You can freely access all content without registering on Boot.dev. By clicking the "browse the lessons" link, users get access to 186 python lessons.