### PR TITLE
Fixed typo, was consructor now constructor.

### DIFF
--- a/src/data/roadmaps/typescript/content/constructor-overloading@oxzcYXxy2I7GI7nbvFYVa.md
+++ b/src/data/roadmaps/typescript/content/constructor-overloading@oxzcYXxy2I7GI7nbvFYVa.md
@@ -13,7 +13,7 @@ class Point {
 }
 ```
 
-Note that, similar to function overloading, we only have one implementation of the consructor and it's the only the signature that is overloaded.
+Note that, similar to function overloading, we only have one implementation of the constructor and it's the only the signature that is overloaded.
 
 Learn more from the following resources:
 


### PR DESCRIPTION
Very minor typo in the Typescript "Constructor Overloading" section. For the paragraph beginning in "Note that, similar to function overloading . . ."