### PR TITLE
Replace duplicated link in Introduction to TypeScript content

### DIFF
--- a/public/roadmap-content/typescript.json
+++ b/public/roadmap-content/typescript.json
@@ -10,7 +10,7 @@
       },
       {
         "title": "TypeScript Official Handbook",
-        "url": "https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html",
+        "url": "https://www.typescriptlang.org/docs/handbook/intro.html",
         "type": "article"
       },
       {


### PR DESCRIPTION
"Overview of TypeScript" and "TypeScript Official Handbook" links to the same web page