### PR TITLE
Golang Structs : Video for struct tags not available on youtube anymo…

### DIFF
--- a/src/data/roadmaps/golang/content/100-go-basics/116-structs.md
+++ b/src/data/roadmaps/golang/content/100-go-basics/116-structs.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [@official@Go Structs](https://go.dev/tour/moretypes/2)
 - [@article@Go by Example: Structs](https://gobyexample.com/structs)
 - [@video@Structs in Go](https://www.youtube.com/watch?v=NMTN543WVQY)
-- [@video@Structs, Struct tags](https://www.youtube.com/watch?v=0m6ifd9n_cy&list=ploilbko9rg3skrcj37kn5zj803hhiurk6&index=13)
+- [@video@Struct tags and creating own tags through reflection](https://www.youtube.com/watch?v=vtHZb7gNlbw)


### PR DESCRIPTION
The video provided in the structs section of golang roadmap is not available on youtube anymore. I found this great video which explains struct tags and also introduces reflection api to demonstrate how we can create a custom struct tag. 