### PR TITLE
Fix: Remove / from link

### DIFF
--- a/src/data/roadmaps/api-design/content/stoplight@OpS2NX1lPTOtfjV1wKtC4.md
+++ b/src/data/roadmaps/api-design/content/stoplight@OpS2NX1lPTOtfjV1wKtC4.md
@@ -5,4 +5,4 @@ Stoplight is an advanced tool that offers a comprehensive platform for technical
 Learn more from the following resources:
 
 - [@official@Stoplight Website](https://stoplight.io/)
-- [@opensource@/stoplightio](https://github.com/stoplightio)
+- [@opensource@stoplightio](https://github.com/stoplightio)


### PR DESCRIPTION
Removed the unnecessary `/` from the @opensource@/stoplightio link.