### PR TITLE
bug-fix: according to the following issue -> Incorrect DevOps navigation

### DIFF
--- a/src/data/roadmaps/mlops/mlops.json
+++ b/src/data/roadmaps/mlops/mlops.json
@@ -632,7 +632,7 @@
       "selected": false,
       "data": {
         "label": "DevOps Roadmap",
-        "href": "https://github.com/utilForever",
+        "href": "https://roadmap.sh/devops",
         "color": "#000000",
         "backgroundColor": "#dedede",
         "style": {


### PR DESCRIPTION
bug-fix: according to the following issue -> Incorrect DevOps navigation in MLOps roadmap #6807

- changed link : https://github.com/utilForever -> https://roadmap.sh/devops in 
[mlops.json](https://github.com/kamranahmedse/developer-roadmap/blob/master/public/roadmap-content/mlops.json)