### PR TITLE
Add missing space to about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -14,7 +14,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         />
         <div>
           <h1 class='text-3xl sm:text-4xl mb-3 font-bold'>
-            <span class='hidden sm:inline'>Hello,</span>I am Kamran Ahmed
+            <span class='hidden sm:inline'>Hello,</span>&nbsp;I am Kamran Ahmed
           </h1>
           <p class='text-gray-500 text-md mb-5'>
             I created roadmap.sh to help developers find their path if they are


### PR DESCRIPTION
Added a missing whitespace to the About page

![Screenshot 2024-06-25 at 09 21 17](https://github.com/kamranahmedse/developer-roadmap/assets/18466481/b4314006-0d59-4846-a230-c358922e1cc8)
