### PR TITLE
useReducer typo error fixed in the new react roadmap

### DIFF
--- a/src/data/roadmaps/react/content/usereducer@v48Mv0wQqjXbvy8x6gDjQ.md
+++ b/src/data/roadmaps/react/content/usereducer@v48Mv0wQqjXbvy8x6gDjQ.md
@@ -1,0 +1,1 @@
+# useReducer

--- a/src/data/roadmaps/react/content/usreducer@v48Mv0wQqjXbvy8x6gDjQ.md
+++ b/src/data/roadmaps/react/content/usreducer@v48Mv0wQqjXbvy8x6gDjQ.md
@@ -1,1 +1,0 @@
-# usReducer

--- a/src/data/roadmaps/react/react.json
+++ b/src/data/roadmaps/react/react.json
@@ -1516,7 +1516,7 @@
       },
       "selected": false,
       "data": {
-        "label": "usReducer",
+        "label": "useReducer",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
# Hi I noticed that useReducer was misspelled  in the new react roadmap
## I renamed :
- ### File name from `usreducer@v48Mv0wQqjXbvy8x6gDjQ` to `usereducer@v48Mv0wQqjXbvy8x6gDjQ`
- ### Title inside it from `usReducer` to `useReducer`
- ### Inside `react.json`: "label": `usReducer` to `useReducer`