### PR TITLE
feat: Add uv venv to environments section in Python roadmap

### DIFF
--- a/src/data/roadmaps/python/content/uv-venv@vu1fvZ3363p4ejEb8whE.md
+++ b/src/data/roadmaps/python/content/uv-venv@vu1fvZ3363p4ejEb8whE.md
@@ -1,0 +1,7 @@
+# uv venv
+
+uv venv is a lightweight virtual environment manager that is part of the uv ecosystem, designed to create and manage isolated Python environments efficiently.
+
+Learn more about it using the following resources:
+
+- [@official@uv GitHub Repository](https://github.com/astral-sh/uv)

--- a/src/data/roadmaps/python/python.json
+++ b/src/data/roadmaps/python/python.json
@@ -2981,11 +2981,42 @@
       "focusable": true
     },
     {
+      "id": "vu1fvZ3363p4ejEb8whE",
+      "type": "subtopic",
+      "position": {
+        "x": 77.79817070787664,
+        "y": 922.1504012205187
+      },
+      "selected": false,
+      "data": {
+        "label": "uv venv",
+        "style": {
+          "fontSize": 17,
+          "justifyContent": "flex-start",
+          "textAlign": "center"
+        }
+      },
+      "zIndex": 999,
+      "width": 145,
+      "height": 46,
+      "style": {
+        "width": 145,
+        "height": 46
+      },
+      "positionAbsolute": {
+        "x": 77.79817070787664,
+        "y": 922.1504012205187
+      },
+      "dragging": false,
+      "selectable": true,
+      "focusable": true
+    },
+    {
       "id": "lkST4ErYyBfrCcpsuptzh",
       "type": "label",
       "position": {
         "x": 77.79817070787664,
-        "y": 926.1504012205187
+        "y": 979.1504012205187
       },
       "selected": false,
       "data": {
@@ -3005,7 +3036,7 @@
       },
       "positionAbsolute": {
         "x": 77.79817070787664,
-        "y": 926.1504012205187
+        "y": 979.1504012205187
       },
       "dragging": false,
       "selectable": true,
@@ -4281,3 +4312,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
### Summary:

This PR addresses issue #7333  by adding **uv venv** to the Environments section of the Python roadmap, 

### Changes made:

Created a new file:  `uv-venv@vu1fvZ3363p4ejEb8whE.md`  to represent the uv venv.

Updated the `python.json` to add **uv venv** as a subtopic under environments.

Adjusted the position of the **"Environments"** label to accommodate the new subtopic.

