### PR TITLE
Removed casino link from Image Optimization Content

### DIFF
--- a/src/data/best-practices/frontend-performance/content/compress-your-images.md
+++ b/src/data/best-practices/frontend-performance/content/compress-your-images.md
@@ -10,7 +10,6 @@ Optimized images load faster in your browser and consume less data.
 - Use a tool and specify a level compression under 85.
 
 - [Image Optimization](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization)
-- [Essential Image Optimization](https://images.guide/)
 - [TinyJPG – Compress JPEG images intelligently](https://tinyjpg.com/)
 - [Kraken.io - Online Image Optimizer](https://kraken.io/web-interface)
 - [Compressor.io](https://compressor.io/compress)


### PR DESCRIPTION
A previously useful linke (image.guide) is now linking to a casino website.

I have removed this link.