### PR TITLE
Update DevOps recommendation colour to purple

### DIFF
--- a/src/data/roadmaps/devops/devops.json
+++ b/src/data/roadmaps/devops/devops.json
@@ -490,7 +490,7 @@
         "oldId": "eL62bKAoJCMsu7zPlgyhy",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -568,7 +568,7 @@
         "oldId": "QCdemtWa2mE78poNXeqzr",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -679,7 +679,7 @@
         "legends": [
           {
             "id": "RkcQf9vafpvjAVpo02XhQ",
-            "color": "#2b78e4",
+            "color": "#874efe",
             "label": "Personal Recommendation / Opinion"
           },
           {
@@ -816,7 +816,7 @@
         "oldId": "z6IBekR8Xl-6f8WEb05Nw",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -892,7 +892,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -931,7 +931,7 @@
         "oldId": "-JGe6oHUuaAdakoOjTV5u",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1120,7 +1120,7 @@
         "oldId": "z6IBekR8Xl-6f8WEb05Nw",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1159,7 +1159,7 @@
         "oldId": "zhNUK953p6tjREndk3yQZ",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1198,7 +1198,7 @@
         "oldId": "7mS6Y_BOAHNgM3OjyFtZ9",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1237,7 +1237,7 @@
         "oldId": "OaqKLZe-XnngcDhDzCtRt",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1276,7 +1276,7 @@
         "oldId": "Jt8BmtLUH6fHT2pGKoJs3",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1354,7 +1354,7 @@
         "oldId": "z6IBekR8Xl-6f8WEb05Nw",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1454,7 +1454,7 @@
         "oldId": "-JGe6oHUuaAdakoOjTV5u",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1526,7 +1526,7 @@
         "oldId": "Z7SsBWgluZWr9iWb2e9XO",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1670,7 +1670,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1707,7 +1707,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -1744,7 +1744,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1929,7 +1929,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -1963,7 +1963,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         },
@@ -2002,7 +2002,7 @@
         "oldId": "qYRJYIZsmf-inMqKECRkI",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -2073,7 +2073,7 @@
         "oldId": "ctor79Vd7EXDMdrLyUcu_",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -2181,7 +2181,7 @@
         "oldId": "ctor79Vd7EXDMdrLyUcu_",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -2219,7 +2219,7 @@
         "oldId": "qYRJYIZsmf-inMqKECRkI",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -2257,7 +2257,7 @@
         "oldId": "eJZdjheptmiwKsVokt7Io",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -2521,7 +2521,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -2558,7 +2558,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -2595,7 +2595,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -2632,7 +2632,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -2670,7 +2670,7 @@
         "oldId": "QZ7bkY-MaEgxYoPDP3nma",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -3132,7 +3132,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -3205,7 +3205,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -3420,7 +3420,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -3490,7 +3490,7 @@
         "oldId": "XA__697KgofsH28coQ-ma",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -3633,7 +3633,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -3670,7 +3670,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -3779,7 +3779,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -3999,7 +3999,7 @@
         "oldId": "GHQWHLxsO40kJ6z_YCinJ",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -4143,7 +4143,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -4180,7 +4180,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -4217,7 +4217,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -4287,7 +4287,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -4614,7 +4614,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -4759,7 +4759,7 @@
         "oldId": "C_sFyIsIIpriZlovvcbSE",
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }
@@ -4867,7 +4867,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -4903,7 +4903,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -5473,7 +5473,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "left-center"
         }
@@ -5510,7 +5510,7 @@
         },
         "legend": {
           "id": "RkcQf9vafpvjAVpo02XhQ",
-          "color": "#2b78e4",
+          "color": "#874efe",
           "label": "Personal Recommendation / Opinion",
           "position": "right-center"
         }


### PR DESCRIPTION
In the version of Roadmap as of writing, the DevOps roadmap has the "Personal Recommendation" heading as the stroke line's blue (\#2b78e4), while on the legend's descriptor says "Pick this or Purple". This PR takes the purple in the Frontend and Backend roadmaps (\#874efe) and replaces all the blue legends in the DevOps roadmap with that colour.

Note that the changes haven't been tested yet, I don't have access to the Roadmap generator.


<img width="980" alt="DevOps roadmap with blue legends" src="https://github.com/user-attachments/assets/1ec6a90a-341e-46a8-a520-7984eb8b259f">

<img width="630" alt="Backend roadmap with purple legends" src="https://github.com/user-attachments/assets/d2e0c80b-3f7b-4150-8524-8d66cc5d4b27">

