### PR TITLE
Add 'sed' command section to the Linux roadmap

### DIFF
--- a/src/data/roadmaps/linux/content/104-text-processing/118-sed.md
+++ b/src/data/roadmaps/linux/content/104-text-processing/118-sed.md
@@ -1,0 +1,46 @@
+# SED in Text Processing
+
+The `sed` command in Linux is a powerful stream editor used for performing basic text transformations on files or standard input. It processes text line by line, allowing you to search, replace, insert, and delete text in a non-interactive way. `sed` is particularly useful for batch processing and automated text manipulations in scripts.
+
+A common usage of `sed` is substituting a specific string with another. By default, it prints the modified content to the terminal but does not modify the file unless explicitly instructed.
+
+```bash
+sed 's/old_text/new_text/g' file.txt
+```
+
+In this example:
+
+- `s`: Stands for "substitute." It indicates that a substitution will be performed.
+- `old_text`: The string you want to replace.
+- `new_text`: The replacement string
+- `g`: (Optional) Makes the substitution global, replacing all occurrences of old_text in each line.
+
+Replace Text in a File:
+
+```bash
+sed 's/hello/world/' file.txt
+```
+
+This command searches for the first occurrence of "hello" in each line of `file.txt` and replaces it with "world". Since no `g` flag is used, only the first occurrence in each line will be replaced.
+
+Replace and Save to the Same File:
+
+```bash
+sed -i 's/foo/bar/g' filename
+```
+
+The `-i` option stands for "in-place," meaning that the changes will be saved directly to `filename`. The command replaces every occurrence of "foo" with "bar" throughout the entire file.
+
+Delete Lines:
+
+```bash
+sed '/pattern/d' filename
+```
+
+This command removes any line in filename that contains "pattern." The `d` flag tells `sed` to delete those lines.
+
+Visit the following resources to learn more:
+
+- [@article@Sed and RedHat.com](https://www.redhat.com/sysadmin/manipulating-text-sed)
+- [@article@Sed and Regular Expressions for Beginners](https://www.gnu.org/software/sed/manual/sed.html)
+- [@article@Sed phoenixap.com](https://phoenixnap.com/kb/linux-sed)

--- a/src/data/roadmaps/linux/linux.json
+++ b/src/data/roadmaps/linux/linux.json
@@ -4806,6 +4806,53 @@
           }
         },
         {
+          "ID": "2182",
+          "typeID": "__group__",
+          "zOrder": "88",
+          "measuredW": "82",
+          "measuredH": "50",
+          "w": "82",
+          "h": "50",
+          "x": "539",
+          "y": "901",
+          "properties": {
+            "controlName": "118-text-processing:sed"
+          },
+          "children": {
+            "controls": {
+              "control": [
+                {
+                  "ID": "0",
+                  "typeID": "TextArea",
+                  "zOrder": "0",
+                  "w": "82",
+                  "h": "50",
+                  "measuredW": "200",
+                  "measuredH": "140",
+                  "x": "0",
+                  "y": "0",
+                  "properties": {
+                    "color": "16770457"
+                  }
+                },
+                {
+                  "ID": "1",
+                  "typeID": "Label",
+                  "zOrder": "1",
+                  "measuredW": "30",
+                  "measuredH": "25",
+                  "x": "26",
+                  "y": "12",
+                  "properties": {
+                    "size": "17",
+                    "text": "sed"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
           "ID": "2183",
           "typeID": "__group__",
           "zOrder": "95",
@@ -7319,3 +7366,4 @@
   "dependencies": [],
   "projectID": "file:///Users/kamrify/Desktop/New%20Roadmaps/Android%20Roadmap.bmpr"
 }
+


### PR DESCRIPTION
Add 'sed' command section to text processing in the Linux roadmap
- Introduced a dedicated section for the 'sed' command in the text processing category.
- Updated the relevant documentation to include examples and usage of the 'sed' command.
- Ensured consistency with existing formatting and structure of the roadmap.
- This addition enhances the learning resource by providing clear guidance on using the 'sed' command effectively.
Related issue: #6207