### PR TITLE
Update template-literal-types@xP25nGw42VqdfZ_9pDMXd.md

### DIFF
--- a/src/data/roadmaps/typescript/content/template-literal-types@xP25nGw42VqdfZ_9pDMXd.md
+++ b/src/data/roadmaps/typescript/content/template-literal-types@xP25nGw42VqdfZ_9pDMXd.md
@@ -1,6 +1,6 @@
 # Template Literal Types
 
-Template literal types in TypeScript are a way to manipulate string values as types. They allow you to create a type based on the result of string manipulation or concatenation. Template literal types are created using the backtick (``) character and string manipulation expressions within the type.
+Template literal types in TypeScript are a way to manipulate string values as types. They allow you to create a type based on the result of string manipulation or concatenation. Template literal types are created using the backtick `` ` `` character and string manipulation expressions within the type.
 
 For example, the following is a template literal type that concatenates two strings:
 


### PR DESCRIPTION
This makes the backtick render correctly. I noticed in different browsers that the double backtick would render as “ instead of two single backticks next to each other.