### PR TITLE
Highlight teams on mobile view

### DIFF
--- a/src/components/Navigation/Navigation.astro
+++ b/src/components/Navigation/Navigation.astro
@@ -17,10 +17,10 @@ import { AccountDropdown } from './AccountDropdown';
       </a>
 
       <a
-          href='/ai'
+          href='/teams'
           class='group inline sm:hidden relative !mr-2 text-blue-300 hover:text-white'
       >
-        AI Roadmaps&nbsp;
+        Teams
 
         <span class='absolute -right-[11px] top-0'>
             <span class='relative flex h-2 w-2'>


### PR DESCRIPTION
Previously we highlighted "teams" on desktop view only and missed highlighting it on mobile view.

<img width="448" alt="Screenshot 2024-05-28 at 09 17 33" src="https://github.com/kamranahmedse/developer-roadmap/assets/25537601/e693ba02-9312-4e04-a434-8c137c703ff7">
