### PR TITLE
Update artifacts spelling mistake

### DIFF
--- a/src/data/roadmaps/devops/content/118-artifcats/index.md
+++ b/src/data/roadmaps/devops/content/118-artifcats/index.md
@@ -1,1 +1,1 @@
-# Artifcats
+# Artifacts


### PR DESCRIPTION
Just a small spelling mistake fix on the DevOps Roadmap:
Artifcats ->Artifacts