### PR TITLE
Fix link to point to "Ambient Modules" anchor in TS Modules Reference

### DIFF
--- a/src/data/roadmaps/typescript/content/ambient-modules@k_5y77k8ZZ9_O2WpWXWTY.md
+++ b/src/data/roadmaps/typescript/content/ambient-modules@k_5y77k8ZZ9_O2WpWXWTY.md
@@ -19,4 +19,4 @@ In this example, we declare an ambient module "my-module" in the `myModule.d.ts`
 
 Learn more from the following links:
 
-- [@official@Ambient Modules](https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules)
+- [@official@Ambient Modules](https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules)


### PR DESCRIPTION
The old link is improperly formatted--as such, it simply redirects the user to https://www.typescriptlang.org/docs/handbook/modules/introduction.html, rather than the more specific https://www.typescriptlang.org/docs/handbook/modules/reference.html#ambient-modules

OLD LINK (for ease of reference):
https://www.typescriptlang.org/docs/handbook/modules.html#ambient-modules