### PR TITLE
Fix: Change "opesource" to "opensource"

### DIFF
--- a/src/data/roadmaps/nodejs/content/drizzle@JXQF9H4_N0rM7ZDKcCZNn.md
+++ b/src/data/roadmaps/nodejs/content/drizzle@JXQF9H4_N0rM7ZDKcCZNn.md
@@ -6,5 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Drizzle Website](https://orm.drizzle.team/)
 - [@official@Drizzle Documentation](https://orm.drizzle.team/docs/overview)
-- [@opesource@Drizzle Github](https://github.com/drizzle-team/drizzle-orm)
+- [@opensource@Drizzle Github](https://github.com/drizzle-team/drizzle-orm)
 - [@article@Getting Started with Drizzle](https://dev.to/franciscomendes10866/getting-started-with-drizzle-orm-a-beginners-tutorial-4782)


### PR DESCRIPTION
Corrects the typo where "n" was missing in "opensource".