### PR TITLE
Delete invalid URL

### DIFF
--- a/src/data/roadmaps/flutter/content/100-dart-basics/index.md
+++ b/src/data/roadmaps/flutter/content/100-dart-basics/index.md
@@ -6,7 +6,6 @@ Visit the following resources to learn more:
 
 - [@official@Dart Overview](https://dart.dev/overview)
 - [@article@What is Dart Programming?](https://www.javatpoint.com/flutter-dart-programming)
-- [@article@About Dart](https://flutterbyexample.com/lesson/about-dart)
 - [@video@What is Dart?](https://www.youtube.com/watch?v=sOSd6G1qXoY)
 - [@video@Dart in 100 Seconds](https://www.youtube.com/watch?v=NrO0CJCbYLA)
 - [@feed@Explore top posts about Dart](https://app.daily.dev/tags/dart?ref=roadmapsh)


### PR DESCRIPTION
Invalid URL: https://flutterbyexample.com/lesson/about-dart

PS: not sure what happened to the initial website but looks like it was transformed into something else.