### PR TITLE
Fixed a typo error in the react.json roadmap file

### DIFF
--- a/public/roadmap-content/react.json
+++ b/public/roadmap-content/react.json
@@ -244,7 +244,7 @@
     "links": [
       {
         "title": "Lifecycle of Reactive Effects",
-        "url": "https://react.dev/learn/lifecycle-of-reactive-effectsv",
+        "url": "https://react.dev/learn/lifecycle-of-reactive-effects",
         "type": "article"
       },
       {


### PR DESCRIPTION
## What does this pr do
This PR addresses an issue with a broken link in the roadmap file.

Fixes #7407 

Before 
`"url": "https://react.dev/learn/lifecycle-of-reactive-effectsv",`
Now 
` "url": "https://react.dev/learn/lifecycle-of-reactive-effects",`

Fix
Removed the extra 'v' in the URL to ensure the link functions correctly.

