### PR TITLE
Remove redundant link in backend roadmap

### DIFF
--- a/src/data/roadmaps/backend/content/orms@Z7jp_Juj5PffSxV7UZcBb.md
+++ b/src/data/roadmaps/backend/content/orms@Z7jp_Juj5PffSxV7UZcBb.md
@@ -5,6 +5,5 @@ Object-Relational Mapping (ORM) is a technique that lets you query and manipulat
 Visit the following resources to learn more:
 
 - [@article@Object Relational Mapping - Wikipedia](https://en.wikipedia.org/wiki/Object–relational_mapping)
-- [@article@What is an ORM and how should I use it?](https://stackoverflow.com/questions/1279613/what-is-an-orm-how-does-it-work-and-how-should-i-use-one)
 - [@article@What is an ORM, how does it work, and how should I use one?](https://stackoverflow.com/a/1279678)
 - [@feed@Explore top posts about Backend Development](https://app.daily.dev/tags/backend?ref=roadmapsh)


### PR DESCRIPTION
this PR addresses this issue https://github.com/kamranahmedse/developer-roadmap/issues/6979, in where we have 2 stackoverflow links that are the same, this removes the question link