### PR TITLE
Correct link for Expo CLI Quickstart

### DIFF
--- a/src/data/roadmaps/react-native/content/102-environment-setup/100-expo/index.md
+++ b/src/data/roadmaps/react-native/content/102-environment-setup/100-expo/index.md
@@ -2,4 +2,4 @@
 
 Expo is a framework and a platform that allows you to develop, build, and deploy React Native applications easily and quickly. It simplifies the development process and provides a set of useful tools and services, including its own CLI (Command Line Interface), a managed workflow, and an SDK (Software Development Kit) with pre-built modules for common features.
 
-Visit the [Expo CLI Quickstart](https://reactnative.dev/docs/environment-setup) page for detailed instructions on how to set up your environment.
+Visit the [Expo CLI Quickstart](https://docs.expo.dev/get-started/create-a-project/) page for detailed instructions on how to set up your environment.

--- a/src/data/roadmaps/react-native/content/102-environment-setup/index.md
+++ b/src/data/roadmaps/react-native/content/102-environment-setup/index.md
@@ -6,7 +6,7 @@ In React Native, setting up the development environment is a crucial step. The e
 
 Expo CLI is a command-line tool built for creating and managing React Native projects easily. It streamlines your development process by providing an entire development environment, including building and deploying your app to both iOS and Android platforms.
 
-Visit the [Expo CLI Quickstart](https://reactnative.dev/docs/environment-setup) page for detailed instructions on how to set up your environment.
+Visit the [Expo CLI Quickstart](https://docs.expo.dev/get-started/create-a-project) page for detailed instructions on how to set up your environment.
 
 ## React Native CLI
 


### PR DESCRIPTION
The Expo CLI Quickstart links to the React Native CLI quickstart. This PR fixes that.