### PR TITLE
Fix persistant search result

### DIFF
--- a/src/components/CommandMenu/CommandMenu.tsx
+++ b/src/components/CommandMenu/CommandMenu.tsx
@@ -243,7 +243,7 @@ export function CommandMenu() {
                 const groupChanged = prevPage && prevPage.group !== page.group;
 
                 return (
-                  <Fragment key={page.id}>
+                  <Fragment key={page.group+'/'+page.id}>
                     {groupChanged && (
                       <div className="border-b border-gray-100"></div>
                     )}


### PR DESCRIPTION
fixes #6193 

the problem was that multiple groups had same .md filename resulting in same id and hence key in fragment. Hence, I made it a composite key.