### PR TITLE
Moved misplaced articles from Typecasting to Exceptions

### DIFF
--- a/src/data/roadmaps/python/content/exceptions@fNTb9y3zs1HPYclAmu_Wv.md
+++ b/src/data/roadmaps/python/content/exceptions@fNTb9y3zs1HPYclAmu_Wv.md
@@ -3,4 +3,8 @@
 Python exceptions are events that occur during the execution of a program and disrupt the normal flow of the program's instructions. When an exception is raised, it indicates that an error has occurred. Python provides a way to handle these exceptions using try-except blocks, allowing developers to manage errors gracefully and ensure the program can continue or exit smoothly.
 
 - [@official@Exceptions Documentation](https://docs.python.org/3/tutorial/errors.html#exceptions)
+- [@article@Python Exceptions: An Introduction](https://realpython.com/python-exceptions/)
+- [@article@Errors and Exceptions](https://docs.python.org/3/tutorial/errors.html)
+- [@article@Python Exception Handling](https://www.programiz.com/python-programming/exception-handling)
+- [@article@Python Try Except](https://www.w3schools.com/python/python_try_except.asp)
 - [@video@Exception Handling in Python](https://www.youtube.com/watch?v=V_NXT2-QIlE)

--- a/src/data/roadmaps/python/content/type-casting@R9DQNc0AyAQ2HLpP4HOk6.md
+++ b/src/data/roadmaps/python/content/type-casting@R9DQNc0AyAQ2HLpP4HOk6.md
@@ -5,7 +5,3 @@ The process of converting the value of one data type (integer, string, float, et
 Visit the following resources to learn more:
 
 - [@article@Type Conversion and Casting](https://www.programiz.com/python-programming/type-conversion-and-casting)
-- [@article@Python Exceptions: An Introduction](https://realpython.com/python-exceptions/)
-- [@article@Errors and Exceptions](https://docs.python.org/3/tutorial/errors.html)
-- [@article@Python Exception Handling](https://www.programiz.com/python-programming/exception-handling)
-- [@article@Python Try Except](https://www.w3schools.com/python/python_try_except.asp)


### PR DESCRIPTION
Roadmap edited: Python
Topics edited: Typecasting, Exceptions
Path used: .../developer-roadmap/src/data/roadmaps/python/content

Description:
I moved misplaced articles that had to do with exceptions from the Typecasting topic to the Exceptions topic.

