### PR TITLE
Remove superfluous 'token' after writing  JWT.

### DIFF
--- a/public/roadmap-content/full-stack.json
+++ b/public/roadmap-content/full-stack.json
@@ -381,7 +381,7 @@
   },
   "vHojhJYjiN0IwruEqi1Dv": {
     "title": "JWT Auth",
-    "description": "JWT stands for JSON Web Token is a token-based encryption open standard/methodology that is used to transfer information securely as a JSON object. Clients and Servers use JWT to securely share information, with the JWT containing encoded JSON objects and claims. JWT tokens are designed to be compact, safe to use within URLs, and ideal for SSO contexts.\n\nVisit the following resources to learn more:",
+    "description": "JWT stands for JSON Web Token is a token-based encryption open standard/methodology that is used to transfer information securely as a JSON object. Clients and Servers use JWT to securely share information, with the JWT containing encoded JSON objects and claims. JWTs are designed to be compact, safe to use within URLs, and ideal for SSO contexts.\n\nVisit the following resources to learn more:",
     "links": [
       {
         "title": "jwt.io Website",

--- a/src/data/best-practices/api-security/api-security.json
+++ b/src/data/best-practices/api-security/api-security.json
@@ -1368,7 +1368,7 @@
                                     "y": "0",
                                     "properties": {
                                         "size": "20",
-                                        "text": "Keep the payload small to reduce the size of the JWT token"
+                                        "text": "Keep the payload small to reduce the size of the JWT"
                                     }
                                 }
                             ]

--- a/src/data/best-practices/api-security/content/jwt-algorithm.md
+++ b/src/data/best-practices/api-security/content/jwt-algorithm.md
@@ -2,4 +2,4 @@
 
 > Do not extract the algorithm from the header, use backend.
 
-Extracting the algorithm from the header of a JWT token can pose a security risk, as an attacker could modify the algorithm and potentially gain unauthorized access. It is therefore recommended to verify the algorithm on the backend rather than extracting it from the header. This can help ensure that the algorithm used to sign and verify the token is secure and has not been tampered with.
+Extracting the algorithm from the header of a JWT can pose a security risk, as an attacker could modify the algorithm and potentially gain unauthorized access. It is therefore recommended to verify the algorithm on the backend rather than extracting it from the header. This can help ensure that the algorithm used to sign and verify the token is secure and has not been tampered with.

--- a/src/data/best-practices/api-security/content/jwt-payload.md
+++ b/src/data/best-practices/api-security/content/jwt-payload.md
@@ -2,4 +2,4 @@
 
 > Avoid storing sensitive data in JWT payload
 
-Storing sensitive data in a JWT token payload can increase the risk of data breaches and other security incidents. If an attacker is able to obtain or tamper with the token, they could potentially access the sensitive data stored in the payload.
+Storing sensitive data in a JWT payload can increase the risk of data breaches and other security incidents. If an attacker is able to obtain or tamper with the token, they could potentially access the sensitive data stored in the payload.

--- a/src/data/best-practices/api-security/content/payload-size.md
+++ b/src/data/best-practices/api-security/content/payload-size.md
@@ -1,5 +1,5 @@
 # JWT Payload Size
 
-> Avoid storing large payloads in JWT tokens
+> Avoid storing large payloads in JWTs
 
 A smaller payload can reduce network overhead, improve processing speed, and decrease the risk of attacks aimed at overloading the system.

--- a/src/data/guides/backend-project-ideas.md
+++ b/src/data/guides/backend-project-ideas.md
@@ -104,7 +104,7 @@ At the same time, when you “set” the value in the cache, you can also give i
 For the last of our “easy” backend projects, let’s cover one more API, an expense tracker API. This API should let you:
 
 - Sign up as a new user.
-- Generate and validate JWT tokens for handling authentication and user session.
+- Generate and validate JWTs for handling authentication and user session.
 - List and filter your past expenses. You can add the following filters:
     - Past week.
     - Last month.
@@ -205,7 +205,7 @@ For this one, you’ll have to keep in mind everything we’ve been covering so 
 
 With that in mind, let’s take a look at the responsibilities of this system:
 
-- JWT token creation and validation to handle authorization.
+- JWT creation and validation to handle authorization.
 - Ability to create new users.
 - Shopping cart management, which involves payment gateway integration as well.
 - Product listings.

--- a/src/data/projects/expense-tracker-api.md
+++ b/src/data/projects/expense-tracker-api.md
@@ -32,7 +32,7 @@ Build an API for an expense tracker application. This API should allow users to 
 Here are the features that you should implement in your Expense Tracker API:
 
 - Sign up as a new user.
-- Generate and validate JWT tokens for handling authentication and user session.
+- Generate and validate JWTs for handling authentication and user session.
 - List and filter your past expenses. You can add the following filters:
   - Past week
   - Past month

--- a/src/data/projects/fitness-workout-tracker.md
+++ b/src/data/projects/fitness-workout-tracker.md
@@ -37,7 +37,7 @@ You should write a data seeder to populate the database with a list of exercises
 
 ### User Authentication and Authorization
 
-Users will be able to sign up, log in, and log out of the application. You should use JWT tokens for authentication and authorization. Only authenticated users should be able to create, update, and delete workout plans. Needless to say, users should only be able to access their own workout plans.
+Users will be able to sign up, log in, and log out of the application. You should use JWTs for authentication and authorization. Only authenticated users should be able to create, update, and delete workout plans. Needless to say, users should only be able to access their own workout plans.
 
 - **Sign-Up**: Allow users to create an account.
 - **Login**: Allow users to log in to their account.

--- a/src/data/projects/image-processing-service.md
+++ b/src/data/projects/image-processing-service.md
@@ -35,7 +35,7 @@ Here is the list of features that you should implement in this project:
 
 - **Sign-Up**: Allow users to create an account.
 - **Log-In**: Allow users to log into their account.
-- **JWT Authentication**: Secure endpoints using JWT tokens for authenticated access.
+- **JWT Authentication**: Secure endpoints using JWTs for authenticated access.
 
 ### Image Management
 
@@ -75,7 +75,7 @@ POST /register
   "password": "password123"
 }
 ```
-Response should be the user object with a JWT token.
+Response should be the user object with a JWT.
 
 Log in an existing user:
 
@@ -86,7 +86,7 @@ POST /login
   "password": "password123"
 }
 ```
-Response should be the user object with a JWT token.
+Response should be the user object with a JWT.
 
 ### Image Management Endpoints
 

--- a/src/data/projects/todo-list-api.md
+++ b/src/data/projects/todo-list-api.md
@@ -77,7 +77,7 @@ This will validate the given details, make sure the email is unique and store th
 }
 ```
 
-The token can either be a JWT token or a random string that can be used for authentication. We leave it up to you to decide the implementation details.
+The token can either be a JWT or a random string that can be used for authentication. We leave it up to you to decide the implementation details.
 
 ### User Login
 

--- a/src/data/roadmaps/full-stack/content/jwt-auth@vHojhJYjiN0IwruEqi1Dv.md
+++ b/src/data/roadmaps/full-stack/content/jwt-auth@vHojhJYjiN0IwruEqi1Dv.md
@@ -1,6 +1,6 @@
 # JWT
 
-JWT stands for JSON Web Token is a token-based encryption open standard/methodology that is used to transfer information securely as a JSON object. Clients and Servers use JWT to securely share information, with the JWT containing encoded JSON objects and claims. JWT tokens are designed to be compact, safe to use within URLs, and ideal for SSO contexts.
+JWT stands for JSON Web Token is a token-based encryption open standard/methodology that is used to transfer information securely as a JSON object. Clients and Servers use JWT to securely share information, with the JWT containing encoded JSON objects and claims. JWTs are designed to be compact, safe to use within URLs, and ideal for SSO contexts.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Since the elongated term for the abbreviation JWT is Json Web Token, adding another word 'token' after it is redundant. This PR fixes this issue in the concerned places.