### PR TITLE
fix: Wrong JavaScript type content

### DIFF
--- a/src/data/roadmaps/javascript/content/string@1RcwBHU3jzx0YxxUGZic4.md
+++ b/src/data/roadmaps/javascript/content/string@1RcwBHU3jzx0YxxUGZic4.md
@@ -1,11 +1,6 @@
 # String
-String is a primitive type that holds a sequence of characters. String in Javascript is written within a pair of single quotation marks '' or double quotation marks "". Both quotes can be used to contain a string but only if the starting quote is the same as the end quote.
 
-### Example
- ```JS
-let string1 = 'John' // Single quotation marks
-let string2 = "Doe" // Double quotation marks
-```
+String is a primitive type that holds a sequence of characters. String in Javascript is written within a pair of single quotation marks '' or double quotation marks "". Both quotes can be used to contain a string but only if the starting quote is the same as the end quote.
 
 Visit the following resources to learn more:
 

--- a/src/data/roadmaps/javascript/content/string@1RcwBHU3jzx0YxxUGZic4.md
+++ b/src/data/roadmaps/javascript/content/string@1RcwBHU3jzx0YxxUGZic4.md
@@ -1,21 +1,12 @@
-# Primitive Types
+# String
+String is a primitive type that holds a sequence of characters. String in Javascript is written within a pair of single quotation marks '' or double quotation marks "". Both quotes can be used to contain a string but only if the starting quote is the same as the end quote.
 
-In JavaScript, a primitive (primitive value, primitive data type) is data that is not an object and has no methods or properties. A significant difference between primitive data types and non-primitives is that primitive types can only contain one value, and that value must be of the same primitive type. In contrast, non-primitives can accommodate a variable number of values, and these values can be of different primitive types. This flexibility is evident in data structures like arrays and objects.
-
-In the context of primitives, it's important to note that they do not possess methods or properties. However, JavaScript enables access to methods and properties associated with primitive types such as string, number, and boolean. this functionality is due to JavaScript's ability to implicitly convert primitives to objects with wrapper objects when necessary. When properties are accessed on primitives, JavaScript auto-boxes the value into a wrapper object and accesses the property on that object instead.
-
-There are 7 primitive data types:
-
-- `string`
-- `number`
-- `bigint`
-- `boolean`
-- `undefined`
-- `Symbol`
-- `null`
-
-Most of the time, a primitive value is represented directly at the lowest level of the language implementation.
+### Example
+ ```JS
+let string1 = 'John' // Single quotation marks
+let string2 = "Doe" // Double quotation marks
+```
 
 Visit the following resources to learn more:
 
-- [@article@Primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive)
+- [@article@String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)


### PR DESCRIPTION
The content in String type on JavaScript roadmap isn't correct. It shows Primitive type instead. This is the new content.