### PR TITLE
Typo - DevOps Roadmap Beginner: typo in final paragraph

### DIFF
--- a/src/data/roadmaps/devops/devops-beginner.json
+++ b/src/data/roadmaps/devops/devops-beginner.json
@@ -208,7 +208,7 @@
       },
       "selected": true,
       "data": {
-        "label": "At this poing, you should have enough knowledge to find a junior to mid-level (maybe even senior) DevOps position at any company depending on the depth of your knowledge. Keep learning and building projects till you find a job. Your job will teach you a lot as well.",
+        "label": "At this point, you should have enough knowledge to find a junior to mid-level (maybe even senior) DevOps position at any company depending on the depth of your knowledge. Keep learning and building projects till you find a job. Your job will teach you a lot as well.",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
Fix typo in final paragraph of beginner roadmap for devops.