### PR TITLE
Added video link on iOS Roadmap's 'Swift Basics' page

### DIFF
--- a/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
+++ b/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
@@ -1,1 +1,3 @@
 # Swift Basics
+
+- [@video@A Swift Tour](https://developer.apple.com/videos/play/wwdc2024/10184)


### PR DESCRIPTION
Added a link to the official Apple "A Swift Tour" basics video for the 'Swift Basics' content page.