### PR TITLE
Fix/grammatical error

### DIFF
--- a/src/components/CreateTeam/SelectRoadmapModal.tsx
+++ b/src/components/CreateTeam/SelectRoadmapModal.tsx
@@ -92,7 +92,7 @@ export function SelectRoadmapModal(props: SelectRoadmapModalProps) {
           />
           <div className="min-h-[200px] p-4">
             <span className="block pb-3 text-xs uppercase text-gray-400">
-              Role-Based Roadmaps
+              Role Based Roadmaps
             </span>
             {roleBasedRoadmaps.length === 0 && (
               <p className="mb-1 flex h-full items-start text-sm italic text-gray-400"></p>
@@ -120,7 +120,7 @@ export function SelectRoadmapModal(props: SelectRoadmapModalProps) {
               </div>
             )}
             <span className="block pb-3 text-xs uppercase text-gray-400">
-              Skill-Based Roadmaps
+              Skill Based Roadmaps
             </span>
             <div className="flex flex-wrap items-center gap-2">
               {skillBasedRoadmaps.map((roadmap) => {

--- a/src/components/CreateTeam/SelectRoadmapModal.tsx
+++ b/src/components/CreateTeam/SelectRoadmapModal.tsx
@@ -92,7 +92,7 @@ export function SelectRoadmapModal(props: SelectRoadmapModalProps) {
           />
           <div className="min-h-[200px] p-4">
             <span className="block pb-3 text-xs uppercase text-gray-400">
-              Role Based Roadmaps
+              Role-Based Roadmaps
             </span>
             {roleBasedRoadmaps.length === 0 && (
               <p className="mb-1 flex h-full items-start text-sm italic text-gray-400"></p>
@@ -120,7 +120,7 @@ export function SelectRoadmapModal(props: SelectRoadmapModalProps) {
               </div>
             )}
             <span className="block pb-3 text-xs uppercase text-gray-400">
-              Skill Based Roadmaps
+              Skill-Based Roadmaps
             </span>
             <div className="flex flex-wrap items-center gap-2">
               {skillBasedRoadmaps.map((roadmap) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,7 +41,7 @@ const videos = await getAllVideos();
     <HeroSection />
 
     <FeaturedItems
-      heading='Role based Roadmaps'
+      heading='Role-based Roadmaps'
       featuredItems={roleRoadmaps
         .filter((roadmapItem) => !roadmapItem.frontmatter.isHidden)
         .map((roadmapItem) => ({
@@ -54,7 +54,7 @@ const videos = await getAllVideos();
     />
 
     <FeaturedItems
-      heading='Skill based Roadmaps'
+      heading='Skill-based Roadmaps'
       featuredItems={skillRoadmaps
         .filter((roadmapItem) => !roadmapItem.frontmatter.isHidden)
         .map((roadmapItem) => ({


### PR DESCRIPTION
Added a hyphen to "Role based" and "Skill based" roadmap headings on the landing page thereby changing them to "Role-based" and "Skill-based". 