### PR TITLE
docs(angular): add language service content

### DIFF
--- a/src/data/roadmaps/angular/content/language-service@ql7SyxrRmjpiXJ9hQeWPq.md
+++ b/src/data/roadmaps/angular/content/language-service@ql7SyxrRmjpiXJ9hQeWPq.md
@@ -1,1 +1,8 @@
 # Language Service
+
+The Angular Language Service provides code editors with a way to get completions, errors, hints, and navigation inside Angular templates (external and in-line). Anytime you open an Angular application for the first time, an installation prompt will occur.
+
+Visit the following links to learn more:
+
+- [@official@Language Service Docs](https://angular.dev/tools/language-service)
+- [@opensource@VS Code NG Language Service](https://github.com/angular/vscode-ng-language-service)


### PR DESCRIPTION
The installation prompt does occur if the project was created with the Angular CLI, which the vast majority of projects should have been created with.   