### PR TITLE
const_cast not modify original_value

### DIFF
--- a/src/data/roadmaps/cpp/content/109-language-concepts/101-type-casting/101-const-cast.md
+++ b/src/data/roadmaps/cpp/content/109-language-concepts/101-type-casting/101-const-cast.md
@@ -9,6 +9,7 @@ Keep in mind that using `const_cast` to modify a truly `const` variable can lead
 Here's a code example showing how to use `const_cast`:
 
 ```cpp
+#include <cassert>
 #include <iostream>
 
 void modifyVariable(int* ptr) {
@@ -21,10 +22,13 @@ int main() {
     std::cout << "Original value: " << original_value << std::endl;
 
     modifyVariable(non_const_value_ptr);
-    std::cout << "Modified value: " << *non_const_value_ptr << std::endl;
+    std::cout << "Modified value: " << *non_const_value_ptr << ", original_value: " << original_value << std::endl;
+
+    assert(non_const_value_ptr == &original_value);
 
     return 0;
 }
+
 ```
 
 In this example, we first create a `const` variable, `original_value`. Then we use `const_cast` to remove the constness of the variable and assign it to a non-const pointer, `non_const_value_ptr`. The `modifyVariable` function takes an `int*` as an argument and modifies the value pointed to by the pointer, which would not have been possible if we passed the original `const int` directly. Finally, we print the `original_value` and the `*non_const_value_ptr`, which shows that the value has been modified using `const_cast`.


### PR DESCRIPTION
Additional printing information is used to tell the user that after conversion and modification through const_cast, although the memory address has not changed and the non_const_value_ptr has changed, the original_value has not changed.

output
```
Original value: 10
Modified value: 42, original_value: 10
```