### PR TITLE
Minor touch ups to guide content and fixed canonical authors link issue

### DIFF
--- a/src/data/guides/how-to-become-devops-engineer.md
+++ b/src/data/guides/how-to-become-devops-engineer.md
@@ -83,7 +83,7 @@ The following section presents a complete DevOps roadmap on how you can learn th
 
 The internet is full of resources for learning DevOps and DevOps tools. Many of these guides lack structure and organization, resulting in a dilemma of where to start. 
 
-To help beginners learn DevOps in a structured manner, [roadmap.sh](http://roadmap.sh/) has a beginner-friendly [DevOps engineer roadmap](https://roadmap.sh/devops?r=devops-beginner) that will help you land into DevOps engineer positions. 
+To help beginners learn DevOps in a structured manner, [roadmap.sh](https://roadmap.sh/) has a beginner-friendly [DevOps engineer roadmap](https://roadmap.sh/devops?r=devops-beginner) that will help you land into DevOps engineer positions. 
 
 This section presents a concise version of the DevOps engineering roadmap. It is recommended that you implement real-world projects recommended in each stage of the roadmap. In the end, you can publish these DevOps projects to GitHub as an open-source project repository, and the repository will act as your portfolio and increase your exposure in the DevOps community.
 

--- a/src/data/guides/journey-to-http2.md
+++ b/src/data/guides/journey-to-http2.md
@@ -159,7 +159,7 @@ By now, you must be convinced that why we needed another revision of the HTTP pr
 
 ##### Frames and Streams
 
-HTTP messages are now composed of one or more frames. There is a `HEADERS` frame for the meta data and `DATA` frame for the payload and there exist several other types of frames (`HEADERS`, `DATA`, `RST_STREAM`, `SETTINGS`, `PRIORITY` etc) that you can check through [the `HTTP/2` specs](https:/http2.github.iohttp2-spec/#FrameTypes).
+HTTP messages are now composed of one or more frames. There is a `HEADERS` frame for the meta data and `DATA` frame for the payload and there exist several other types of frames (`HEADERS`, `DATA`, `RST_STREAM`, `SETTINGS`, `PRIORITY` etc) that you can check through [the `HTTP/2` specs](https://httpwg.org/specs/rfc7540.html#iana-frames).
 
 Every `HTTP/2` request and response is given a unique stream ID and it is divided into frames. Frames are nothing but binary pieces of data. A collection of frames is called a Stream. Each frame has a stream id that identifies the stream to which it belongs and each frame has a common header. Also, apart from stream ID being unique, it is worth mentioning that, any request initiated by client uses odd numbers and the response from server has even numbers stream IDs.
 
@@ -197,6 +197,6 @@ There was extensive discussion on whether security (through `TLS`) should be mad
 
 `HTTP/2` is here and it has already [surpassed SPDY in adaption](https://caniuse.com/#search=http2) which is gradually increasing. `HTTP/2` has alot to offer in terms of performance gain and it is about time we should start using it.
 
-For anyone interested in further details here is the [link to specs](https:/http2.github.iohttp2-spec) and a link [demonstrating the performance benefits of `HTTP/2`](https://www.http2demo.io/).
+For anyone interested in further details here is the [link to specs](https://httpwg.org/specs/rfc9113.html) and a link [demonstrating the performance benefits of `HTTP/2`](https://www.http2demo.io/).
 
 And that about wraps it up. Until next time! stay tuned.

--- a/src/pages/authors/[authorId].astro
+++ b/src/pages/authors/[authorId].astro
@@ -31,7 +31,7 @@ const videos = await getVideosByAuthor(authorId);
 ---
 
 <BaseLayout
-  permalink={`/author/${author.id}`}
+  permalink={`/authors/${author.id}`}
   title={`${author.frontmatter.name} - Author at roadmap.sh`}
   briefTitle={author.frontmatter.name}
   ogImageUrl={`https://roadmap.sh/${authorFrontmatter.imageUrl}`}


### PR DESCRIPTION
Fixed a couple of small http vs https issues that @Edlan01 raised & corrected the incorrect canonical link issue for author pages (see issue below)


<img width="488" alt="Screenshot 2024-08-08 at 10 52 24" src="https://github.com/user-attachments/assets/cf9ea99f-b541-4365-9432-79fd2e03bcb3">


The link that users navigate too via a guide is correct at `/authors/*` but the canonical link is incorrect at `/author/*`