### PR TITLE
Fix: Replace "article" with "official" for Jest Website

### DIFF
--- a/src/data/roadmaps/nodejs/content/jest@5xrbKv2stKPJRv7Vzf9nM.md
+++ b/src/data/roadmaps/nodejs/content/jest@5xrbKv2stKPJRv7Vzf9nM.md
@@ -4,6 +4,6 @@ Jest is a delightful JavaScript Testing Framework with a focus on simplicity. It
 
 Visit the following resources to learn more:
 
-- [@article@Jest Website](https://jestjs.io)
+- [@official@Jest Website](https://jestjs.io)
 - [@article@Jest Documentation](https://jestjs.io/docs/getting-started)
 - [@feed@Explore top posts about Jest](https://app.daily.dev/tags/jest?ref=roadmapsh)


### PR DESCRIPTION
Corrects the typo where 'article' was mistakenly used instead of 'official' when referencing the Jest website.