### PR TITLE
Update resource link for OOP section

### DIFF
--- a/src/data/roadmaps/software-design-architecture/content/102-object-oriented-programming/index.md
+++ b/src/data/roadmaps/software-design-architecture/content/102-object-oriented-programming/index.md
@@ -4,5 +4,5 @@ Object-oriented programming (OOP) is a programming paradigm that is based on the
 
 Learn more from the following links:
 
-- [@article@Discover Object Oriented Programming](https://blog.hubspot.com/website/object-oriented-programming)
+- [@article@Discover Object Oriented Programming](https://opendsa.cs.vt.edu/ODSA/Books/Everything/html/IntroOO.html)
 - [@video@Software Development Tutorial - What is object-oriented language?s](https://www.youtube.com/watch?app=desktop&v=SS-9y0H3Si8)


### PR DESCRIPTION
One of the links for the introduction to object oriented programming no longer leads to the site it used to but to an unrelated one, I found a link I think would be suitable for this.