### PR TITLE
Centered the html logo on frontend language guide

### DIFF
--- a/src/data/guides/frontend-languages.md
+++ b/src/data/guides/frontend-languages.md
@@ -77,7 +77,9 @@ These are the best front-end languages you should learn in 2024:
 
 ### HyperText Markup Language (HTML)
 
-![HTML HyperText Markup Language](https://assets.roadmap.sh/guest/html-bmvj9.png)
+<p align="center">
+  <img src="https://assets.roadmap.sh/guest/html-bmvj9.png" alt="HTML HyperText Markup Language" />
+</p>
 
 HTML is the standard markup language for creating web pages. It defines the structure and layout of content within a web browser, allowing for the display of text, images, videos, and more that users interact with. HTML is beginner-friendly, supported across multiple browsers, and fundamental to web development. 
 


### PR DESCRIPTION
As the title says, center the logo.

<img width="703" alt="Screenshot 2024-08-08 at 11 15 35" src="https://github.com/user-attachments/assets/3a11f078-8a55-4e1b-80bd-b55162fb4213">
