### PR TITLE
Removed 'for product managers' from topic titles

### DIFF
--- a/src/data/roadmaps/product-manager/content/ab-testing@Ws7IFrHQNoBjLE2Td2xIZ.md
+++ b/src/data/roadmaps/product-manager/content/ab-testing@Ws7IFrHQNoBjLE2Td2xIZ.md
@@ -1,3 +1,3 @@
-# A/B Testing for Product Managers
+# A/B Testing
 
 A/B testing, otherwise known as split testing, is an essential statistical tool that is central to the responsibilities of a product manager. This method involves comparing two versions of a webpage, product feature, or user interface to determine which performs better according to certain metrics or goals. It allows product managers to make data-driven decisions and improve the product based on real user experiences and preferences. A solid understanding of A/B testing methods and application equips product managers with the ability to optimize user engagement, retention and conversion rates.

--- a/src/data/roadmaps/product-manager/content/advanced-analysis@9y_I41kJhkmyBJjiTw8Xd.md
+++ b/src/data/roadmaps/product-manager/content/advanced-analysis@9y_I41kJhkmyBJjiTw8Xd.md
@@ -1,3 +1,3 @@
-# Advanced Analysis for Product Managers
+# Advanced Analysis
 
 The field of Advanced Analysis plays a pivotal role in the domain of Product Management. As the driving force behind decision-making, it incorporates sophisticated methods and tools to draw meaning from data, enabling Product Managers to extract actionable insights. This subject involves applications such as Predictive Modeling, Statistical Analysis, and Machine Learning algorithms to yield a deep understanding of user behavior, market trends, product performance and forecast potential outcomes. With the power of advanced analysis, Product Managers can create data-driven strategies, optimize the user experience, and accelerate overall product growth.

--- a/src/data/roadmaps/product-manager/content/amplitude@Z5oorppEJ0ydvwMXSlk1J.md
+++ b/src/data/roadmaps/product-manager/content/amplitude@Z5oorppEJ0ydvwMXSlk1J.md
@@ -1,3 +1,3 @@
-# Amplitude as an Analytical Tool for Product Managers
+# Amplitude
 
 Amplitude is an exceptional analytical tool that offers in-depth insights about user behavior, allowing product managers to optimize their products based on real-time data. Equipped with features like funnel analysis, retention analysis, and user segmentation, Amplitude provides an essential understanding of how users interact with products. For product managers, understanding these interactions is crucial in decision-making, prioritizing product improvements, and enhancing the overall user experience. Thus, Amplitude serves as a valuable resource for Product Managers looking to drive product growth and maximize user engagement.

--- a/src/data/roadmaps/product-manager/content/case-studies@JhhjMPTNb646aQKlS_cji.md
+++ b/src/data/roadmaps/product-manager/content/case-studies@JhhjMPTNb646aQKlS_cji.md
@@ -1,3 +1,3 @@
-# Case Studies in Positioning for Product Managers
+# Case Studies
 
 Case studies play a pivotal role in exhibiting the efficiency of a product and its potential value in the lives of customers. For Product Managers, understanding case studies in positioning is invaluable. It allows them to comprehend how a product fits into a market, how it behaves in relation to competitors, and how it meets customer needs. These case studies provide insights into the real-world application and results of strategic positioning, enabling Product Managers to devise more effective strategies that attract target customers and build lasting brand value.

--- a/src/data/roadmaps/product-manager/content/decline@yOve7g_05UMpXHcGpdZcW.md
+++ b/src/data/roadmaps/product-manager/content/decline@yOve7g_05UMpXHcGpdZcW.md
@@ -1,3 +1,3 @@
-# Decline in Product Management
+# Decline
 
 The decline phase of the product development lifecycle comes after the development, introduction, growth, and maturity stages, characterized by decreasing sales and market relevance. For product managers, this phase involves making strategic decisions regarding the product's future, such as discontinuation, repositioning, or reinvention. The focus shifts to cost reduction, managing inventory, and maximizing any remaining value from the product. Effective management during the decline phase is essential for mitigating losses, reallocating resources to more promising products, and planning for a smooth exit or transition, ensuring minimal disruption to the overall product portfolio.

--- a/src/data/roadmaps/product-manager/content/discord@e6gO1twjter9xWm14g9S9.md
+++ b/src/data/roadmaps/product-manager/content/discord@e6gO1twjter9xWm14g9S9.md
@@ -1,3 +1,3 @@
-# Discord - A Communication Tool for Product Managers
+# Discord
 
 Discord is a widely used communication tool that is beginning to make its mark in the field of product management. It offers a secure and user-friendly platform with features that are quintessential for a Product Manager. With its rich text chats, voice channels, and ability to create multiple channels with different access levels, it ensures seamless communication within cross-functional teams. For Product Managers, Discord can be an essential collaboration tool that aids in the exchange of innovative ideas, constructive feedback, and bug reporting, thereby allowing them to design, plan, and execute with efficiency.

--- a/src/data/roadmaps/product-manager/content/heap@xas-t2sAKmJNfb0-Zcpwy.md
+++ b/src/data/roadmaps/product-manager/content/heap@xas-t2sAKmJNfb0-Zcpwy.md
@@ -1,3 +1,3 @@
-# Heap - A Powerful Analytics Tool
+# Heap Analytics
 
 Heap Analytics is a robust solution for product managers looking to gain actionable insights into their product's usage and performance. It's a powerful analytics tool that allows the automatic capturing of every user interaction across the entire customer journey. From clicks and taps to form submissions and transactions, Heap captures all data without needing any pre-defined tracking set-up. As a Product Manager, understanding the value that Heap brings in effortlessly tracking user engagement and offering data-driven insights is integral for refining product decisions and driving the overall product strategy.

--- a/src/data/roadmaps/product-manager/content/job-stories@B9fgJmzVViaq7dvSuEglb.md
+++ b/src/data/roadmaps/product-manager/content/job-stories@B9fgJmzVViaq7dvSuEglb.md
@@ -1,3 +1,3 @@
-# Job Stories under Product Requirements
+# Job Stories
 
 The concept of Job Stories is a tool integral to a Product Manager's dynamic role. Structured differently from traditional user stories, Job Stories shift the focus from personas to the situation, providing a fresh perspective for understanding user requirements. They provide an opportunity for product managers to emphasize the context and causality of user needs. This perspective plays a crucial role in creating successful products and ensuring they deliver value to the end-users. Teleriking why and when someone uses the product opens avenues for actionable insights leading to judicious decision-making in defining product requirements.

--- a/src/data/roadmaps/product-manager/content/kanban-basics@kJ2HQFEsnc5yISU8d9Lla.md
+++ b/src/data/roadmaps/product-manager/content/kanban-basics@kJ2HQFEsnc5yISU8d9Lla.md
@@ -1,3 +1,3 @@
-# Kanban Basics for Product Managers
+# Kanban Basics
 
 As a Product Manager in the fast-paced environment of technological innovation, being aware of and proficient in Agile methodology and specifically, the Kanban basics, is crucial. Originated in Toyota production system, Kanban is a visual tool that effectively supports the management of a product as it goes through its lifecycle. For a Product Manager, understanding Kanban basics implies being able to streamline workflow, limit work-in-progress and visualize work, thereby optimizing the efficiency of a team and the production timeline. Simply put, Kanban helps in managing work by balancing demands with available capacity, and improving the handling of system-level bottlenecks.

--- a/src/data/roadmaps/product-manager/content/linear@PIIGfDN6t8H6tXZuKuE04.md
+++ b/src/data/roadmaps/product-manager/content/linear@PIIGfDN6t8H6tXZuKuE04.md
@@ -1,3 +1,3 @@
-# Linear under Project Management Tools
+# Linear
 
 Linear is a powerful project management tool designed to help teams improve their productivity and efficiency. It helps organize, prioritize, and track tasks in one streamlined platform. For the role of a Product Manager, Linear is an essential tool that aids in managing and monitoring progress, evaluating performance, and ensuring the roadmap aligns with the strategic goals of the product. Product managers may utilize the functionalities of Linear to communicate with various stakeholders, delegate tasks, and manage product backlogs effectively. Its clean and user-friendly interface makes it easy for Product Managers to streamline their workflow and focus more on building high-quality products.

--- a/src/data/roadmaps/product-manager/content/positioning@YPqdrZguH0ArEFSe-VwKS.md
+++ b/src/data/roadmaps/product-manager/content/positioning@YPqdrZguH0ArEFSe-VwKS.md
@@ -1,3 +1,3 @@
-# Positioning in Product Management
+# Positioning
 
 Positioning, within the realm of product management, refers to the delicate art of crafting and communicating a product's unique value proposition to the intended audience, in relation to competing products. It's about defining where your product fits into the market and how it should be perceived by its consumer base. A seasoned Product Manager meticulously shapes and controls this perception in order to strengthen the product’s standing in the market, increase sales, and boost the overall brand image. The correct positioning strategy can ultimately lead to a product's success or failure. For Product Managers, mastering this strategic function is a key element in directing both product development and marketing efforts.

--- a/src/data/roadmaps/product-manager/content/predictive-analytics@YsDt5I0prvYeaFfn4_lpx.md
+++ b/src/data/roadmaps/product-manager/content/predictive-analytics@YsDt5I0prvYeaFfn4_lpx.md
@@ -1,3 +1,3 @@
-# Predictive Analytics in Product Management
+# Predictive Analytics
 
 In today's fast-paced digital business landscape, it's imperative for a Product Manager to leverage data for driving effective decision-making. This is where Predictive Analytics comes into play. Predictive Analytics employs statistical algorithms and machine learning techniques to determine the likelihood of future outcomes based on historical data. For Product Managers, this powerful tool allows them to anticipate customer behavior and market trends, inform planning and prioritization, and ultimately enhance their product's value proposition. This proactive approach can markedly reduce risks while maximizing opportunities for enterprise growth and customer satisfaction.

--- a/src/data/roadmaps/product-manager/content/predictive-analytics@h5N51_YgjaTHhPUHxkqQR.md
+++ b/src/data/roadmaps/product-manager/content/predictive-analytics@h5N51_YgjaTHhPUHxkqQR.md
@@ -1,3 +1,3 @@
-# Predictive Analytics in Product Management
+# Predictive Analytics
 
 Product Management encompasses a plethora of analytical strategies and one of the essential approaches is Predictive Analytics. As a Product Manager, having insights about future outcomes can make a substantial difference in decision-making. Predictive Analytics is leveraged to analyze historical and current data and make predictions about unseen or future events. This can help in efficient planning, risk management, and strategic decision making. It's a powerful tool for product managers that enables them to predict trends, understand user behavior, forecast demand, and ultimately, to build better products.

--- a/src/data/roadmaps/product-manager/content/risk-register@WBnLicFo9p2zm57pyXciI.md
+++ b/src/data/roadmaps/product-manager/content/risk-register@WBnLicFo9p2zm57pyXciI.md
@@ -1,3 +1,3 @@
-# Risk Register in the Context of Product Management
+# Risk Register
 
 The Risk Register is an important tool for Product Managers as it systematically identifies and manages potential issues that could negatively impact the outcome of a product's development. It consists of a log of potential risks, quantifying their impact, likelihood, and mitigation strategies. This essential document allows Product Managers to prioritize strategies, allocate resources more efficiently, and develop contingency plans. In essence, a Risk Register helps Product Managers to better anticipate, assess, and prepare for the potential bumps on the road to successful product delivery. It encourages a proactive rather than reactive approach to managing risk, contributing to overall product success.

--- a/src/data/roadmaps/product-manager/content/roadmapping-tools@XG-QBb--HXL-1r-jInYDN.md
+++ b/src/data/roadmaps/product-manager/content/roadmapping-tools@XG-QBb--HXL-1r-jInYDN.md
@@ -1,3 +1,3 @@
-# Roadmapping Tools for Product Managers
+# Roadmapping Tools
 
 Every exceptional product manager understands the crucial role that product roadmaps play in the successful coordination and execution of product strategy. Roadmapping tools often come into play here, as they help simplify complex processes, while enhancing communication and transparency among teams. These tools deliver visually compelling, data-supported product maps, offering an easy-to-understand view of the prioritized features, projected timelines, strategic alignment, and progress tracking. By utilizing such applications, product managers are not only able to manage and communicate their strategy effectively, but also prioritize requests, track progress, and adjust plans based on insights.

--- a/src/data/roadmaps/product-manager/content/slack@UdOJDzkDP_R3E5f_IltYh.md
+++ b/src/data/roadmaps/product-manager/content/slack@UdOJDzkDP_R3E5f_IltYh.md
@@ -1,3 +1,3 @@
-# Slack - A Communication Tool for Product Managers
+# Slack
 
 As a product manager, effective communication with different stakeholders is a crucial task. Slack emerges as an essential platform for this role. It is a cloud-based team collaboration tool that facilitates quick and efficient communication among team members, from developers and marketing professionals to various stakeholders. This platform also integrates with a variety of other tools that product managers use regularly, thereby acting as an operational hub for project management. Product managers can create channels on Slack for different projects or topics to ensure organized and focused conversations. It also supports direct messaging and file sharing which enhances day-to-day communication and coordination.

--- a/src/data/roadmaps/product-manager/content/trello@SD98_s1ET_j2eIIKmcKRc.md
+++ b/src/data/roadmaps/product-manager/content/trello@SD98_s1ET_j2eIIKmcKRc.md
@@ -1,4 +1,4 @@
-# Trello - A Project Management Tool for Product Managers
+# Trello
 
 Product management entails numerous responsibilities, among which is managing several tasks, teams and deadlines to make sure that products are developed and launched on time. To effectively manage these responsibilities, Product Managers often require robust Project Management Tools. One such tool is "Trello".
 


### PR DESCRIPTION
Having "for product managers" in the title was causing the youtube and google search buttons to repeat "for product managers in the search" such as: `slack - a communication tool for product managers for product manager`