### PR TITLE
docs(frontend-performance): fix 'cssnano' website link

### DIFF
--- a/src/data/best-practices/frontend-performance/content/minify-css.md
+++ b/src/data/best-practices/frontend-performance/content/minify-css.md
@@ -6,7 +6,7 @@ When CSS files are minified, the content is loaded faster and less data is sent 
 
 Use tools to minify your files automatically before or during your build or your deployment.
 
-- [cssnano: A modular minifier based on the PostCSS ecosystem. - cssnano](https://cssnano.co/)
+- [cssnano: A modular minifier based on the PostCSS ecosystem. - cssnano](https://cssnano.github.io/cssnano/)
 - [CSS Minifier](https://goonlinetools.com/css-minifier/)
 - [@neutrinojs/style-minify - npm](https://www.npmjs.com/package/@neutrinojs/style-minify)
 - [Online CSS Compressor](http://refresh-sf.com)


### PR DESCRIPTION
cssnano website now has been changed: https://cssnano.github.io/cssnano/. The before link: https://cssnano.co/ is Invalid

![image](https://github.com/kamranahmedse/developer-roadmap/assets/44056372/4d688268-9446-4244-a259-6bc9489ddb70)
