### PR TITLE
Remove Trello and Associated Links from Tools Section of Software Architecture Roadmap

### DIFF
--- a/public/roadmap-content/software-architect.json
+++ b/public/roadmap-content/software-architect.json
@@ -613,27 +613,6 @@
       }
     ]
   },
-  "a6joS9WXg-rbw29_KfBd9": {
-    "title": "Trello",
-    "description": "Trello is the visual tool that empowers your team to manage any type of project, workflow, or task tracking.\n\nVisit the following resources to learn more:",
-    "links": [
-      {
-        "title": "Trello",
-        "url": "https://trello.com",
-        "type": "article"
-      },
-      {
-        "title": "Trello Guide",
-        "url": "https://trello.com/guide",
-        "type": "article"
-      },
-      {
-        "title": "A Tour Of Trello",
-        "url": "https://www.youtube.com/watch?v=AyfupeWS0yY",
-        "type": "video"
-      }
-    ]
-  },
   "3bpd0iZTd3G-H8A7yrExY": {
     "title": "Atlassian Tools",
     "description": "The Jira platform is, at its core, our workflow engine that allows you to track issues or tasks through a predefined and customizable workflow. These tasks can be organized by project, allowing for the entirety of your organization to track their issues at a project level with complete transparency using granular user permissions.\n\n### Jira Service Desk\n\nJira Service Desk is for teams who receive incoming issues/requests from other teams/customers. Jira Service Desk is designed specifically for end-users to submit tickets to a help desk team.\n\n### Jira Core\n\nJira Core takes this workflow engine and caters it for business teams to develop organized, easy to use, task-oriented projects. Whether the tasks are a simple to-do list or a robust 7 step workflow with complex transitions, Jira Core is built to accommodate all of your requirements. Jira Core is an excellent solution for business teams, legal teams, HR teams, non-technical teams, marketing teams, financial teams, operation teams, and more.\n\n### Confluence\n\nConfluence is a collaboration wiki used to help teams collaborate and share knowledge efficiently. It acts as your document collaboration and repository as it keeps full tracking of what changed in each document, when, and by whom to keep an 'audit' trail. Team members can create, share, and collaborate on content.\n\n### Bitbucket\n\nBitbucket Server is the on-premises Git repository management solution for enterprise teams. It allows everyone in your organization to easily collaborate on your Git repositories.\n\n### Statuspage\n\nStatuspage helps teams inform customers and end-users about outages and scheduled maintenance. Statuspage is the communication piece of your incident management process. Keep users in the loop from 'investigating' through 'resolved'.\n\n### Opsgenie\n\nOpsgenie is a modern incident management solution for operating always-on services that enable dev and ops teams to stay aware and in control of alerts and incidents.\n\n### Advanced Roadmaps for Jira\n\nAdvanced Roadmaps is a Jira Software Cloud Premium feature that's designed to help multiple teams collaborate together, track the big picture, identify dependencies across large pieces of work, and plan for team capacity.\n\nAdvanced Roadmaps is available as a standalone app for Jira Software Server and Data Center.\n\n### Jira Align\n\nJira Align is an Enterprise Agile Planning platform that helps improve visibility, strategic alignment, and enterprise adaptability in order to accelerate your digital transformation.\n\nVisit the following resources to learn more:",

--- a/public/roadmap-content/software-architect.json
+++ b/public/roadmap-content/software-architect.json
@@ -613,6 +613,27 @@
       }
     ]
   },
+  "a6joS9WXg-rbw29_KfBd9": {
+    "title": "Trello",
+    "description": "Trello is the visual tool that empowers your team to manage any type of project, workflow, or task tracking.\n\nVisit the following resources to learn more:",
+    "links": [
+      {
+        "title": "Trello",
+        "url": "https://trello.com",
+        "type": "article"
+      },
+      {
+        "title": "Trello Guide",
+        "url": "https://trello.com/guide",
+        "type": "article"
+      },
+      {
+        "title": "A Tour Of Trello",
+        "url": "https://www.youtube.com/watch?v=AyfupeWS0yY",
+        "type": "video"
+      }
+    ]
+  },
   "3bpd0iZTd3G-H8A7yrExY": {
     "title": "Atlassian Tools",
     "description": "The Jira platform is, at its core, our workflow engine that allows you to track issues or tasks through a predefined and customizable workflow. These tasks can be organized by project, allowing for the entirety of your organization to track their issues at a project level with complete transparency using granular user permissions.\n\n### Jira Service Desk\n\nJira Service Desk is for teams who receive incoming issues/requests from other teams/customers. Jira Service Desk is designed specifically for end-users to submit tickets to a help desk team.\n\n### Jira Core\n\nJira Core takes this workflow engine and caters it for business teams to develop organized, easy to use, task-oriented projects. Whether the tasks are a simple to-do list or a robust 7 step workflow with complex transitions, Jira Core is built to accommodate all of your requirements. Jira Core is an excellent solution for business teams, legal teams, HR teams, non-technical teams, marketing teams, financial teams, operation teams, and more.\n\n### Confluence\n\nConfluence is a collaboration wiki used to help teams collaborate and share knowledge efficiently. It acts as your document collaboration and repository as it keeps full tracking of what changed in each document, when, and by whom to keep an 'audit' trail. Team members can create, share, and collaborate on content.\n\n### Bitbucket\n\nBitbucket Server is the on-premises Git repository management solution for enterprise teams. It allows everyone in your organization to easily collaborate on your Git repositories.\n\n### Statuspage\n\nStatuspage helps teams inform customers and end-users about outages and scheduled maintenance. Statuspage is the communication piece of your incident management process. Keep users in the loop from 'investigating' through 'resolved'.\n\n### Opsgenie\n\nOpsgenie is a modern incident management solution for operating always-on services that enable dev and ops teams to stay aware and in control of alerts and incidents.\n\n### Advanced Roadmaps for Jira\n\nAdvanced Roadmaps is a Jira Software Cloud Premium feature that's designed to help multiple teams collaborate together, track the big picture, identify dependencies across large pieces of work, and plan for team capacity.\n\nAdvanced Roadmaps is available as a standalone app for Jira Software Server and Data Center.\n\n### Jira Align\n\nJira Align is an Enterprise Agile Planning platform that helps improve visibility, strategic alignment, and enterprise adaptability in order to accelerate your digital transformation.\n\nVisit the following resources to learn more:",

--- a/src/data/roadmaps/software-architect/content/trello@a6joS9WXg-rbw29_KfBd9.md
+++ b/src/data/roadmaps/software-architect/content/trello@a6joS9WXg-rbw29_KfBd9.md
@@ -1,9 +1,0 @@
-# Trello
-
-Trello is the visual tool that empowers your team to manage any type of project, workflow, or task tracking.
-
-Visit the following resources to learn more:
-
-- [@official@Trello](https://trello.com)
-- [@video@A Tour Of Trello](https://www.youtube.com/watch?v=AyfupeWS0yY)
-- [@official@Trello Guide](https://trello.com/guide)


### PR DESCRIPTION
Issue Solved : #7597

### Description:

**Purpose**:  
This PR removes Trello from the tools section of the software architecture roadmap, as it is already included within the broader Atlassian tools suite. Removing this entry eliminates redundancy and streamlines the tools list.

**Context**:  
The software architecture roadmap lists various tools for architecture and project management. Trello, as part of the Atlassian suite, was previously listed separately, creating redundancy. This update consolidates Trello under the Atlassian tools entry, aligning with a simplified tools list structure.

### Changes Made:

1. **Removed standalone Trello entry**:  
   - Deleted Trello from the tools section, as it is already covered under Atlassian tools.
2. **Updated documentation references**:  
   - Adjusted any descriptions or links to ensure consistency with this removal.

---

### Additional Notes:

- This PR aims to improve clarity within the tools list by consolidating tools that fall under the same suite.
- Please review for any additional mentions of Trello or suggestions for tools that should be consolidated similarly.

--- 