### PR TITLE
Java roadmap: jvm clarifications

### DIFF
--- a/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
+++ b/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
@@ -7,6 +7,6 @@ Visit the following resources to learn more:
 - [@article@What is JVM & architecture?](https://www.freecodecamp.org/news/jvm-tutorial-java-virtual-machine-architecture-explained-for-beginners/)
 - [@article@Introducing the Java Virtual Machine](https://www.infoworld.com/article/3272244/what-is-the-jvm-introducing-the-java-virtual-machine.html)
 - [@video@How JVM works?](https://youtu.be/G1ubVOl9IBw)
-- [@feed@Explore top posts about JVM](https://app.daily.dev/tags/jvm?ref=roadmapsh)
 - [@article@JVM languages](https://www.whizlabs.com/blog/jvm-languages/)
 - [@article@ GraalVM](https://www.graalvm.org/)
+- [@feed@Explore top posts about JVM](https://app.daily.dev/tags/jvm?ref=roadmapsh)

--- a/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
+++ b/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
@@ -1,14 +1,10 @@
 # How JVM Works
 
-The Java Virtual Machine (JVM) is a program that executes Java bytecode. JVMs are available for various hardware and software platforms, making them platform-dependent but the programs themselves - not. The so-called "Write once run everywhere" becomes true here. The JVM is responsible for calling the main method in Java code and is a crucial part of the Java Runtime Environment (JRE).
-
-While primarily designed for Java, the JVM can run any language that compiles to Java bytecode. This flexibility allows other languages like Kotlin, Scala, and Groovy to leverage the JVM ecosystem.
-
-Multiple JVM implementations exist, each with unique features. Oracle's HotSpot is the standard implementation, while GraalVM is a high-performance alternative that's gaining popularity. GraalVM offers enhanced performance.
+The Java Virtual Machine (JVM) is a platform-dependent program that executes platform-independent Java bytecode, embodying the "Write once, run everywhere" principle. As a crucial component of the Java Runtime Environment (JRE), the JVM is responsible for initiating Java programs by calling their main method. While designed primarily for Java, the JVM's ability to run any language compiled to Java bytecode has led to its adoption by other languages like Kotlin, Scala, and Groovy. Multiple JVM implementations exist, with Oracle's HotSpot being the standard and GraalVM emerging as a high-performance alternative, each offering unique features and optimizations
 
 Visit the following resources to learn more:
 
-- [@article@What is JVM & architectyre?](https://www.geeksforgeeks.org/jvm-works-jvm-architecture/)
+- [@article@What is JVM & architecture?](https://www.freecodecamp.org/news/jvm-tutorial-java-virtual-machine-architecture-explained-for-beginners/)
 - [@article@Introducing the Java Virtual Machine](https://www.infoworld.com/article/3272244/what-is-the-jvm-introducing-the-java-virtual-machine.html)
 - [@video@How JVM works?](https://youtu.be/G1ubVOl9IBw)
 - [@feed@Explore top posts about JVM](https://app.daily.dev/tags/jvm?ref=roadmapsh)

--- a/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
+++ b/src/data/roadmaps/java/content/101-java-advanced-topics/106-how-jvm-works.md
@@ -1,11 +1,16 @@
 # How JVM Works
 
-The Java Virtual Machine is a program whose purpose is to execute other programs. JVMs are available for many hardware and software platforms (i.e. JVM is platform dependent). JVM is the one that actually calls the main method present in a java code. JVM is a part of JRE(Java Runtime Environment)
+The Java Virtual Machine (JVM) is a program that executes Java bytecode. JVMs are available for various hardware and software platforms, making them platform-dependent but the programs themselves - not. The so-called "Write once run everywhere" becomes true here. The JVM is responsible for calling the main method in Java code and is a crucial part of the Java Runtime Environment (JRE).
+
+While primarily designed for Java, the JVM can run any language that compiles to Java bytecode. This flexibility allows other languages like Kotlin, Scala, and Groovy to leverage the JVM ecosystem.
+
+Multiple JVM implementations exist, each with unique features. Oracle's HotSpot is the standard implementation, while GraalVM is a high-performance alternative that's gaining popularity. GraalVM offers enhanced performance.
 
 Visit the following resources to learn more:
 
-- [@article@What is JVM?](https://www.javatpoint.com/jvm-java-virtual-machine)
+- [@article@What is JVM & architectyre?](https://www.geeksforgeeks.org/jvm-works-jvm-architecture/)
 - [@article@Introducing the Java Virtual Machine](https://www.infoworld.com/article/3272244/what-is-the-jvm-introducing-the-java-virtual-machine.html)
-- [@article@JVM (Java Virtual Machine) Architecture](https://www.javatpoint.com/jvm-java-virtual-machine)
 - [@video@How JVM works?](https://youtu.be/G1ubVOl9IBw)
 - [@feed@Explore top posts about JVM](https://app.daily.dev/tags/jvm?ref=roadmapsh)
+- [@article@JVM languages](https://www.whizlabs.com/blog/jvm-languages/)
+- [@article@ GraalVM](https://www.graalvm.org/)


### PR DESCRIPTION
removed duplicate link
added JVM languages and GraalVM as a popular alternative