### PR TITLE
Added the missed article link for the PostgreSQL DBA Roadmap.

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/set-operations@kOwhnSZBwIhIbIsoAXQ50.md
+++ b/src/data/roadmaps/postgresql-dba/content/set-operations@kOwhnSZBwIhIbIsoAXQ50.md
@@ -7,3 +7,4 @@ Learn more from the following resources:
 - [@official@Combining Queries](https://www.postgresql.org/docs/current/queries-union.html)
 - [@article@PostgreSQL UNION Operator](https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-union/)
 - [@article@PostgreSQL INTERSECT Operator](https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-intersect/)
+- [@article@PostgreSQL EXCEPT Operator](https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-except/)


### PR DESCRIPTION
In the Set Operations in PostgreSQL Step, 

There are three set operations: 
1. UNION, 
2. INTERSECT, and 
3. EXCEPT. 

The EXCEPT operation's article link is missing at the bottom. This is a PR for adding the article link.

Please take a look at the image below.
<img width="523" alt="Screenshot 2024-09-08 at 10 03 01 PM" src="https://github.com/user-attachments/assets/bf73fadd-4e1a-41cb-b9a5-890d79e3838d">


