### PR TITLE
Fix typo in software architecture definition

### DIFF
--- a/src/data/roadmaps/software-architect/software-architect.json
+++ b/src/data/roadmaps/software-architect/software-architect.json
@@ -500,7 +500,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Describes how an application is built including its components, how they interact with eachother, environment in which they operate and so on.",
+        "label": "Describes how an application is built including its components, how they interact with each other, environment in which they operate and so on.",
         "style": {
           "fontSize": 17,
           "borderColor": "transparent",


### PR DESCRIPTION
Hi :wave: 

Thank you very much for this great content.

The goal of this PR is just to fix a small typo, replacing 'eachother' by 'each other'.

https://www.grammarbook.com/blog/definitions/eachother-or-each-other/