### PR TITLE
fix: [roadmaps/full-stack] Change "full stack" to "full-stack" to be more precise

### DIFF
--- a/src/data/roadmaps/full-stack/content/102-checkpoint-static-websites.md
+++ b/src/data/roadmaps/full-stack/content/102-checkpoint-static-websites.md
@@ -5,9 +5,9 @@ Now that you have learnt HTML and CSS, you should be able to build static webpag
 The practice that I used to follow when I was learning was this:
 
 - While you are watching a course or reading a book, make sure to code along with the instructor/author — pause the video at regular intervals and code what you are being taught.
-- Search on YouTube and watch a few project based tutorials on the topic that you are learning. Apart from coding along with the instructor:
+- Search on YouTube and watch a few project-based tutorials on the topic that you are learning. Apart from coding along with the instructor:
   - Try to build the same project at least 2 to 3 times on your own without looking at the video. If you get stuck, refer to the section of the video where the instructor builds that part of the project.
-  - Build something else that is similar to the project that you just built. For example, if you just built a todo app, try to build a notes app or a reminder app.
+  - Build something else that is similar to the project that you just built. For example, if you just built a todo app, try to build a note app or a reminder app.
 
 ## Project Ideas
 

--- a/src/data/roadmaps/full-stack/full-stack.json
+++ b/src/data/roadmaps/full-stack/full-stack.json
@@ -687,7 +687,7 @@
           "y": "387",
           "properties": {
             "size": "32",
-            "text": "Full Stack "
+            "text": "Full-stack "
           }
         },
         {
@@ -3411,7 +3411,7 @@
           "y": "2503",
           "properties": {
             "size": "17",
-            "text": "Continue Learning with following relevant tracks"
+            "text": "Continue Learning with the following relevant tracks"
           }
         },
         {
@@ -3782,7 +3782,7 @@
                   "y": "249",
                   "properties": {
                     "size": "18",
-                    "text": "full stack development."
+                    "text": "full-stack development."
                   }
                 },
                 {

--- a/src/data/roadmaps/full-stack/full-stack.md
+++ b/src/data/roadmaps/full-stack/full-stack.md
@@ -2,28 +2,28 @@
 jsonUrl: '/jsons/roadmaps/full-stack.json'
 pdfUrl: '/pdfs/roadmaps/full-stack.pdf'
 order: 3
-briefTitle: 'Full Stack'
-briefDescription: 'Step by step guide to becoming a full stack developer in 2024'
-title: 'Full Stack Developer'
-description: 'Step by step guide to becoming a modern full stack developer in 2024'
+briefTitle: 'Full-stack'
+briefDescription: 'A step-by-step guide to becoming a full-stack developer in 2024'
+title: 'Full-stack Developer'
+description: 'A step-by-step guide to becoming a modern full-stack developer in 2024'
 isNew: false
 hasTopics: true
 dimensions:
   width: 968
   height: 1951.64
 question:
-  title: 'What is Full Stack Development?'
+  title: 'What is Full-stack Development?'
   description: |
-    Full stack development is the practice of being proficient in both the front-end and back-end aspects of web application development. A full stack developer is capable of working on all layers of a software application, from the user interface and user experience (front-end) to the server, database, and server-side logic (back-end). This versatility allows them to create and maintain complete web applications independently or as part of a development team.
+    Full-stack development is the practice of being proficient in both the front-end and back-end aspects of web application development. A full-stack developer is capable of working on all layers of a software application, from the user interface and user experience (front-end) to the server, database, and server-side logic (back-end). This versatility allows them to create and maintain complete web applications independently or as part of a development team.
 schema:
-  headline: 'Full Stack Developer Roadmap'
-  description: 'Learn how to become a Full Stack Developer with this interactive step by step guide in 2024. We also have resources and short descriptions attached to the roadmap items so you can get everything you want to learn in one place.'
+  headline: 'Full-stack Developer Roadmap'
+  description: 'Learn how to become a Full-stack Developer with this interactive step-by-step guide in 2024. We also have resources and short descriptions attached to the roadmap items so you can get everything you want to learn in one place.'
   imageUrl: 'https://roadmap.sh/roadmaps/full-stack.png'
   datePublished: '2023-01-05'
   dateModified: '2023-01-20'
 seo:
-  title: 'Full Stack Developer Roadmap'
-  description: 'Learn to become a modern full stack developer using this roadmap. Community driven, articles, resources, guides, interview questions, quizzes for modern full stack development.'
+  title: 'Full-stack Developer Roadmap'
+  description: 'Learn to become a modern full-stack developer using this roadmap. Community-driven, articles, resources, guides, interview questions, quizzes for modern full-stack development.'
   keywords:
     - 'javascript roadmap 2024'
     - 'full stack roadmap 2024'


### PR DESCRIPTION
This PR contains the following changes:

- All "full stack" instances are replaced with "full-stack" to be more precise as "full-stack" is a hyphenated noun compound, and "Full-stack Developer" title should be preferred.

- Improvements: "step by step" to "step-by-step", "notes app" to "note app", "project based" to "project-based"...