### PR TITLE
Remove “official” from JavaScript.com

### DIFF
--- a/public/roadmap-content/backend.json
+++ b/public/roadmap-content/backend.json
@@ -224,7 +224,7 @@
         "type": "article"
       },
       {
-        "title": "Official JavaScript Documentation",
+        "title": "JavaScript Beginner Resources",
         "url": "https://www.javascript.com/",
         "type": "article"
       },


### PR DESCRIPTION
Removes the title “Official JavaScript Documentation” from javascript.com. It is not official documentation (heck it’s not even _documentation_); it’s basically an advertisement for a for-profit company who is uninvolved with TC39 and just ponied up for the domain\*. Not to say that it doesn’t have good resources; I think it’s helpful. But it’s not “official” by any means and it’s not correct to call it as such.

\* I should know—I was working at the company that bought it, when they bought it. It was always intended to be a marketing tool. It was bought while I worked at CodeSchool, which then got bought by PluralSight, and it just got shuffled over during the acquisition.