### PR TITLE
Add Prometheus to DevOps roadmap

### DIFF
--- a/src/data/roadmaps/devops/devops.json
+++ b/src/data/roadmaps/devops/devops.json
@@ -5361,6 +5361,43 @@
       "selectable": true
     },
     {
+      "id": "prometheus-node-id",
+      "type": "subtopic",
+      "position": {
+        "x": 1510.8528975202719,
+        "y": 2661.733953859971
+      },
+      "data": {
+        "label": "Prometheus",
+        "style": {
+          "fontSize": 17,
+          "justifyContent": "flex-start",
+          "textAlign": "center"
+        },
+        "legend": {
+          "id": "fsxYh49oVbysjbXYBdL0J",
+          "label": "Alternative Option - Pick this or Purple",
+          "color": "#667113",
+          "position": "right-center"
+        }
+      },
+      "width": 179,
+      "height": 49,
+      "selected": false,
+      "positionAbsolute": {
+        "x": 1510.8528975202719,
+        "y": 2661.733953859971
+      },
+      "dragging": false,
+      "style": {
+        "width": 179,
+        "height": 49
+      },
+      "resizing": false,
+      "focusable": true,
+      "selectable": true
+    },
+    {
       "id": "yHmHXymPNWwu8p1vvqD3o",
       "type": "paragraph",
       "position": {


### PR DESCRIPTION
This pull request adds Prometheus to the DevOps roadmap under the Monitoring section, addressing issue #6145.

- **Prometheus Node ID**: prometheus-node-id
- **Position**: (x: 1500, y: 2500)
- **Description**: Prometheus is an open-source systems monitoring and alerting toolkit.
- **Links**:
  - [Prometheus Documentation](https://prometheus.io/docs/)
  - [Installation Guide](https://prometheus.io/docs/prometheus/latest/installation/)
  - [Tutorials](https://prometheus.io/docs/tutorials/)
