### PR TITLE
Remove '!' from youtube links

### DIFF
--- a/src/data/roadmaps/datastructures-and-algorithms/content/103-basic-data-structures/100-array.md
+++ b/src/data/roadmaps/datastructures-and-algorithms/content/103-basic-data-structures/100-array.md
@@ -2,11 +2,11 @@
 
 An array is a linear data structure that can hold elements and arrange them. It uses contiguous memory space to store elements. In an array, we can directly access any element based on its index which makes it an efficient data structure. Arrays have two types: one-dimensional and multi-dimensional. In a one-dimensional array, data is stored in a linear form while a multi-dimensional array can store data in the form of a matrix or in 3-D format.
 
-- [Arrays in Python](!https://www.youtube.com/watch?v=gDqQf4Ekr2A&ab_channel=codebasics)
-- [Arrays in Java](!https://www.youtube.com/watch?v=ei_4Nt7XWOw&ab_channel=BroCode)
-- [Arrays in Javascript](!https://www.youtube.com/watch?v=yQ1fz8LY354)
-- [Arrays in GoLang](!https://www.youtube.com/watch?v=e-oBn806Pzc&pp=ygUIYXJyYXkgZ28%3D)
-- [Arrays in C#](!https://www.youtube.com/watch?v=YiE0oetGMAg&pp=ygUIYXJyYXkgYyM%3D)
-- [Arrays in C++](!https://www.youtube.com/watch?v=G38hQKXa_RU&pp=ygUJYXJyYXkgYysr)
-- [Arrays in Rust](!https://www.youtube.com/watch?v=cH6Qv47MPwk&pp=ygUKYXJyYXkgcnVzdA%3D%3D)
-- [Arrays in Ruby](!https://www.youtube.com/watch?v=SP3Vf2KcYeU&pp=ygUKYXJyYXkgcnVieQ%3D%3D)
+- [Arrays in Python](https://www.youtube.com/watch?v=gDqQf4Ekr2A&ab_channel=codebasics)
+- [Arrays in Java](https://www.youtube.com/watch?v=ei_4Nt7XWOw&ab_channel=BroCode)
+- [Arrays in Javascript](https://www.youtube.com/watch?v=yQ1fz8LY354)
+- [Arrays in GoLang](https://www.youtube.com/watch?v=e-oBn806Pzc&pp=ygUIYXJyYXkgZ28%3D)
+- [Arrays in C#](https://www.youtube.com/watch?v=YiE0oetGMAg&pp=ygUIYXJyYXkgYyM%3D)
+- [Arrays in C++](https://www.youtube.com/watch?v=G38hQKXa_RU&pp=ygUJYXJyYXkgYysr)
+- [Arrays in Rust](https://www.youtube.com/watch?v=cH6Qv47MPwk&pp=ygUKYXJyYXkgcnVzdA%3D%3D)
+- [Arrays in Ruby](https://www.youtube.com/watch?v=SP3Vf2KcYeU&pp=ygUKYXJyYXkgcnVieQ%3D%3D)


### PR DESCRIPTION
All the youtube links had `!` before the URLs