### PR TITLE
Add backend frameworks guide

### DIFF
--- a/src/data/guides/backend-frameworks.md
+++ b/src/data/guides/backend-frameworks.md
@@ -6,7 +6,7 @@ excludedBySlug: '/backend/frameworks'
 seo:
   title: 'Top 7 Backend Frameworks to Use in 2024: Pro Advice'
   description: 'Get expert advice on backend frameworks for 2024. Learn about the top 7 frameworks that can elevate your development process.'
-  ogImageUrl: 'https://assets.roadmap.sh/guest/backend-languages-2x930.jpg'
+  ogImageUrl: 'https://assets.roadmap.sh/guest/top-backend-frameworks-jfpux.jpg'
 isNew: true
 type: 'textual'
 date: 2024-09-27

--- a/src/data/guides/backend-frameworks.md
+++ b/src/data/guides/backend-frameworks.md
@@ -1,0 +1,441 @@
+---
+title: 'Top 7 Backend Frameworks to Use in 2024: Pro Advice'
+description: 'Get expert advice on backend frameworks for 2024. Learn about the top 7 frameworks that can elevate your development process.'
+authorId: fernando
+excludedBySlug: '/backend/frameworks'
+seo:
+  title: 'Top 7 Backend Frameworks to Use in 2024: Pro Advice'
+  description: 'Get expert advice on backend frameworks for 2024. Learn about the top 7 frameworks that can elevate your development process.'
+  ogImageUrl: 'https://assets.roadmap.sh/guest/backend-languages-2x930.jpg'
+isNew: true
+type: 'textual'
+date: 2024-09-27
+sitemap:
+  priority: 0.7
+  changefreq: 'weekly'
+tags:
+  - 'guide'
+  - 'textual-guide'
+  - 'guide-sitemap'
+---
+
+![Best backend frameworks](https://assets.roadmap.sh/guest/top-backend-frameworks-jfpux.jpg)
+
+Choosing the right backend framework in 2024 can be crucial when you’re building web applications. While the programming language you pick is important, the backend framework you go with will help define how scalable, secure, and maintainable your application is. It’s the foundation that supports all the features your users interact with on the frontend and keeps everything running smoothly behind the scenes.
+
+So, it’s a decision you want to get right.
+
+In 2024, [backend development](https://roadmap.sh/backend) is more complex and interconnected than ever. Developers are working with APIs, microservices, cloud-native architectures, and ensuring high availability while keeping security at the forefront. It’s an era where the demand for real-time data, seamless integrations, and efficient performance is higher than ever.
+
+Whether you're building an enterprise-level application or a small startup, the right backend framework can save you time and headaches down the road.
+
+Let’s take a look at the following top backend development frameworks at the top of all lists for 2024:
+
+* NextJS
+* Fastify
+* SvelteKit
+* Ruby on Rails
+* Laravel
+* Phoenix
+* Actix
+
+## Criteria for Evaluating The Top Backend Frameworks
+
+How can you determine what “best backend framework” means for you? To answer that question, I’ll define a set of key factors to consider. Let’s break down the most important criteria that will help you make the best choice for your project:
+
+**Performance**:
+
+* A high-performing backend framework processes server-side tasks (e.g., database queries, user sessions, real-time data) quickly and efficiently.
+* Faster processing improves user experience, especially in 2024 when speed is critical.
+
+**Scalability**:
+
+* The framework should handle increased traffic, larger datasets, and feature expansion without issues.
+* It should smoothly scale for both small and large user bases.
+
+**Flexibility**:
+
+* A flexible framework adapts to new business or technical requirements.
+* It should support various project types without locking you into a specific structure.
+
+**Community and Ecosystem**:
+
+* A strong community provides support through tutorials, forums, and third-party tools.
+* A good ecosystem includes useful plugins and integrations for popular services or databases.
+
+**Learning Curve**:
+
+* An easy-to-learn framework boosts productivity and helps you get up to speed quickly.
+* A framework should balance ease of learning with powerful functionality.
+
+**Security**:
+
+* A reliable framework includes built-in security features to protect user data and prevent vulnerabilities.
+* It should help you comply with regulations and address security concerns from the start.
+
+**Future-Proofing**:
+
+* Choose a framework with a history of updates, a clear development roadmap, and a growing community.
+* A future-proof framework ensures long-term support and relevance.
+
+### My go-to backend framework
+
+My favorite backend framework is Next.js because it has the highest scores from the group.
+
+That said, I’ve applied the above criteria to the best backend development frameworks I’m covering below in this guide. This table gives you a snapshot view of how they all compare according to my ratings, and I’ll explain the details further below.
+
+![backend frameworks](https://assets.roadmap.sh/guest/backend-framework-table-nl1iw.png)
+
+Of course, Next.js is the best one for me, and that works for me alone. You have to consider your own projects and your own context to understand what the best choice for you would be.
+
+Let’s get into the selection and what their strengths and weaknesses are to help you select the right one for you.
+
+## Top 7 Backend Frameworks in 2024
+
+### Next.js
+
+![NextJS](https://assets.roadmap.sh/guest/logo-nextjs-mbn1n.png)
+
+Next.js is a full-stack React framework and one of the most popular backend frameworks in the JavaScript community. Over the years, it has evolved into a robust web development solution that supports static site generation (SSG), server-side rendering (SSR), and even edge computing. Backed by Vercel, it’s now one of the go-to frameworks for modern web development.
+
+#### 1\. Performance
+
+Next.js has a wonderful performance thanks to its ability to optimize for both static and dynamic generation. With server-side rendering and support for edge computing, it's built to handle high-performance requirements. Additionally, automatic code splitting ensures only the necessary parts of the app are loaded, reducing load times.
+
+⭐ **Rating: 5/5**
+
+#### 2\. Scalability
+
+Next.js is designed to scale easily, from small static websites to large-scale dynamic applications. Its ability to turn backend routes into serverless functions puts it at an unfair advantage over other frameworks. Paired with Vercel’s deployment platform, scaling becomes almost effortless.
+
+⭐ **Rating: 5/5**
+
+#### 3\. Flexibility
+
+Next.js is one of the most flexible frameworks out there. It supports a wide range of use cases, from simple static websites to highly complex full-stack applications. With its API routes feature, developers can create powerful backends, making Next.js suitable for both frontend and backend development in a single framework.
+
+⭐ **Rating: 5/5**
+
+#### 4\. Community and Ecosystem
+
+The Next.js community (just like the JavaScript community in general)  is large and quite active, with an ever-growing number of plugins, integrations, and third-party tools. The framework has solid documentation and an active ecosystem, thanks to its close ties to both the React community and Vercel’s developer support.
+
+⭐ **Rating: 5/5**
+
+#### 5\. Learning Curve
+
+For developers already familiar with React, Next.js provides a relatively smooth learning curve. However, for those new to SSR, SSG or even RSC (React Server Components), there’s a bit of a learning curve as you adapt to these concepts (after all, you’re learning React and backend development at the same time). That said, the framework's excellent documentation and active community make it easier to grasp.
+
+⭐ **Rating: 4/5**
+
+#### 6\. Security
+
+Next.js doesn’t inherently have a wide array of built-in security tools, but it follows secure default practices and can be paired with Vercel’s security optimizations for additional protection. Out of the box, Next.js ensures some level of security against common web threats but will need further configuration depending on the app's complexity.
+
+⭐ **Rating: 3.5/5**
+
+#### 7\. Future-Proofing
+
+Backed by Vercel, Next.js has a bright future. Vercel consistently pushes updates, introduces new features, and improves the overall developer experience. Given its adoption and strong support, Next.js is very future-proof, with no signs of slowing down.
+
+⭐ **Rating: 5/5**
+
+### Fastify
+
+![Fastify](https://assets.roadmap.sh/guest/logo-fastify-3bw4o.png)
+
+Fastify is a lightweight and fast backend framework for Node.js, often seen as a high-performance alternative to Express.js. It was created with a strong focus on speed, low overhead, and developer-friendly tooling, making it a popular choice for developers building APIs and microservices. Fastify offers a flexible plugin architecture and features like schema-based validation and HTTP/2 support, setting it apart in the Node.js ecosystem.
+
+#### 1\. Performance
+
+Fastify shines when it comes to performance. It’s optimized for handling large amounts of requests with low latency, making it one of the fastest Node.js frameworks available.
+
+⭐ **Rating: 5/5**
+
+#### 2\. Scalability
+
+With a strong focus on scalability, Fastify is ideal for handling large applications and high-traffic scenarios. Its lightweight nature ensures that you can build scalable services with minimal resource consumption.
+
+⭐ **Rating: 5/5**
+
+#### 3\. Flexibility
+
+Fastify’s [plugin architecture](https://fastify.dev/docs/latest/Reference/Plugins/) is one of its key strengths. This allows developers to easily extend the framework’s capabilities and tailor it to specific use cases, whether you’re building APIs, microservices, or even server-rendered applications.
+
+⭐ **Rating: 5/5**
+
+#### 4\. Community and Ecosystem
+
+While Fastify’s community is not as large as Express.js or Next.js, it is steadily growing. The ecosystem of plugins and tools continues to expand, making it easier to find the right tools and libraries to fit your needs. However, its smaller ecosystem means fewer third-party tools compared to some of the more established frameworks.
+
+⭐ **Rating: 3/5**
+
+#### 5\. Learning Curve
+
+If you’re coming from Express.js or another Node.js framework, Fastify’s learning curve is minimal. Its API is designed to be familiar and easy to adopt for Node.js developers. While there are some differences in how Fastify handles things like schema validation and plugins, it’s a relatively smooth transition for most developers.
+
+⭐ **Rating: 4/5**
+
+#### 6\. Security
+
+Fastify incorporates built-in security features such as schema-based validation, which helps prevent vulnerabilities like injection attacks. The framework also supports HTTP/2 out of the box, which provides enhanced security and performance.
+
+⭐ **Rating: 4/5**
+
+#### 7\. Future-Proofing
+
+Fastify has a strong development roadmap and is [consistently updated](https://github.com/fastify/fastify) with performance improvements and new features. The backing from a growing community and its continued adoption by large-scale applications make Fastify a solid bet for long-term use.
+
+⭐ **Rating: 5/5**
+
+### SvelteKit
+
+![SvelteKit](https://assets.roadmap.sh/guest/logo-sveltekit-9ntqz.png)
+
+SvelteKit is a full-stack framework built on top of Svelte, a front-end compiler that moves much of the heavy lifting to compile time rather than runtime. SvelteKit was designed to simplify building modern web applications by providing server-side rendering (SSR), static site generation (SSG), and support for client-side routing—all in a performance-optimized package. In other words, it’s an alternative to Next.js.
+
+#### 1\. Performance
+
+SvelteKit leverages Svelte compile-time optimizations, resulting in fast runtime performance. Unlike frameworks that rely heavily on virtual DOM diffing, Svelte compiles components to efficient JavaScript code, which means fewer resources are used during rendering.
+
+⭐ **Rating: 5/5**
+
+#### 2\. Scalability
+
+While SvelteKit is excellent for small to medium-sized applications, its scalability for enterprise-level applications is still being tested by the developer community. It is possible to scale SvelteKit for larger applications, especially with the right infrastructure and server setup, but it may not yet have the same level of proven scalability as more mature frameworks like Next.js or Fastify.
+
+⭐ **Rating: 4/5**
+
+#### 3\. Flexibility
+
+As with most web frameworks, SvelteKit is highly flexible, allowing developers to build everything from static sites to full-stack robust web applications. It provides SSR out of the box, making it easy to handle front-end and back-end logic in a single codebase. Additionally, it supports various deployment environments like serverless functions or traditional servers.
+
+⭐ **Rating: 5/5**
+
+#### 4\. Community and Ecosystem
+
+The SvelteKit community is growing rapidly, and more tools, plugins, and resources are being developed to support it. While the ecosystem isn’t as mature as frameworks like React or Vue, the rate of adoption is promising. The official documentation is well-written, and there’s a growing number of third-party tools, libraries, and guides available for developers to tap into.
+
+⭐ **Rating: 3.5/5**
+
+#### 5\. Learning Curve
+
+For developers familiar with Svelte, the transition to SvelteKit is smooth and intuitive. However, if you're new to Svelte, there is a moderate learning curve, particularly in understanding Svelte’s reactivity model and SvelteKit's routing and SSR features. Still, the simplicity of Svelte as a framework helps ease the learning process compared to more complex frameworks like React or Angular.
+
+⭐ **Rating: 4/5**
+
+#### 6\. Security
+
+SvelteKit’s security features are still evolving, with basic protections in place but requiring developers to implement best practices to build really secure web applications. There are no significant built-in security tools like in some larger frameworks, so developers need to be cautious and handle aspects like input validation, cross-site scripting (XSS) protection, and CSRF manually.
+
+⭐ **Rating: 3/5**
+
+#### 7\. Future-Proofing
+
+Svelte’s increasing popularity and SvelteKit’s rapid development signal a bright future for the framework. The growing adoption of Svelte, backed by its simplicity and performance, ensures that SvelteKit will continue to be developed and improved in the coming years.
+
+⭐ **Rating: 5/5**
+
+### Ruby on Rails
+
+![Ruby on Rails](https://assets.roadmap.sh/guest/logo-rails-eg1x0.png)
+
+Ruby on Rails (Rails) is a full-stack web development framework written in Ruby, created by David Heinemeier Hansson in 2004\. Rails revolutionized web development by promoting "convention over configuration" and allowing developers to rapidly build web applications with fewer lines of code. It
+
+#### 1\. Performance
+
+Rails performs exceptionally well for typical CRUD (Create, Read, Update, Delete) applications, where database operations are straightforward and heavily optimized within the framework. However, as applications grow in complexity or require real-time features, Rails’ performance can become a challenge.
+
+⭐ **Rating: 3.5/5**
+
+#### 2\. Scalability
+
+Rails is often critiqued for its scalability limitations, but it can scale when combined with proper architecture and best practices. Techniques like database sharding, horizontal scaling, and using background jobs for heavy-lifting tasks can help. Still, it’s not the first choice for developers who anticipate massive scale, as it requires careful planning and optimization to avoid performance bottlenecks.
+
+⭐ **Rating: 3.5/5**
+
+#### 3\. Flexibility
+
+Rails is a great framework for rapid development, especially for standard web applications, such as e-commerce platforms, blogs, or SaaS products. However, it’s less flexible when it comes to non-standard architectures or unique application needs. It’s designed with conventions in mind, so while those conventions help you move fast, they can become restrictive in more unconventional use cases.
+
+⭐ **Rating: 3.5/5**
+
+#### 4\. Community and Ecosystem
+
+Next to JavaScript with NPM, Rails has one of the most mature ecosystems in web development, with a huge repository of gems (libraries) that can help speed up development. From user authentication systems to payment gateways, there’s a gem for almost everything, saving developers from reinventing the wheel. The community is also very active, and there are many resources, tutorials, and tools to support developers at every level.
+
+⭐ **Rating: 5/5**
+
+#### 5\. Learning Curve
+
+Rails is known for its easy learning curve, especially for those new to web development. The framework’s focus on convention over configuration means that beginners don’t need to make many decisions and can get a functional app up and running quickly. On top of that, Ruby’s readable syntax also makes it approachable for new devs.
+
+However, as the application grows, mastering the framework’s more advanced concepts and learning how to break through those pre-defined conventions can become a bit of a problem.
+
+⭐ **Rating: 4/5**
+
+#### 6\. Security
+
+Rails comes with a solid set of built-in security features, including protections against SQL injection, XSS (cross-site scripting), and CSRF (cross-site request forgery). By following Rails' conventions, developers can implement secure practices without much additional work. However, as with any framework, you still need to stay updated on security vulnerabilities and ensure proper coding practices are followed.
+
+⭐ **Rating: 4.5/5**
+
+#### 7\. Future-Proofing
+
+While Rails is still highly relevant and widely used, its growth has slowed down from its initial hype during 2010, and it’s no longer the hot, new framework. That said, it remains a solid choice for many businesses, especially those building content-heavy or e-commerce applications. With an established user base and regular updates, Rails is not going anywhere, but its popularity may continue to wane as newer frameworks gain traction.
+
+⭐ **Rating: 4/5**
+
+### Laravel
+
+![Laravel](https://assets.roadmap.sh/guest/logo-laravel-iteyj.png)
+
+Laravel is a PHP backend framework that was introduced in 2011 by Taylor Otwell. It has since become one of the most popular frameworks in the PHP ecosystem, known for its elegant syntax, ease of use, and focus on developer experience (known to some as the RoR of PHP). Laravel offers a range of built-in tools and features like routing, authentication, and database management, making it ideal for building full-featured web applications quickly.
+
+#### 1\. Performance
+
+Laravel performs well for most typical web applications, especially CRUD operations. However, for larger, more complex applications, performance can be a concern. Using tools like caching, query optimization, and Laravel’s built-in optimization features (such as queue handling and task scheduling) can help boost performance, but some extra work may be required for high-load environments.
+
+⭐ **Rating: 4/5**
+
+#### 2\. Scalability
+
+Laravel can scale, but like Rails, it requires careful attention to architecture and infrastructure. By using horizontal scaling techniques, microservices, and services like AWS or Laravel’s Vapor platform, you can build scalable applications. However, Laravel is often seen as better suited for small to medium applications without heavy scaling needs right out of the box.
+
+⭐ **Rating: 3.5/5**
+
+#### 3\. Flexibility
+
+Laravel is highly flexible, allowing you to build a wide variety of web applications. With built-in features for routing, ORM, middleware, and templating, you can quickly build anything from small websites to enterprise applications.
+
+⭐ **Rating: 5/5**
+
+#### 4\. Community and Ecosystem
+
+Contrary to popular belief (mainly due to a lack of hype around the technology), Laravel has a large, active community and a vast ecosystem of packages and third-party tools. With Laracasts, a popular video tutorial platform, and Laravel.io the community portal for Laravel developers, there are many ways to reach out and learn from others.
+
+⭐ **Rating: 5/5**
+
+#### 5\. Learning Curve
+
+Laravel has a relatively gentle learning curve, especially for developers familiar with PHP. Its focus on simplicity, readable syntax, and built-in features make it easy to pick up for beginners. However, mastering the full list of Laravel’s capabilities and best practices can take some time for more complex projects.
+
+⭐ **Rating: 4.5/5**
+
+#### 6\. Security
+
+Just like others, Laravel comes with built-in security features, such as protection against common vulnerabilities like SQL injection, cross-site scripting (XSS), and cross-site request forgery (CSRF). The framework adheres to best security practices, making it easier for developers to build secure applications without much extra effort.
+
+⭐ **Rating: 4.5/5**
+
+#### 7\. Future-proofing
+
+Laravel is still highly relevant and continues to grow in popularity (having [recently secured a very substantial](https://laravel-news.com/laravel-raises-57-million-series-a) amount of money). It has a regular release schedule and a strong commitment to maintaining backward compatibility. With its consistent updates, active community, and growing ecosystem, Laravel is a solid choice for long-term projects.
+
+⭐ **Rating: 4.5/5**
+
+### Phoenix
+
+![Phoenix](https://assets.roadmap.sh/guest/phoenix-logo-5g60a.png)
+
+#### **Overview and History**
+
+Phoenix is a backend framework written in Elixir, designed to create high-performance, scalable web applications. It leverages Elixir's concurrency and fault-tolerant nature (inherited from the Erlang ecosystem) to build real-time, distributed systems.
+
+#### 1\. Performance
+
+Phoenix is known for its outstanding performance, particularly in handling large numbers of simultaneous connections. Thanks to Elixir’s concurrency model and lightweight processes, Phoenix can serve thousands of requests with minimal resource consumption. Real-time applications benefit especially from Phoenix’s built-in WebSockets and its LiveView feature for updating UIs in real-time without the need for JavaScript-heavy frameworks.
+
+⭐ **Rating: 5/5**
+
+#### 2\. Scalability
+
+Scalability is one of Phoenix’s biggest features. Because it runs on the Erlang VM, which was designed for distributed, fault-tolerant systems, Phoenix can scale horizontally and vertically with ease.
+
+⭐ **Rating: 5/5**
+
+#### 3\. Flexibility
+
+Phoenix is highly flexible, supporting everything from traditional web applications to real-time applications like chat apps and live updates. Its integration with Elixir’s functional programming paradigm and the BEAM virtual machine allows developers to build fault-tolerant, systems. The flexibility extends to how you can structure applications, scale components, and handle real-time events seamlessly.
+
+⭐ **Rating: 5/5**
+
+#### 4\. Community and Ecosystem
+
+Phoenix has a growing and passionate community, but it’s still smaller compared to more established frameworks like Rails or Laravel. However, it benefits from Elixir’s ecosystem, including libraries for testing, real-time applications, and database management. The community is supportive, and the framework’s documentation is detailed and developer-friendly, making it easy to get started.
+
+⭐ **Rating: 2.5/5**
+
+#### 5\. Learning Curve
+
+Phoenix, being built on Elixir, has a steeper learning curve than frameworks based on more common languages like JavaScript or PHP. Elixir’s functional programming model, while powerful, can be challenging for developers unfamiliar with the paradigm.
+
+⭐ **Rating: 3.5/5**
+
+#### 6\. Security
+
+As with most of the popular backend frameworks, Phoenix comes with strong built-in security features, including protections against common vulnerabilities like XSS, SQL injection, and CSRF. Additionally, because Elixir processes are isolated, Phoenix applications are resilient to many types of attacks. While some manual work is still required to ensure security, Phoenix adheres to best practices and provides tools to help developers write secure code.
+
+⭐ **Rating: 4.5/5**
+
+#### 7\. Future-Proofing
+
+Phoenix has a bright future thanks to its solid foundation in the Erlang/Elixir ecosystem, which is known for long-term reliability and support. While the framework might be technologically sound and future-proof, the key to having Elixir in the future will depend on the growth of its popularity. If Elixir’s community keeps growing, we’ll be able to enjoy the framework for a long time.
+
+⭐ **Rating: 5/5**
+
+### Actix
+
+![Actix](https://assets.roadmap.sh/guest/logo-actix-rust-31pi3.png)
+
+Actix is a powerful, high-performance web framework written in Rust. It’s based on the actor model, which is ideal for building concurrent, distributed systems. Actix is known for its incredible performance and memory safety, thanks to Rust’s strict compile-time guarantees.
+
+#### 1\. Performance
+
+Actix is one of the fastest web frameworks available, thanks to Rust’s system-level performance and Actix’s use of asynchronous programming. As it happens with JavaScript-based frameworks, it can handle a large number of requests with minimal overhead, making it ideal for high-performance, real-time applications.
+
+⭐ **Rating: 5/5**
+
+#### 2\. Scalability
+
+The actor model makes Actix the best at handling concurrent tasks and scaling across multiple threads or servers. Rust’s memory safety model and Actix’s architecture make it highly efficient in resource usage, meaning applications can scale well without excessive overhead.
+
+⭐ **Rating: 5/5**
+
+#### 3\. Flexibility
+
+Actix is flexible but requires a deeper understanding of Rust’s ownership and concurrency model to fully take advantage of it. It’s great for building both small, fast APIs and large, service architectures. While Actix is powerful, it’s less forgiving compared to other popular backend frameworks like Node.js or Python’s Flask, where rapid prototyping is easier.
+
+⭐ **Rating: 3/5**
+
+#### 4\. Community and Ecosystem
+
+Rust’s ecosystem, while growing, is still smaller compared to more established languages like JavaScript or Python. However, the Rust community is highly engaged, and support is steadily improving.
+
+⭐ **Rating: 3.5/5**
+
+#### 5\. Learning Curve
+
+Actix inherits Rust’s learning curve, which can be steep for developers new to systems programming or Rust’s strict memory management rules. However, for developers already familiar with Rust, Actix can be a great gateway into web development.
+
+⭐ **Rating: 2/5**
+
+#### 6\. Security
+
+Rust is known for its memory safety and security guarantees, and Actix benefits from these inherent strengths. Rust’s compile-time checks prevent common security vulnerabilities like null pointer dereferencing, buffer overflows, and data races. While these features tackle one side of the security ecosystem, more relevant ones like web-related vulnerabilities are not tackled by the framework.
+
+⭐ **Rating: 2.5/5**
+
+#### **7\. Future-Proofing**
+
+Rust’s growing popularity and adoption, especially in performance-critical areas, ensure that Actix has a strong future. While Actix’s ecosystem is still developing, the framework is regularly maintained and benefits from Rust’s long-term stability.
+
+⭐ **Rating: 4.5/5**
+
+## Conclusion
+
+Choosing the right backend framework is a critical decision that can shape the future of your project. In 2024, developers have more powerful options than ever, from popular backend frameworks like Ruby on Rails, Laravel or Next.js to high-performance focused, like Fastify, SvelteKit, Phoenix, and Actix. Each framework has its own strengths, making it essential to consider factors such as performance, scalability, flexibility, and the learning curve to ensure you pick the right tool for the job.
+
+Ultimately, there’s no proverbial silver bullet that solves all your problems. Your choice will depend on your project’s needs, your team's expertise, and the long-term goals of your application.
+
+So take your time, weigh the pros and cons, and pick the framework that aligns best with your vision for the future.

--- a/src/data/roadmaps/backend/faqs.astro
+++ b/src/data/roadmaps/backend/faqs.astro
@@ -40,9 +40,10 @@ export const faqs: FAQType[] = [
       ]
   },
   {
-      question: 'What are backend technologies?',
+      question: 'What are backend frameworks?',
       answer: [
-          '[Backend technologies](https://roadmap.sh/backend/technologies) are the technologies that power the server-side of web applications. They are responsible for managing data, processing requests, and generating responses to the client-side of the application. Some of the most popular backend technologies include programming languages like Python, Ruby, Java, and Go, as well as frameworks like Django, Ruby on Rails, Spring Boot, and Gin. Backend technologies also include databases like PostgreSQL, MySQL, and MongoDB, as well as tools like Docker, Kubernetes, and Jenkins. These technologies work together to create the server-side of web applications and provide the functionality that users interact with on the client-side.',
+          '[Backend frameworks](https://roadmap.sh/backend/frameworks) are the frameworks that power the server-side of web applications. They are responsible for managing data, processing requests, and generating responses to the client-side of the application. Some of the most popular backend frameworks include Django for Python, Ruby on Rails for Ruby, Spring Boot for Java, and Gin for Go.',
+          'These frameworks work alongside databases like PostgreSQL, MySQL, and MongoDB, as well as tools like Docker, Kubernetes, and Jenkins. Backend frameworks, along with other server-side components, work together to create the functionality that users interact with on the client-side of web applications.'
 
       ]
   }

--- a/src/pages/backend/frameworks.astro
+++ b/src/pages/backend/frameworks.astro
@@ -1,0 +1,34 @@
+---
+import GuideContent from '../../components/Guide/GuideContent.astro';
+import GuideHeader from '../../components/GuideHeader.astro';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { getGuideById } from '../../lib/guide';
+import { getOpenGraphImageUrl } from '../../lib/open-graph';
+import { replaceVariables } from '../../lib/markdown';
+
+const guideId = 'backend-frameworks';
+const guide = await getGuideById(guideId).catch(() => null);
+if (!guide) {
+  return Astro.redirect('/404');
+}
+
+const { frontmatter: guideData } = guide!;
+
+const ogImageUrl =
+  guideData.seo.ogImageUrl ||
+  getOpenGraphImageUrl({
+    group: 'guide',
+    resourceId: guideId,
+  });
+---
+
+<BaseLayout
+  title={replaceVariables(guideData.seo.title)}
+  description={replaceVariables(guideData.seo.description)}
+  permalink={`/backend/languages`}
+  canonicalUrl={guideData.canonicalUrl}
+  ogImageUrl={ogImageUrl}
+>
+  <GuideHeader guide={guide!} />
+  <GuideContent guide={guide!} />
+</BaseLayout>


### PR DESCRIPTION
Guide has been completed and FAQs updated to reference the guide.

@Edlan01 same again on this one, the HTML table for the frameworks didn't work so I screenshot, compressed and added, let me know if there's any issues with that.