### PR TITLE
Add links to the free "Rust Atomics and Locks" ebook

### DIFF
--- a/src/data/roadmaps/rust/content/104-concurrency-parallelism/101-atomic-operations.md
+++ b/src/data/roadmaps/rust/content/104-concurrency-parallelism/101-atomic-operations.md
@@ -1,3 +1,7 @@
 # Atomic Operations and Memory Barriers
 
 Atomic operations in Rust are low-level types that support lock-free concurrent programming. These operations are atomic because they complete in a single operation rather than being interruptible. In Rust, atomic types provide primitive shared-memory communication between threads, and can also be used for non-blocking data structures and are supported using machine instructions directly. They form the building blocks for other, higher-level concurrency abstractions. It includes variety of atomic operations such as `store`, `load`, `swap`, `fetch_add`, `compare_and_swap` and more, which are operations performed in a single, uninterrupted step.
+
+Learn more from the following links:
+
+- [@opensource@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)

--- a/src/data/roadmaps/rust/content/104-concurrency-parallelism/101-atomic-operations.md
+++ b/src/data/roadmaps/rust/content/104-concurrency-parallelism/101-atomic-operations.md
@@ -4,4 +4,4 @@ Atomic operations in Rust are low-level types that support lock-free concurrent 
 
 Learn more from the following links:
 
-- [@opensource@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)
+- [@article@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)

--- a/src/data/roadmaps/rust/content/104-concurrency-parallelism/102-threads.md
+++ b/src/data/roadmaps/rust/content/104-concurrency-parallelism/102-threads.md
@@ -1,3 +1,7 @@
 # Threads, Channels, and Message Passing
 
 Threads are the smallest unit of computing that can be scheduled by an operating system. They live in the context of a process, and each thread within a process shares the process's resources including memory and file handles. In Rust, the `std::thread` module allows you to have direct control over threads. This model of concurrency is known as 1:1, mapping one operating system thread to one language thread. You can write concurrent programs in Rust using threads in a similar way as most other languages. You start threads with `std::thread::spawn` and wait for them to finish with `join`.
+
+Learn more from the following links:
+
+- [@opensource@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)

--- a/src/data/roadmaps/rust/content/104-concurrency-parallelism/102-threads.md
+++ b/src/data/roadmaps/rust/content/104-concurrency-parallelism/102-threads.md
@@ -4,4 +4,4 @@ Threads are the smallest unit of computing that can be scheduled by an operating
 
 Learn more from the following links:
 
-- [@opensource@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)
+- [@article@Rust Atomics and Locks - Low-Level Concurrency in Practice](https://marabos.nl/atomics/)


### PR DESCRIPTION
Added links to the [Rust Atomics and Locks by Mara Bos](https://marabos.nl/atomics/) freely online available book. It is a fantastic comprehensible resource about low-level concurrency, written by a core Rust contributor.

Not sure what `@type@` of the link it is - `opensource`, `article`, `course`?