### PR TITLE
feat(roadmap/angular): update RxJS transformation section

### DIFF
--- a/src/data/roadmaps/angular/content/101-rxjs-basics/104-operators/102-transformation.md
+++ b/src/data/roadmaps/angular/content/101-rxjs-basics/104-operators/102-transformation.md
@@ -3,19 +3,20 @@
 In RxJS, "transformation" refers to the process of modifying or manipulating the data emitted by an Observable. There are a variety of methods available in RxJS that can be used to transform the data emitted by an Observable, including:
 
 - map: applies a function to each item emitted by the Observable and emits the resulting value
-- flatMap: applies a function to each item emitted by the Observable, and then flattens the resulting Observables into a single Observable
-- concatMap: applies a function to each item emitted by the Observable, and then concatenates the resulting Observables into a single Observable
 - mergeMap: applies a function to each item emitted by the Observable, and then merges the resulting Observables into a single Observable
 - switchMap: applies a function to each item emitted by the Observable, and then switches to the latest resulting Observable
+- concatMap: applies a function to each item emitted by the Observable, and then concatenates the resulting Observables into a single Observable
+- exhaustMap: applies a function to each item emitted by the Observable, but ignores subsequent emissions until the current Observable completes
 
 These are just a few examples of the many methods available in RxJS for transforming the data emitted by an Observable. Each method has its own specific use case, and the best method to use will depend on the requirements of your application.
 
 Here are the official documentation links for the RxJS transformation methods:
 
-- [@article@map](https://rxjs.dev/api/operators/map)
-- [@article@flatMap](https://rxjs.dev/api/operators/flatMap)
-- [@article@concatMap](https://rxjs.dev/api/operators/concatMap)
-- [@article@mergeMap](https://rxjs.dev/api/operators/mergeMap)
-- [@article@switchMap](https://rxjs.dev/api/operators/switchMap)
+- [@official@map](https://rxjs.dev/api/operators/map)
+- [@official@mergeMap](https://rxjs.dev/api/operators/mergeMap)
+- [@official@switchMap](https://rxjs.dev/api/operators/switchMap)
+- [@official@concatMap](https://rxjs.dev/api/operators/concatMap)
+- [@official@exhaustMap](https://rxjs.dev/api/operators/exhaustMap)
+- [@video@switchMap vs mergeMap vs concatMap vs exhaustMap practical guide](https://youtu.be/40pC5wHowWw)
 
 You can find more information and examples on these methods in the official RxJS documentation. Additionally, you can find more operators on https://rxjs.dev/api/operators and you can also find more information on the library as a whole on https://rxjs.dev/


### PR DESCRIPTION
- remove deprecated flatMap operator (Renamed to mergeMap. Will be removed in v8)
- add exhaustMap
- add video for Higher-Order RxJs Mapping Operators
- sort operators by complexity
- change the type of some resources to the **official** category