### PR TITLE
docs(rust): fix typo on functions content page

### DIFF
--- a/src/data/roadmaps/rust/content/101-language-basics/100-syntax/103-functions.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/100-syntax/103-functions.md
@@ -1,4 +1,4 @@
- Functions and Method Syntax
+# Functions and Method Syntax
 
 In Rust, functions are declared using the `fn` keyword. Each function can take a set of input variables with their specified types, and may return data of a specified type. The body of a function is contained within curly braces `{}`. Unlike other languages, in Rust, you don't need to end the last statement in a block with a semicolon; omitting the last semicolon of a block in this way turns the last statement into an expression, and the result of this expression becomes the implicit return value of the block. In other words, if we want to return a value, we simply write the expression we want to return.
 


### PR DESCRIPTION
This PR fixes a typo on the functions and method page of Rust Roadmap, causing the title getting rendered as body when it should be a header