### PR TITLE
Move Flutter and React Native to Skill-based roadmap

### DIFF
--- a/src/components/Roadmaps/RoadmapsPage.tsx
+++ b/src/components/Roadmaps/RoadmapsPage.tsx
@@ -229,12 +229,12 @@ const groups: GroupType[] = [
       {
         title: 'React Native',
         link: '/react-native',
-        type: 'role',
+        type: 'skill',
       },
       {
         title: 'Flutter',
         link: '/flutter',
-        type: 'role',
+        type: 'skill',
       },
     ],
   },

--- a/src/data/roadmaps/flutter/flutter.md
+++ b/src/data/roadmaps/flutter/flutter.md
@@ -53,5 +53,5 @@ sitemap:
 tags:
   - 'roadmap'
   - 'main-sitemap'
-  - 'role-roadmap'
+  - 'skill-roadmap'
 ---

--- a/src/data/roadmaps/react-native/react-native.md
+++ b/src/data/roadmaps/react-native/react-native.md
@@ -51,5 +51,5 @@ sitemap:
 tags:
   - 'roadmap'
   - 'main-sitemap'
-  - 'role-roadmap'
+  - 'skill-roadmap'
 ---


### PR DESCRIPTION
## Objective:

- Should be able to see `Flutter` and `React Native` under **skill-based roadmaps**

## Description:

- Updated Flutter and ReactNative from role to skill based skills in RoadmapsPage.tsx, flutter.md and react-native.md files

## How to test:

- If you go to `home page` of roadmap and `/roadmaps` -> `All Roadmaps`
- You could see both of them under `SKILL BASED ROADMAPS`

## Screenshots:

**Home screen**
<img width="1334" alt="Screenshot 2024-05-16 at 9 19 22 AM" src="https://github.com/kamranahmedse/developer-roadmap/assets/41512228/802ce51f-9a4d-4f13-9e93-2f1dd723fae9">

**All roadmaps screen**
<img width="1272" alt="Screenshot 2024-05-16 at 9 20 06 AM" src="https://github.com/kamranahmedse/developer-roadmap/assets/41512228/dd22545b-ecd7-41df-ac9a-fa551c23663e">

