### PR TITLE
Remove unavailable nudge theory video

### DIFF
--- a/src/data/roadmaps/ux-design/content/nudge-theory@6ffY5wO-XhkiDJJ5YcI0x.md
+++ b/src/data/roadmaps/ux-design/content/nudge-theory@6ffY5wO-XhkiDJJ5YcI0x.md
@@ -11,6 +11,5 @@ In the context of UX design, nudge theory can be applied in various ways to infl
 
 When applying nudge theory in UX design, it's crucial to maintain a balance between encouraging positive behaviors and respecting user autonomy. Designers should aim to empower users with meaningful choices and useful information, rather than manipulating or deceiving them.
 
-- [@video@Nudge Theory Explained with Examples (on YouTube)](https://www.youtube.com/watch?v=u3yxxteiyya&ab_channel=epm)
 - [@video@Nudge Theory Explained in less than 10 minutes](https://youtu.be/fA5eGIMZTRQ)
 - [@article@Nudge Theory overview with examples](https://www.businessballs.com/improving-workplace-performance/nudge-theory/)


### PR DESCRIPTION
The video "Nudge Theory Explained with Examples" isn't available anymore, so I removed it from the topic.

![image](https://github.com/user-attachments/assets/0612b658-ab57-436e-95f6-b1b8dece4548)
