### PR TITLE
Fixing broken rxjs link

### DIFF
--- a/src/data/roadmaps/angular/content/101-rxjs-basics/104-operators/103-combination.md
+++ b/src/data/roadmaps/angular/content/101-rxjs-basics/104-operators/103-combination.md
@@ -26,4 +26,4 @@ Further documentation can be found in the official RxJS documentation:
 
 - WithLatestFrom: https://rxjs.dev/api/operators/withLatestFrom
 
-- ForkJoin: https://rxjs.dev/api/operators/forkJoin
+- ForkJoin: https://rxjs.dev/api/index/function/forkJoin


### PR DESCRIPTION
- Fixing broken rxjs link roadmap Angular.

![image](https://github.com/kamranahmedse/developer-roadmap/assets/51521476/a4923141-21ab-4e80-b66c-90e1a74c3c11)
