### PR TITLE
fix(angular): remove duplicate template ref vars files

### DIFF
--- a/src/data/roadmaps/angular/angular.json
+++ b/src/data/roadmaps/angular/angular.json
@@ -2580,39 +2580,6 @@
       "resizing": false
     },
     {
-      "id": "Wc2ybRw43uamEtno0FpDv",
-      "type": "subtopic",
-      "position": {
-        "x": -99.73327447982547,
-        "y": 957.2304293708296
-      },
-      "selected": false,
-      "data": {
-        "label": "Template Ref Vars",
-        "style": {
-          "fontSize": 17,
-          "justifyContent": "flex-start",
-          "textAlign": "center"
-        },
-        "oldId": "nyDry6ZWyEUuTq4pw-lU3"
-      },
-      "zIndex": 999,
-      "width": 225,
-      "height": 49,
-      "style": {
-        "width": 225,
-        "height": 49
-      },
-      "positionAbsolute": {
-        "x": -99.73327447982547,
-        "y": 957.2304293708296
-      },
-      "dragging": false,
-      "resizing": false,
-      "selectable": true,
-      "focusable": true
-    },
-    {
       "id": "VsU6713jeIjAOEZnF6gWx",
       "type": "subtopic",
       "position": {

--- a/src/data/roadmaps/angular/content/template-ref-vars@Wc2ybRw43uamEtno0FpDv.md
+++ b/src/data/roadmaps/angular/content/template-ref-vars@Wc2ybRw43uamEtno0FpDv.md
@@ -1,1 +1,0 @@
-# Template Ref Vars


### PR DESCRIPTION
Unneeded duplication of `Template Ref Vars` file.  Removed the one without content.