### PR TITLE
fix: correct spelling from "Synatx" to "Syntax"

### DIFF
--- a/src/data/roadmaps/java/content/100-java-fundamentals/107-loops.md
+++ b/src/data/roadmaps/java/content/100-java-fundamentals/107-loops.md
@@ -2,7 +2,7 @@
 
 In Java and other programming languages, loops are used to iterate a part of the program several times. There are four types of loops in Java, `for`, `forEach`, `while`, and `do...while`.
 
-- Synatx of `for` loop is `for(initialization;condition;increment/decrement){}`
+- Syntax of `for` loop is `for(initialization;condition;increment/decrement){}`
 - Syntax of `forEach` loop is `for(data_type variable:array_name){}`
 
 Visit the following resources to learn more:


### PR DESCRIPTION
Changed the spelling from "Synatx" to "Syntax" to improve readability and maintain consistency across the topic.