### PR TITLE
docs(code-review): fix typo "Veryfing" to "Verifying"

### DIFF
--- a/src/data/best-practices/code-review/content/change-functioning.md
+++ b/src/data/best-practices/code-review/content/change-functioning.md
@@ -1,6 +1,6 @@
 # Verify the Change in Production.
 
-Veryfing the change is a crucial step in the code review process that ensures the recently merged changes work correctly and do not cause any unexpected disruptions when deployed to the live production environment. Rigorous testing before deployment helps minimize the risks, but having an additional layer of validation post-deployment provides you with the confidence that your code changes are working as intended while interacting with real users and production data. To make sure of this, consider the following tips:
+Verifying the change is a crucial step in the code review process that ensures the recently merged changes work correctly and do not cause any unexpected disruptions when deployed to the live production environment. Rigorous testing before deployment helps minimize the risks, but having an additional layer of validation post-deployment provides you with the confidence that your code changes are working as intended while interacting with real users and production data. To make sure of this, consider the following tips:
 
 - Implement automated monitoring and alerting systems to keep track of your application's key performance indicators (KPIs) and notify you in case of a significant change in the metrics.
 


### PR DESCRIPTION
I found a typo in `change-functioning.md` for the code-review roadmap.


![Screenshot 2024-08-19 at 8 15 08 PM](https://github.com/user-attachments/assets/399890d8-2696-4908-95cb-06593a69d658)
