### PR TITLE
Use VS Code, not Emacs

### DIFF
--- a/src/data/roadmaps/devops/devops.json
+++ b/src/data/roadmaps/devops/devops.json
@@ -1345,7 +1345,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Vim / Nano /  Emacs",
+        "label": "Vim / Nano / VS Code",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
I use Emacs as my standard IDE because it's what I learned in college. I love being able to do everything from the keyboard and not have to use a mouse. However, I never recommend anyone to learn Emacs because of ergonomics: having to put one's pinky on the Ctrl key so much to get around makes me have to be very careful about how must stress I put on my hands.

Instead of Emacs, I recommend using VS Code. It's a good modern IDE with lots of great integrations. It's easy to learn, and has great support.

For editors you need to be able to use from the command-line, vi is the only one that's needed. Maybe nano, but there's really nothing to "learn" because it's self-explanatory with the legend at the bottom of the Ctrl keys. So I think really the standard DevOps engineer should know the best full-functioning IDE + vi. The list recommended by the DevOps guide on this site, although opinionated, should have recommendations that I think would be shared by the majority of DevOps engineers. Plus, for helping support developers, DevOps engineers should know how to use the same tools developers do.

A comparison between Emacs & VS Code:

* https://www.g2.com/compare/gnu-emacs-vs-visual-studio-code
