### PR TITLE
Add content under Swift Basics section on the iOS roadmap

### DIFF
--- a/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
+++ b/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
@@ -1,1 +1,3 @@
 # Swift Basics
+
+Take this quick [tour](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour) on Swift to get a glimpse of what this beauitful language has to offer. It'll be a fun read.

--- a/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
+++ b/src/data/roadmaps/ios/content/swift-basics@fboebSmquyJyozsMRJDtK.md
@@ -1,3 +1,8 @@
 # Swift Basics
 
-Take this quick [tour](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour) on Swift to get a glimpse of what this beauitful language has to offer. It'll be a fun read.
+
+Swift is a powerful and intuitive programming language for macOS, iOS, watchOS, and tvOS. Writing Swift code is interactive and fun, the syntax is concise yet expressive, and Swift includes modern features developers love. Swift code is safe by design, yet also produces software that runs lightning-fast.
+
+Learn more from the following resources:
+
+- [@official@Tour of Swift](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/guidedtour)


### PR DESCRIPTION
I've added a quick link to the standard Swift Tour. It'll be a perfect pointer to place under this section.

Do merge if you found this useful and relevant. 

Thanks and you're welcome!