### PR TITLE
Fix: Replace "article" with "official" for Ruby Website

### DIFF
--- a/src/data/roadmaps/datastructures-and-algorithms/content/100-language/107-ruby.md
+++ b/src/data/roadmaps/datastructures-and-algorithms/content/100-language/107-ruby.md
@@ -4,7 +4,7 @@ Ruby is a high-level, interpreted programming language that blends Perl, Smallta
 
 Visit the following resources to learn more:
 
-- [@article@Ruby Website](https://www.ruby-lang.org/en/)
+- [@official@Ruby Website](https://www.ruby-lang.org/en/)
 - [@article@Learn Ruby in 20 minutes](https://www.ruby-lang.org/en/documentation/quickstart/)
 - [@article@Ruby, An Introduction to a Programmer’s Best Friend](https://thenewstack.io/ruby-a-programmers-best-friend/)
 - [@feed@Explore top posts about Ruby](https://app.daily.dev/tags/ruby?ref=roadmapsh)


### PR DESCRIPTION
Corrects the typo where 'article' was mistakenly used instead of 'official'.