### PR TITLE
Add `loop` and `if let` structures to "Control Flow Constructs" in Rust roadmap.

### DIFF
--- a/src/data/roadmaps/rust/content/101-language-basics/100-syntax/102-control-flow.md
+++ b/src/data/roadmaps/rust/content/101-language-basics/100-syntax/102-control-flow.md
@@ -1,7 +1,8 @@
 # Control Flow Constructs
 
-In Rust, control flow is managed through various structures, like `if`, `else`, `while`, `for`, and `match`. The `if` and `else` structures are used to execute different blocks of code based on certain conditions. Similar to other languages, `while` and `for` are used for looping over a block of code. The `while` loop repeats a block of code until the condition is false, and the `for` loop is used to iterate over a collection of values, such as an array or a range. Rust's `match` structure, which is similar to switch statements in other languages, is a powerful tool used for pattern matching: it checks through different cases defined by the programmer and executes the block where the match is found.
+In Rust, control flow is managed through various structures, like `if`, `else`, `while`, `for`, `loop`, `match` and `if let`. The `if` and `else` structures are used to execute different blocks of code based on certain conditions. Similar to other languages, `while` and `for` are used for looping over a block of code. The `while` loop repeats a block of code until the condition is false, and the `for` loop is used to iterate over a collection of values, such as an array or a range. The `loop` keyword tells Rust to execute a block of code over and over again forever or until you explicitly tell it to stop. Rust's `match` structure, which is similar to switch statements in other languages, is a powerful tool used for pattern matching: it checks through different cases defined by the programmer and executes the block where the match is found. The `if let` syntax lets you combine `if` and `let` into a less verbose way to handle values that match one pattern while ignoring the rest.
 
 Learn more from the following links:
 
 - [@article@Control Flow](https://rust-book.cs.brown.edu/ch03-05-control-flow.html)
+- [@article@Concise Control Flow with `if let`](https://rust-book.cs.brown.edu/ch06-03-if-let.html)


### PR DESCRIPTION
I have found that `loop` and `if let` are not present with other structures in **Control Flow Constructs**, so I added them and a link to [**Concise Control Flow with `if let`**](https://rust-book.cs.brown.edu/ch06-03-if-let.html) in Rust Book