### PR TITLE
add documentation links to data-structure pages

### DIFF
--- a/src/data/roadmaps/rust/content/101-language-basics/102-constructs/102-traits.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/102-constructs/102-traits.md
@@ -1,3 +1,7 @@
 # Traits
 
 Traits in Rust programming language define shared behaviors. They are a way to group method signatures together to define a set of behaviors required by a type. Anything with a certain trait will have the behavior of that trait's methods. Traits are abstract, and it's not possible as such to create instances of traits. However, we can define pointers of trait types, and these can hold any implementer of the trait. A trait is implemented for something else, which can be a concrete type or another trait.
+
+Learn more from the following links:
+
+- [Traits: Defining Shared Behaviour](https://doc.rust-lang.org/book/ch10-02-traits.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/106-vector.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/106-vector.md
@@ -1,3 +1,7 @@
 # Vector
 
 A `Vector` in Rust, often referred to as `Vec`, is a growable, or dynamically-sized, array-like data structure that can store homogeneous types. It stores elements of the same type in a contiguous block of memory, with the count of elements and capacity managed automatically by Rust. Unlike arrays, vectors do not need to have a predetermined size at compile time and their size can be increased or decreased at runtime. The `Vec<T>` holds its data on the heap. It maintains a pointer to the data, a length, and a capacity. The length is the number of elements currently stored in the vector, while the capacity is the total allocation in the memory. The key methods for a `Vec<T>` include `push()`, `pop()`, and `len()`, among others.
+
+Learn more from the following links:
+
+- [Storing Lists of Values with Vectors](https://doc.rust-lang.org/book/ch08-01-vectors.html?highlight=vector#storing-lists-of-values-with-vectors)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/107-string.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/107-string.md
@@ -1,3 +1,7 @@
 # String
 
 In Rust, `String` is a growable, mutable, owned, UTF-8 encoded string type. When Rustaceans refer to 'strings' in Rust, they usually mean the `String` and the string slice `str` types, not just one of those types. Both types are UTF-8 encoded. A `String` in Rust is similar to a string in other languages, but is not null-terminated at the end. Creation of a `String` can be done from a literal string with `String::from("Hello, world!")` or by converting a string slice with `"Hello, world!".to_string()`. String concatenations and manipulations are achieved via a multitude of methods such as `push_str()`, `push()`, `+` operator, `format!()` macro, etc.
+
+Learn more from the following links:
+
+- [What Is a String?](https://doc.rust-lang.org/book/ch08-02-strings.html?highlight=String#what-is-a-string)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/108-hashmap.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/108-hashmap.md
@@ -1,3 +1,7 @@
 # Hashmap
 
 The `HashMap` in Rust is part of the standard library's collections framework and it's a generic collection of key-value pairs. It allows for the quick lookup, insertion, and removal of items using hashing. A `HashMap<K, V>` holds a mapping of keys of type `K` to values of type `V`. The keys are unique and when a key gets inserted for the second time with a different value, the new value replaces the old value. Rust's `HashMap` uses a cryptographically strong hashing algorithm which can help avoid denial-of-service (DoS) attacks. It is however not ordered, so items may not be in the same order as they were inserted.
+
+Learn more from the following links:
+
+- [Storing Keys With Associated Values In Hash Maps](https://doc.rust-lang.org/book/ch08-03-hash-maps.html?highlight=hashmap#storing-keys-with-associated-values-in-hash-maps)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/109-hashset.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/109-hashset.md
@@ -1,3 +1,7 @@
 # Hashset
 
 `HashSet` in Rust is a collection of unique elements. It's a data structure which stores details in the form of key and value, and it uses `hashing` to store elements. It's implemented as a `hash table`, as it makes use of a hasher to make the structure more secure against collision attacks. A `HashSet` only contains keys, associating the value portion of the map with a dummy unit. The value of `HashSet` returns an iterator over the elements of the set and these elements are arbitrary and not in any specific order.
+
+Learn more from the following links:
+
+- [Hashset](https://doc.rust-lang.org/rust-by-example/std/hash/hashset.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/110-linked-list.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/110-linked-list.md
@@ -1,3 +1,7 @@
 # LinkedList
 
 The **Linked List** in Rust is a sequence of nodes where each node consists of a value and a pointer/reference to the next node in the sequence. Linked Lists are primarily used for implementing higher level data structures such as stacks, queues and associative arrays. Rust's `std::collections` provides a `LinkedList` struct that is a doubly-linked list with O(1) insertion and removal at both the front and back, but with O(n) indexing.
+
+Learn more from the following links:
+
+- [LinkedList](https://doc.rust-lang.org/std/collections/struct.LinkedList.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/111-binary-heap.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/111-binary-heap.md
@@ -1,3 +1,7 @@
 # BinaryHeap
 
 A `Binary Heap` is a complete binary tree which is either Min Heap or Max Heap. In a Max Binary Heap, the key at root must be maximum among all other keys present in Binary Heap. The same property must be recursively true for all nodes in Binary Tree. Min Binary Heap is similar to Max Binary Heap. But in a Min Binary Heap, the key at root must be minimum among all other keys present in Binary Heap. This property must be recursively true for all nodes in Binary Tree. Binary Heaps have efficient implementations on arrays.
+
+Learn more from the following links:
+
+- [BinaryHeap](https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/112-stack.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/112-stack.md
@@ -1,3 +1,7 @@
 # Stack
 
 The **Stack** is a fundamental data structure in Rust, which is based on the principle of Last-In-First-Out (LIFO). In other words, elements that are added last are the first ones to be removed. This is functionally similar to a real-world stack, such as a stack of plates. One key aspect of stacks in Rust is that they are bounded to a certain size at compile-time. This implies that stack size does not grow or shrink dynamically. In Rust, function calls are operated using stack with each call pushing a new stack frame to the end, and each return statement popping one off. Stack Overflow occurs when too much of the stack is used.
+
+Learn more from the following links:
+
+- [Box, Stack and Heap](https://doc.rust-lang.org/rust-by-example/std/box.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/113-queue.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/113-queue.md
@@ -1,3 +1,7 @@
 # Queue
 
 In Rust, a Queue is another important linear data structure which follows a particular order in which the operations are performed. The order given to the elements follows the FIFO (First In First Out) approach. There are no direct standard library data structures meant solely to act as a Queue in Rust, but we can obtain queue-like behaviors using other provided data structures. More commonly, the VecDeque structure is used as a Queue. It supports constant time element insertion and removal at both ends. The 'push_back' and 'pop_front' functions essentially form a Queue structure.
+
+Learn more from the following links:
+
+- [Queues](https://docs.rs/queues/latest/queues/)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/114-btree-map.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/114-btree-map.md
@@ -1,3 +1,7 @@
 # BTreeMap
 
 In Rust, `BTreeMap` is a generic collection that stores data in a sorted tree structure. More specifically, it uses a self-balancing binary search tree (a type of `B+-tree`). `BTreeMap`s implement the `Map` trait, including methods such as `get`, `insert`, `remove`, and many others. The data stored in a `BTreeMap` will be sorted by key, which allows efficient lookup, insertions, and removals. The keys of the `BTreeMap` must implement the `Ord` trait, which means they must be orderable. Because `BTreeMap`s store data in a sorted order, the iteration of keys and values will be in sorted order as well.
+
+Learn more from the following links:
+
+- [BTreeMap](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/115-btree-set.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/115-btree-set.md
@@ -1,3 +1,7 @@
 # BTreeSet
 
 `BTreeSet` in Rust is a data structure that implements a set backed by a BTree. Its functionality is similar to that of other set data structures in that it maintains a collection of unique elements and allows for operations like insertion, removal, and querying. But the elements in a `BTreeSet` are sorted according to an ordering relation, which may be customized by the user. The sorting enables efficient range queries as well as other operations such as finding the minimum or maximum element.
+
+Learn more from the following links:
+
+- [Btree Set](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/116-rc.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/116-rc.md
@@ -1,3 +1,7 @@
 # Rc
 
 `Rc` stands for Reference Counting, a data type in Rust that allows multiple owners for the same data on the heap while keeping track of the number of references to that data. If there are zero references to data, the value can be cleaned up without any references becoming invalid. Avoiding these problems comes at the cost of some memory overhead, because `Rc` keeps track of the total number of references which means it needs to allocate memory to keep the count.
+
+Learn more from the following links:
+
+- [rct - The Reference Counted Smart Pointer](https://doc.rust-lang.org/book/ch15-04-rc.html#rct-the-reference-counted-smart-pointer)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/117-arc.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/117-arc.md
@@ -1,3 +1,7 @@
 # Arc
 
 `Arc` in Rust stands for "Atomic Reference Counting". It is a thread-safe reference-counting type used for sharing immutable data between multiple parts of the system. With `Arc`, we can have multiple references to the same data which is useful for concurrent programming. When the last reference to a type is gone, the `Arc` will clean up the underlying data. Unlike `Rc` (Reference Counting), which is single-threaded, `Arc` uses atomic operations for incrementing and decrementing the reference count hence making it safe to share across threads.
+
+Learn more from the following links:
+
+- [Arc](https://doc.rust-lang.org/rust-by-example/std/arc.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/118-mutex.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/118-mutex.md
@@ -1,3 +1,7 @@
 # Mutex
 
 `Mutex` or "Mutual Exclusion" in Rust is a concurrency primitive that is used to protect shared data from being concurrently accessed by multiple threads. When one thread starts using a `Mutex`, other threads have to wait until the Mutex is unlocked. When a thread has finished handling the shared data, it should unlock the `Mutex` to allow other threads to access the shared data. If not properly handled, it could lead to a software deadlock or other timing-related issues. Rust's Mutex has a built-in safeguard against these problems – if a thread that is holding a Mutex crashes, Rust will automatically unlock the Mutex.
+
+Learn more from the following links:
+
+- [Mutex](https://doc.rust-lang.org/std/sync/struct.Mutex.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/119-rwlock.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/119-rwlock.md
@@ -1,3 +1,7 @@
 # RwLock
 
 `RwLock` in Rust stands for Read/Write lock, which is a type of synchronization primitive. It is an advanced version of the Mutex data structure. Unlike Mutex, which only allows one thread to access the data, `RwLock` allows multiple threads to read data at the same time but only one thread to write. If a thread is writing, no other thread can read or write. The syntax for declaring `RwLock` is `let lock = RwLock::new(value)`. Please remember that a potential downside of `RwLock` is lock contention, making sure to properly manage read-write access. The appropriate use of `RwLock` can enable better performance for workloads that involve heavy reading.
+
+Learn more from the following links:
+
+- [RwLock](https://doc.rust-lang.org/std/sync/struct.RwLock.html)

--- a/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/120-channels.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/103-data-structures/120-channels.md
@@ -1,3 +1,7 @@
 # Channels
 
 Channels in Rust allow communication between threads. They are a programming paradigm that is part of the message passing concurrency model. Channels are used to send and receive values between threads, ensuring thread safety by avoiding shared state. Rust channels have two parts - `Sender` and `Receiver`. `Sender` is used for sending data, and `Receiver` is used to read the data. This model follows the 'multiple producer, single consumer' rule, meaning it can have multiple sending ends but only one receiving end. Channels in Rust are provided by the `std::sync::mpsc` module, where mpsc stands for Multiple Producer, Single Consumer.
+
+Learn more from the following links:
+
+- [Channels](https://doc.rust-lang.org/rust-by-example/std_misc/channels.html)


### PR DESCRIPTION
Several data structure pages were missing content, I have added the official documentation for each structure.