### PR TITLE
Fixed markdown typo

### DIFF
--- a/src/data/roadmaps/game-developer/content/104-programming-languages/103-rust.md
+++ b/src/data/roadmaps/game-developer/content/104-programming-languages/103-rust.md
@@ -2,4 +2,4 @@
 
 **Rust** is a modern, open-source, multi-paradigm programming language designed for performance and safety, especially safe concurrency. It was initially designed by Mozilla Research as a language that can provide memory safety without garbage collection. Since then, it has gained popularity due to its features and performance that often compare favorably to languages like C++. Its rich type system and ownership model guarantee memory-safety and thread-safety while maintaining a high level of abstraction. Rust supports a mixture of imperative procedural, concurrent actor, object-oriented and pure functional styles.
 
-[Learn Rust full tutorial](https://youtu.be/BpPEoZW5IiY?si=lyBbBPLXQ0HWdJNr
+[Learn Rust full tutorial](https://youtu.be/BpPEoZW5IiY?si=lyBbBPLXQ0HWdJNr)


### PR DESCRIPTION
There was a markdown typo which is:
[Learn Rust full tutorial](https://youtu.be/BpPEoZW5IiY?si=lyBbBPLXQ0HWdJNr

...