### PR TITLE
fix typo golang/advanced

### DIFF
--- a/src/data/roadmaps/golang/content/101-go-advanced/110-scheduler.md
+++ b/src/data/roadmaps/golang/content/101-go-advanced/110-scheduler.md
@@ -1,6 +1,6 @@
 # Go Scheduler
 
-Go Scheduler allows us to understand more deeply about how Golang works internally. In terms of logical prcoessors, 
+Go Scheduler allows us to understand more deeply about how Golang works internally. In terms of logical processors, 
 cores, threads, pool cache, context switching etc. The Go scheduler is part of the Go runtime, and the Go runtime 
 is built into your application
 


### PR DESCRIPTION
"processors" instead of "prcoessors"