### PR TITLE
Added warning to Vue CLI regarding its maintenance mode

### DIFF
--- a/src/data/roadmaps/vue/content/100-fundamental-topics/100-vue-cli.md
+++ b/src/data/roadmaps/vue/content/100-fundamental-topics/100-vue-cli.md
@@ -1,5 +1,7 @@
 # Vue CLI
 
+> ⚠️ **\[Warning]** Vue CLI is now in maintenance mode. For new projects, please use [create-vue](<https://github.com/vuejs/create-vue>) to scaffold [Vite](<https://vitejs.dev/>)-based projects.
+
 Vue CLI is a full system for rapid Vue.js development, providing:
 
 - Interactive project scaffolding via `@vue/cli`.


### PR DESCRIPTION
Dear Developers,

Thank you very much for the awesome resource and project!

The `create-vue` recommendation was added [2 years](<https://github.com/vuejs/vue-cli/commit/7c0134e653a0f58315ac9b06e940a5c5928b8b0b>) ago by Evan You, and it feels like it must be stated in the feature description here, too.

Best and kind regards :sparkles: 