### PR TITLE
Improve Focus Management in Popup Component

### DIFF
--- a/src/components/Popup/Popup.astro
+++ b/src/components/Popup/Popup.astro
@@ -22,6 +22,7 @@ const { id, title, subtitle } = Astro.props;
       <button
         type='button'
         class='absolute top-3 right-2.5 text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center popup-close'
+        autofocus
       >
         <Icon icon='close' />
         <span class='sr-only'>Close popup</span>

--- a/src/components/Popup/popup.js
+++ b/src/components/Popup/popup.js
@@ -4,6 +4,7 @@ export class Popup {
     this.onDOMLoaded = this.onDOMLoaded.bind(this);
     this.handleClosePopup = this.handleClosePopup.bind(this);
     this.handleKeydown = this.handleKeydown.bind(this);
+    this.lastFocusedElement = null;
   }
 
   /**
@@ -20,6 +21,8 @@ export class Popup {
     }
 
     e.preventDefault();
+    this.lastFocusedElement = e.target;
+
     popupEl.classList.remove('hidden');
     popupEl.classList.add('flex');
     const focusEl = popupEl.querySelector('[autofocus]');
@@ -30,6 +33,7 @@ export class Popup {
 
   handleClosePopup(e) {
     const target = e.target;
+
     const popupBody = target.closest('.popup-body');
     const closestPopup = target.closest('.popup');
     const closeBtn = target.closest('.popup-close');
@@ -41,6 +45,8 @@ export class Popup {
     if (closestPopup) {
       closestPopup.classList.add('hidden');
       closestPopup.classList.remove('flex');
+
+      this.lastFocusedElement && this.lastFocusedElement.focus();
     }
   }
 
@@ -53,6 +59,8 @@ export class Popup {
     if (popup) {
       popup.classList.add('hidden');
       popup.classList.remove('flex');
+
+      this.lastFocusedElement && this.lastFocusedElement.focus();
     }
   }
 


### PR DESCRIPTION
### Summary

- Enhanced focus handling in the popup component:
  - Focus now moves to the close button when the popup opens.
  - When the popup is closed (via the Escape key or close button), focus returns to the element that triggered it.
  
**Notes for Reviewer**
- This update follows W3C's ARIA dialog best practices for accessible
  focus management ([W3C reference](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)).

### Testing Done
- Tested manually and attached videos showcasing the Ui and behaviour before and after the changes.

### Attachments
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/08b19389-5635-4ff9-8b55-5b7e4b1366ea">|<video  src="https://github.com/user-attachments/assets/e7f20729-11b6-42eb-9611-9dabf9a93f45">|

