### PR TITLE
Fixed link display of 101-why-rust.md

### DIFF
--- a/src/data/roadmaps/rust/content/100-introduction/101-why-rust.md
+++ b/src/data/roadmaps/rust/content/100-introduction/101-why-rust.md
@@ -2,5 +2,5 @@
 
 Rust is a systems programming language that aims to provide memory safety, concurrency, and performance with a focus on zero cost abstractions. It was originally created by Graydon Hoare at Mozilla Research, with contributions from Brendan Eich, the creator of JavaScript. Rust is appreciated for the solutions it provides to common programming language issues. Its emphasis on safety and speed, the support for concurrent programming, along with a robust type system are just a few reasons why developers choose Rust.
     
-    - [Convince your boss to use Rust](https://www.youtube.com/playlist?list=PLZaoyhMXgBzqkaLKR8HHWZaASMvW4gRtZ)
-    - [Rust in 100 seconds](https://www.youtube.com/watch?v=5C_HPTJg5ek&pp=ygUNcnVzdCBmaXJlYmFzZQ%3D%3D)
+- [Convince your boss to use Rust](https://www.youtube.com/playlist?list=PLZaoyhMXgBzqkaLKR8HHWZaASMvW4gRtZ)
+- [Rust in 100 seconds](https://www.youtube.com/watch?v=5C_HPTJg5ek&pp=ygUNcnVzdCBmaXJlYmFzZQ%3D%3D)


### PR DESCRIPTION
Unnecessary tabs makes markdown render them as "code" instead of links

(Thank you so much for this website btw)

# Currently Looks like this on website

<img width="599" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/59707554/b4560112-2edf-48ff-a493-a5cc50e785b9">


# Before

<img width="1045" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/59707554/2ba5dd89-7f49-4753-86de-76d6c37cd749">

# After

<img width="1004" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/59707554/66ab5880-93be-4637-9baa-b42546761ef3">
