### PR TITLE
remove link loc from 102-storage-volume.md

### DIFF
--- a/src/data/roadmaps/aws/content/101-ec2/102-storage-volume.md
+++ b/src/data/roadmaps/aws/content/101-ec2/102-storage-volume.md
@@ -4,4 +4,4 @@ In AWS, an `Amazon EBS` (Elastic Block Store) is the storage volume used by EC2 
 
 Visit the following resources to learn more:
 
-- [@official@Elastic Block Store](https://docs.aws.amazon.com/pt_br/ebs/latest/userguide/what-is-ebs.html)
+- [@official@Elastic Block Store](https://docs.aws.amazon.com/ebs/latest/userguide/what-is-ebs.html)


### PR DESCRIPTION
the link to Elastic Block Store documentation has a hard coded language that causes it to open to the Portuguese version

removing this will default to the users preferred language