### PR TITLE
fixed typo react-router instead of Remix

### DIFF
--- a/src/data/roadmaps/frontend/frontend.json
+++ b/src/data/roadmaps/frontend/frontend.json
@@ -3088,7 +3088,7 @@
       },
       "selected": false,
       "data": {
-        "label": "react-router",
+        "label": "Remix",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
In the frontend roadmap in the SSR section says React NextJs, Astro and then react-rotuer when it should say Remix