### PR TITLE
Corrects the CQS article

### DIFF
--- a/src/data/roadmaps/software-design-architecture/content/100-clean-code-principles/113-command-query-separation.md
+++ b/src/data/roadmaps/software-design-architecture/content/100-clean-code-principles/113-command-query-separation.md
@@ -4,4 +4,4 @@ Command-Query Separation (CQS) is a software design principle that separates the
 
 Learn more from the following links:
 
-- [@article@CQRS Pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs)
+- [@article@CQS Pattern](https://martinfowler.com/bliki/CommandQuerySeparation.html))

--- a/src/data/roadmaps/software-design-architecture/content/100-clean-code-principles/113-command-query-separation.md
+++ b/src/data/roadmaps/software-design-architecture/content/100-clean-code-principles/113-command-query-separation.md
@@ -4,4 +4,4 @@ Command-Query Separation (CQS) is a software design principle that separates the
 
 Learn more from the following links:
 
-- [@article@CQS Pattern](https://martinfowler.com/bliki/CommandQuerySeparation.html))
+- [@article@CQS Pattern](https://martinfowler.com/bliki/CommandQuerySeparation.html)


### PR DESCRIPTION
The previous article referred to a broader, architectural pattern of CQRS, which are not the same