### PR TITLE
fixed React SSR option name to Remix

### DIFF
--- a/src/data/roadmaps/frontend/frontend.json
+++ b/src/data/roadmaps/frontend/frontend.json
@@ -3088,7 +3088,7 @@
       },
       "selected": false,
       "data": {
-        "label": "react-router",
+        "label": "Remix",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
the label in SSR -> React was being presented as "react-router" but the content was about Remix. I changed the label name to "Remix"