### PR TITLE
remove all varvy links

### DIFF
--- a/src/data/best-practices/frontend-performance/content/avoid-404-files.md
+++ b/src/data/best-practices/frontend-performance/content/avoid-404-files.md
@@ -4,4 +4,4 @@
 
 404 request can slow down the performance of your website and negatively impact the user experience. Additionally, they can also cause search engines to crawl and index non-existent pages, which can negatively impact your search engine rankings. To avoid 404 requests, ensure that all links on your website are valid and that any broken links are fixed promptly.
 
-- [How to avoid Bad Requests?](https://varvy.com/pagespeed/avoid-bad-requests.html)
+- [404 Not Found Overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404)

--- a/src/data/best-practices/frontend-performance/content/avoid-base64-images.md
+++ b/src/data/best-practices/frontend-performance/content/avoid-base64-images.md
@@ -17,4 +17,3 @@ Instead of using Base64 encoded images, it is generally recommended to use binar
 - [Base64 Encoding & Performance, Part 1 and 2 by Harry Roberts](https://csswizardry.com/2017/02/base64-encoding-and-performance/)
 - [A closer look at Base64 image performance – The Page Not Found Blog](http://www.andygup.net/a-closer-look-at-base64-image-performance/)
 - [When to base64 encode images (and when not to) | David Calhoun](https://www.davidbcalhoun.com/2011/when-to-base64-encode-images-and-when-not-to/)
-- [Base64 encoding images for faster pages | Performance and seo factors](https://varvy.com/pagespeed/base64-images.html)

--- a/src/data/best-practices/frontend-performance/content/keep-ttfb-less-1-3s.md
+++ b/src/data/best-practices/frontend-performance/content/keep-ttfb-less-1-3s.md
@@ -4,5 +4,4 @@ Reduce as much as you can the time your browser waits before receiving data.
 
 - [What is Waiting (TTFB) in DevTools, and what to do about it](https://scaleyourcode.com/blog/article/27)
 - [Monitoring your servers with free tools is easy](https://scaleyourcode.com/blog/article/7)
-- [Time to First Byte (TTFB)](https://varvy.com/pagespeed/ttfb.html)
 - [Global latency testing tool](https://latency.apex.sh)

--- a/src/data/best-practices/frontend-performance/content/use-http-cache-headers.md
+++ b/src/data/best-practices/frontend-performance/content/use-http-cache-headers.md
@@ -2,4 +2,4 @@
 
 Set HTTP headers to avoid expensive number of roundtrips between your browser and the server.
 
-- [Using cache-control for browser caching](https://varvy.com/pagespeed/cache-control.html)
+- [HTTP Caching Overview](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching)

--- a/src/data/best-practices/frontend-performance/content/use-non-blocking-javascript.md
+++ b/src/data/best-practices/frontend-performance/content/use-non-blocking-javascript.md
@@ -16,4 +16,3 @@ JavaScript blocks the normal parsing of the HTML document, so when the parser re
 - If you have small scripts, maybe use inline script place above async scripts.
 
 - [Remove Render-Blocking JavaScript](https://developers.google.com/speed/docs/insights/v5/get-started)
-- [Defer loading JavaScript](https://varvy.com/pagespeed/defer-loading-javascript.html)


### PR DESCRIPTION
All links from varvy.com are dead and redirect to a gambling website.
Where removing the link left no content, I have replaced it with mdn docs on the topic.