### PR TITLE
Update broken link

### DIFF
--- a/src/data/roadmaps/git-github/content/rebase@99FVJ3Zs8n6lr8L95mG6g.md
+++ b/src/data/roadmaps/git-github/content/rebase@99FVJ3Zs8n6lr8L95mG6g.md
@@ -4,4 +4,4 @@ Rebasing in Git is a powerful and potentially complex feature used to reorganize
 
 Visit the following resources to learn more:
 
-- [@official@Rebasing](https://git-scm.com/book/en/Git-Branching-Rebasing)
+- [@official@Rebasing](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)


### PR DESCRIPTION
A resource URL on the [git-github roadmap ](https://roadmap.sh/git-github) has changed.