### PR TITLE
Fix: Replace "article" with "official" for Mongoose Website

### DIFF
--- a/src/data/roadmaps/nodejs/content/mongoose@NDf-o-WECK02mVnZ8IFxy.md
+++ b/src/data/roadmaps/nodejs/content/mongoose@NDf-o-WECK02mVnZ8IFxy.md
@@ -4,6 +4,6 @@ Mongoose is an Object Data Modeling (ODM) library for MongoDB and Node.js. Mongo
 
 Visit the following resources to learn more:
 
-- [@article@Mongoose Website](https://mongoosejs.com)
+- [@official@Mongoose Website](https://mongoosejs.com)
 - [@article@Getting Started with MongoDB and Mongoose](https://www.mongodb.com/developer/languages/javascript/getting-started-with-mongodb-and-mongoose/)
 - [@feed@Explore top posts about Mongoose](https://app.daily.dev/tags/mongoose?ref=roadmapsh)


### PR DESCRIPTION
Corrects the typo where 'article' was mistakenly used instead of 'official'.