### PR TITLE
Added Video Resources for Component's in React Roadmap

### DIFF
--- a/src/data/roadmaps/react/content/102-components/100-class-components.md
+++ b/src/data/roadmaps/react/content/102-components/100-class-components.md
@@ -10,3 +10,4 @@ Visit the following resources to learn more:
 - [Is There Any Reason to Still Use React Class Components?](https://medium.com/geekculture/is-there-any-reason-to-still-use-react-class-components-9b6a1e6aa9ef)
 - [Functional Components vs Class Components in React](https://www.freecodecamp.org/news/functional-components-vs-class-components-in-react)
 - [Migrate Class Components to Functional Components with Hooks in React](https://www.robinwieruch.de/react-hooks-migration/)
+- [React Class Components Tutorial](https://www.youtube.com/watch?v=lnV34uLEzis)

--- a/src/data/roadmaps/react/content/102-components/101-functional-components.md
+++ b/src/data/roadmaps/react/content/102-components/101-functional-components.md
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 - [Your first component](https://react.dev/learn/your-first-component)
 - [Passing props to a component](https://react.dev/learn/passing-props-to-a-component)
 - [Functional Components in React](https://www.robinwieruch.de/react-function-component/)
+- [React JS Functional Components](https://www.youtube.com/watch?v=NJ_qbsLf52w)

--- a/src/data/roadmaps/react/content/102-components/index.md
+++ b/src/data/roadmaps/react/content/102-components/index.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [Creating and nesting components](https://react.dev/learn#components)
 - [Explore the different types of components in React](https://www.robinwieruch.de/react-component-types/)
 - [What is the difference between components, elements, and instances?](https://www.robinwieruch.de/react-element-component/)
+- [Components & Templates in React](https://www.youtube.com/watch?v=9D1x7-2FmTA)


### PR DESCRIPTION
We are missing video resources for some topics, which are sometimes more helpful. I've added some for the Components topic.