### PR TITLE
Fix answer for backend question about containerization

### DIFF
--- a/src/data/question-groups/backend/backend.md
+++ b/src/data/question-groups/backend/backend.md
@@ -61,7 +61,7 @@ questions:
     topics:
       - 'Beginner'
   - question: What is containerization, and how does it benefit backend development?
-    answer: statelessness-http.md
+    answer: containerization.md
     topics:
       - 'Beginner'
   - question: What measures would you take to secure a newly developed API?


### PR DESCRIPTION
# Issue

Answer for _"What is containerization, and how does it benefit backend development?"_ points to `statelessness-http.md`. On the [page](https://roadmap.sh/questions/backend) it looks like this:

<img width="682" alt="image" src="https://github.com/kamranahmedse/developer-roadmap/assets/16839849/b4a5df81-d2a8-444c-b039-a0a0d2591dcc">

# Fix

Use existing `containerization.md` instead of `statelessness-http.md`