### PR TITLE
Add formatting so the HTML elements don't get rendered

### DIFF
--- a/src/data/roadmaps/vue/content/v-model@cxu2Wbt306SxM4JKQQqnL.md
+++ b/src/data/roadmaps/vue/content/v-model@cxu2Wbt306SxM4JKQQqnL.md
@@ -1,5 +1,5 @@
 # v-model
 
-The v-model directive in Vue.js is used for creating two-way data bindings on form input elements, such as <input>, <textarea>, and <select>. This means that the data can be updated in the component when the user inputs something, and the UI will update if the data in the component changes.
+The v-model directive in Vue.js is used for creating two-way data bindings on form input elements, such as `<input>`, `<textarea>`, and `<select>`. This means that the data can be updated in the component when the user inputs something, and the UI will update if the data in the component changes.
 
 - [@article@Form Input Bindings](https://vuejs.org/guide/essentials/forms.html)


### PR DESCRIPTION
The <input> <textarea> and <select> elements are attempted to be rendered by the browser so they aren't visible as text