### PR TITLE
Adding 2 videos links to Aws Roadmap - EC2 and VPC topics

### DIFF
--- a/src/data/roadmaps/aws/content/101-ec2/index.md
+++ b/src/data/roadmaps/aws/content/101-ec2/index.md
@@ -5,4 +5,4 @@ Amazon Elastic Compute Cloud (EC2) is a web service that provides secure, resiza
 Visit the following resources to learn more:
 
 - [@official@EC2 - User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html)
-- [@video@Introduction to Amazon EC2](https://www.youtube.com/watch?v=TsRBftzZsQo)
+- [@video@Introduction to Amazon EC2](https://www.youtube.com/watch?v=eaicwmnSdCs)

--- a/src/data/roadmaps/aws/content/101-ec2/index.md
+++ b/src/data/roadmaps/aws/content/101-ec2/index.md
@@ -5,3 +5,4 @@ Amazon Elastic Compute Cloud (EC2) is a web service that provides secure, resiza
 Visit the following resources to learn more:
 
 - [@official@EC2 - User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/concepts.html)
+- [@video@Introduction to Amazon EC2](https://www.youtube.com/watch?v=TsRBftzZsQo)

--- a/src/data/roadmaps/aws/content/102-vpc/index.md
+++ b/src/data/roadmaps/aws/content/102-vpc/index.md
@@ -5,3 +5,4 @@ Amazon VPC (Virtual Private Cloud) is a service that lets you launch AWS resourc
 Visit the following resources to learn more:
 
 - [@official@VPC](https://aws.amazon.com/vpc/)
+- [@video@AWS VPC Beginner to Advanced uses](https://www.youtube.com/watch?v=g2JOHLHh4rI)


### PR DESCRIPTION
First commit is adding a link to aws official video that give us a resume of what is ec2 and his vantages. Its a short video so i think its good to people to get a _fast_ knowledge of uses of ec2 and _why_ use this.

Second commit is adding a link to freecodecamp video that covers practically everything of vpc service.