### PR TITLE
Fix and add links in Computer Science roadmap

### DIFF
--- a/src/data/roadmaps/computer-science/content/101-pick-a-language/100-c-plus-plus.md
+++ b/src/data/roadmaps/computer-science/content/101-pick-a-language/100-c-plus-plus.md
@@ -4,9 +4,10 @@ C++ is a powerful general-purpose programming language. It can be used to develo
 
 Visit the following resources to learn more:
 
-- [@article@Learn Cpp](https://learncpp.com/)
-- [@article@C++ Reference](https://en.cppreference.com/)
+- [@article@Learn C++](https://learncpp.com/)
+- [@article@Cpp Reference](https://en.cppreference.com/)
+- [@article@CPlusPlus](https://cplusplus.com/)
 - [@article@C++ TutorialsPoint](https://www.tutorialspoint.com/cplusplus/index.htm)
 - [@article@W3Schools C++](https://www.w3schools.com/cpp/default.asp)
 - [@roadmap.sh@C++ Roadmap](https://roadmap.sh/cpp)
-- [@feed@Explore top posts about C Programming](https://app.daily.dev/tags/c?ref=roadmapsh)
+- [@feed@Explore top posts about C++ Programming](https://app.daily.dev/tags/c++?ref=roadmapsh)

--- a/src/data/roadmaps/computer-science/content/101-pick-a-language/100-c-plus-plus.md
+++ b/src/data/roadmaps/computer-science/content/101-pick-a-language/100-c-plus-plus.md
@@ -4,10 +4,9 @@ C++ is a powerful general-purpose programming language. It can be used to develo
 
 Visit the following resources to learn more:
 
-- [@article@Learn C++](https://learncpp.com/)
-- [@article@Cpp Reference](https://en.cppreference.com/)
-- [@article@CPlusPlus](https://cplusplus.com/)
+- [@article@Learn Cpp](https://learncpp.com/)
+- [@article@C++ Reference](https://en.cppreference.com/)
 - [@article@C++ TutorialsPoint](https://www.tutorialspoint.com/cplusplus/index.htm)
 - [@article@W3Schools C++](https://www.w3schools.com/cpp/default.asp)
 - [@roadmap.sh@C++ Roadmap](https://roadmap.sh/cpp)
-- [@feed@Explore top posts about C++ Programming](https://app.daily.dev/tags/c++?ref=roadmapsh)
+- [@feed@Explore top posts about C Programming](https://app.daily.dev/tags/c?ref=roadmapsh)

--- a/src/data/roadmaps/computer-science/content/101-pick-a-language/105-c-sharp.md
+++ b/src/data/roadmaps/computer-science/content/101-pick-a-language/105-c-sharp.md
@@ -8,4 +8,4 @@ Visit the following resources to learn more:
 - [@article@C# on W3 schools](https://www.w3schools.com/cs/index.php)
 - [@article@Introduction to C#](https://docs.microsoft.com/en-us/shows/CSharp-101/?WT.mc_id=Educationalcsharp-c9-scottha)
 - [@video@C# tutorials](https://www.youtube.com/watch?v=gfkTfcpWqAY\&list=PLTjRvDozrdlz3_FPXwb6lX_HoGXa09Yef)
-- [@feed@Explore top posts about C Programming](https://app.daily.dev/tags/c?ref=roadmapsh)
+- [@feed@Explore top posts about C# Programming](https://app.daily.dev/tags/csharp?ref=roadmapsh)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
@@ -4,6 +4,7 @@ Arrays store elements in contiguous memory locations, resulting in easily calcul
 
 Visit the following resources to learn more:
 
+- [@video@Array Data Structure | Illustrated Data Structures](https://www.youtube.com/watch?v=QJNwK2uJyGs)
 - [@course@Array Data Structure - Coursera](https://www.coursera.org/lecture/data-structures/arrays-OsBSF)
 - [@course@Dynamic Arrays - Coursera](https://www.coursera.org/lecture/data-structures/dynamic-arrays-EwbnV)
 - [@article@UC Berkeley CS61B - Linear and Multi-Dim Arrays (Start watching from 15m 32s)](https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
@@ -4,10 +4,9 @@ Arrays store elements in contiguous memory locations, resulting in easily calcul
 
 Visit the following resources to learn more:
 
-- [@video@Array Data Structure | Illustrated Data Structures](https://www.youtube.com/watch?v=QJNwK2uJyGs)
 - [@course@Array Data Structure - Coursera](https://www.coursera.org/lecture/data-structures/arrays-OsBSF)
-- [@article@UC Berkeley CS61B - Linear and Multi-Dim Arrays (Start watching from 15m 32s)](https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE)
 - [@course@Dynamic Arrays - Coursera](https://www.coursera.org/lecture/data-structures/dynamic-arrays-EwbnV)
+- [@article@UC Berkeley CS61B - Linear and Multi-Dim Arrays (Start watching from 15m 32s)](https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE)
 - [@video@Dynamic and Static Arrays](https://www.youtube.com/watch?v=PEnFFiQe1pM&list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&index=6)
 - [@video@Dynamic Array Code](https://www.youtube.com/watch?v=tvw4v7FEF1w&list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&index=5)
 - [@video@Jagged Arrays](https://www.youtube.com/watch?v=1jtrQqYpt7g)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/100-array.md
@@ -8,4 +8,6 @@ Visit the following resources to learn more:
 - [@course@Array Data Structure - Coursera](https://www.coursera.org/lecture/data-structures/arrays-OsBSF)
 - [@article@UC Berkeley CS61B - Linear and Multi-Dim Arrays (Start watching from 15m 32s)](https://archive.org/details/ucberkeley_webcast_Wp8oiO_CZZE)
 - [@course@Dynamic Arrays - Coursera](https://www.coursera.org/lecture/data-structures/dynamic-arrays-EwbnV)
+- [@video@Dynamic and Static Arrays](https://www.youtube.com/watch?v=PEnFFiQe1pM&list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&index=6)
+- [@video@Dynamic Array Code](https://www.youtube.com/watch?v=tvw4v7FEF1w&list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&index=5)
 - [@video@Jagged Arrays](https://www.youtube.com/watch?v=1jtrQqYpt7g)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/index.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/index.md
@@ -7,4 +7,5 @@ Visit the following resources to learn more:
 - [@article@What are Data Structures?](https://www.geeksforgeeks.org/data-structures)
 - [@article@ Data Structures and Algorithms](https://www.javatpoint.com/data-structure-tutorial)
 - [@video@Data Structures Illustrated](https://www.youtube.com/watch?v=9rhT3P1MDHk\&list=PLkZYeFmDuaN2-KUIv-mvbjfKszIGJ4FaY)
+- [@video@A Great Data Structures playlist](https://youtube.com/playlist?list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&si=_EEf7x58G6lUcMGG)
 - [@feed@Explore top posts about Data Structures](https://app.daily.dev/tags/data-structures?ref=roadmapsh)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/index.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/index.md
@@ -6,6 +6,7 @@ Visit the following resources to learn more:
 
 - [@article@What are Data Structures?](https://www.geeksforgeeks.org/data-structures)
 - [@article@ Data Structures and Algorithms](https://www.javatpoint.com/data-structure-tutorial)
+- [@course@ Data Structures and Algorithms By Google](https://techdevguide.withgoogle.com/paths/data-structures-and-algorithms/)
 - [@video@Data Structures Illustrated](https://www.youtube.com/watch?v=9rhT3P1MDHk\&list=PLkZYeFmDuaN2-KUIv-mvbjfKszIGJ4FaY)
 - [@video@A Great Data Structures playlist](https://youtube.com/playlist?list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&si=_EEf7x58G6lUcMGG)
 - [@feed@Explore top posts about Data Structures](https://app.daily.dev/tags/data-structures?ref=roadmapsh)

--- a/src/data/roadmaps/computer-science/content/102-data-structures/index.md
+++ b/src/data/roadmaps/computer-science/content/102-data-structures/index.md
@@ -8,5 +8,5 @@ Visit the following resources to learn more:
 - [@article@ Data Structures and Algorithms](https://www.javatpoint.com/data-structure-tutorial)
 - [@course@ Data Structures and Algorithms By Google](https://techdevguide.withgoogle.com/paths/data-structures-and-algorithms/)
 - [@video@Data Structures Illustrated](https://www.youtube.com/watch?v=9rhT3P1MDHk\&list=PLkZYeFmDuaN2-KUIv-mvbjfKszIGJ4FaY)
-- [@video@A Great Data Structures playlist](https://youtube.com/playlist?list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&si=_EEf7x58G6lUcMGG)
+- [@video@Data Structures playlist](https://youtube.com/playlist?list=PLDV1Zeh2NRsB6SWUrDFW2RmDotAfPbeHu&si=_EEf7x58G6lUcMGG)
 - [@feed@Explore top posts about Data Structures](https://app.daily.dev/tags/data-structures?ref=roadmapsh)


### PR DESCRIPTION
I made some changes to the Computer Science Roadmap. In the C# section, I edited the feed link because it was redirecting to the C feed. Additionally, I added some useful resources to the data structures and array sections.