### PR TITLE
fixing typo Angular 101-why-use-typescript.md

### DIFF
--- a/src/data/roadmaps/angular/content/100-typescript-basics/101-why-use-typescript.md
+++ b/src/data/roadmaps/angular/content/100-typescript-basics/101-why-use-typescript.md
@@ -3,7 +3,7 @@
 TypeScript extends JavaScript, providing a better developer experience. The benefits of using TypeScript over JavaScript include:
 - **Static typing** – TypeScript comes with optional static typing and a type inference system, which means that a variable declared with no type may be inferred by TypeScript based on its value.
 - **Object-oriented programming** – TypeScript supports object-oriented programming concepts like classes, inheritance, etc.
-- **ompile time checks** – JavaScript is an interpreted programming language. There is no compilation involved. Hence, the errors get caught during the runtime. Since TypeScript compiles into JavaScript, errors get reported during the compile time rather than the runtime.
+- **Compile time checks** – JavaScript is an interpreted programming language. There is no compilation involved. Hence, the errors get caught during the runtime. Since TypeScript compiles into JavaScript, errors get reported during the compile time rather than the runtime.
 - **Code editor support** – IDEs or code editors like VS Code support autocomplete for a TypeScript codebase. They also provide inline documentation and highlight the errors.
 - **Integration with existing JavaScript Packages** – You might want to use an npm package written in JavaScript. Since TypeScript is a superset of JavaScript, you can import and use that package. Moreover, the TypeScript community creates and maintains type definitions for popular packages that can be utilized in your project.
 


### PR DESCRIPTION
In the doc, there was a typo, where, a 'C' was missing in the word 'compile'.