### PR TITLE
Replace Assembly with GDScript

### DIFF
--- a/src/data/roadmaps/game-developer/content/assembly@AaRZiItRcn8fYb5R62vfT.md
+++ b/src/data/roadmaps/game-developer/content/assembly@AaRZiItRcn8fYb5R62vfT.md
@@ -1,5 +1,0 @@
-# Assembly
-
-**Assembly** is a low-level programming language, often used for direct hardware manipulation, real-time systems, and to write performance-critical code. It provides a strong correspondence between its instructions and the architecture's machine-code instructions, since it directly represents the specific commands of the computer's CPU structure. However, it's closer to machine language (binary code) than to human language, which makes it difficult to read and understand. The syntax varies greatly, which depends upon the CPU architecture for which it's designed, thus Assembly language written for one type of processor can't be used on another. Despite its complexity, time-intensive coding process and machine-specific nature, Assembly language is still utilized for speed optimization and hardware manipulation where high-level languages may not be sufficient.
-
-- [@video@Code walkthrough of a game written in x64 assembly](https://www.youtube.com/watch?v=WUoqlp30M78)

--- a/src/data/roadmaps/game-developer/content/gdscript@AaRZiItRcn8fYb5R62vfT.md
+++ b/src/data/roadmaps/game-developer/content/gdscript@AaRZiItRcn8fYb5R62vfT.md
@@ -1,0 +1,8 @@
+# GDScript
+
+GDScript is a high-level, dynamically-typed programming language designed specifically for the Godot Engine, an open-source game development platform. It is tailored for ease of use and rapid development of game logic and functionality. GDScript features a syntax similar to Python, which simplifies learning and coding for developers familiar with Python, while providing direct access to Godot's rich set of built-in functions and game-specific APIs. The language integrates closely with Godot's scene system and scripting environment, enabling developers to create and manipulate game objects, handle input, and control game behavior efficiently.
+
+Learn more from the following resources:
+
+- [@official@GDScript Website](https://gdscript.com/)
+- [@video@How to program in Godot - GDScript Tutorial](https://www.youtube.com/watch?v=e1zJS31tr88)

--- a/src/data/roadmaps/game-developer/game-developer.json
+++ b/src/data/roadmaps/game-developer/game-developer.json
@@ -2525,7 +2525,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Assembly",
+        "label": "GDScript",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
Assembly is extremely niche in game development yet the rise in popularity of Godot makes GDScript all the more prevalent 