### PR TITLE
add new references to learn component lifecycles

### DIFF
--- a/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
+++ b/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
@@ -1,6 +1,6 @@
 # Component Life Cycle
 
-React components have a lifecycle consisting of three phases: Mounting, Updating, and Unmounting along with several “lifecycle methods” that you can override to run code at particular times in the process. You can use this [lifecycle diagram](https://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/) as a cheat sheet.
+React components have a lifecycle consisting of three phases: Mounting, Updating, and Unmounting along with several “lifecycle methods” that you can override to run code at particular times in the process.
 
 It is not recommended to use lifecycle methods manually. Instead, use the useEffect hook with functional components.
 
@@ -11,3 +11,4 @@ Visit the following resources to learn more:
 - [@article@React component lifecycle: React lifecycle methods & hooks](https://tsh.io/blog/react-component-lifecycle-methods-vs-hooks/)
 - [@article@The React lifecycle: methods and hooks explained](https://retool.com/blog/the-react-lifecycle-methods-and-hooks-explained#react-hooks-and-the-component-lifecycle)
 - [@article@React Lifecycle: Methods & Hooks In Detail](https://www.bairesdev.com/blog/react-lifecycle-methods-hooks/)
+- [@article@lifecycle diagram](https://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/)

--- a/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
+++ b/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
@@ -6,5 +6,8 @@ It is not recommended to use lifecycle methods manually. Instead, use the useEff
 
 Visit the following resources to learn more:
 
+- [@article@React component lifecycle: React lifecycle methods & hooks](https://tsh.io/blog/react-component-lifecycle-methods-vs-hooks/)
+- [@article@The React lifecycle: methods and hooks explained](https://retool.com/blog/the-react-lifecycle-methods-and-hooks-explained#react-hooks-and-the-component-lifecycle)
+- [@article@React Lifecycle: Methods & Hooks In Detail](https://www.bairesdev.com/blog/react-lifecycle-methods-hooks/)
+- [@official@Lifecycle of Reactive Effects](https://react.dev/learn/lifecycle-of-reactive-effectsv)
 - [@official@Class Component](https://react.dev/reference/react/Component)
-- [@official@Lifecycle of Reactive Effects](https://react.dev/learn/lifecycle-of-reactive-effects)

--- a/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
+++ b/src/data/roadmaps/react/content/component-lifecycle@8OBlgDRUg-CTgDXY-QHyO.md
@@ -6,8 +6,8 @@ It is not recommended to use lifecycle methods manually. Instead, use the useEff
 
 Visit the following resources to learn more:
 
+- [@official@Lifecycle of Reactive Effects](https://react.dev/learn/lifecycle-of-reactive-effectsv)
+- [@official@Class Component](https://react.dev/reference/react/Component)
 - [@article@React component lifecycle: React lifecycle methods & hooks](https://tsh.io/blog/react-component-lifecycle-methods-vs-hooks/)
 - [@article@The React lifecycle: methods and hooks explained](https://retool.com/blog/the-react-lifecycle-methods-and-hooks-explained#react-hooks-and-the-component-lifecycle)
 - [@article@React Lifecycle: Methods & Hooks In Detail](https://www.bairesdev.com/blog/react-lifecycle-methods-hooks/)
-- [@official@Lifecycle of Reactive Effects](https://react.dev/learn/lifecycle-of-reactive-effectsv)
-- [@official@Class Component](https://react.dev/reference/react/Component)


### PR DESCRIPTION
The previous references for component lifecycles were outdated as they focused on the class component paradigm. This PR updates the documentation to include a more relevant reference that explains the lifecycle methods in the context of functional components, aligning with modern React practices. https://github.com/kamranahmedse/developer-roadmap/issues/6771