### PR TITLE
Remove Trello and Associated Links from Tools Section of Software Architecture Roadmap

### DIFF
--- a/src/data/roadmaps/software-architect/migration-mapping.json
+++ b/src/data/roadmaps/software-architect/migration-mapping.json
@@ -38,7 +38,6 @@
   "architect-tools": "SuMhTyaBS9vwASxAt39DH",
   "architect-tools:git": "ZEzYb-i55hBe9kK3bla94",
   "architect-tools:slack": "CYnUg_okOcRrD7fSllxLW",
-  "architect-tools:trello": "a6joS9WXg-rbw29_KfBd9",
   "architect-tools:atlassian-tools": "3bpd0iZTd3G-H8A7yrExY",
   "architectures": "OaLmlfkZid7hKqJ9G8oNV",
   "architectures:serverless": "FAXKxl3fWUFShYmoCsInZ",

--- a/src/data/roadmaps/software-architect/software-architect.json
+++ b/src/data/roadmaps/software-architect/software-architect.json
@@ -1944,36 +1944,6 @@
       "focusable": true
     },
     {
-      "id": "a6joS9WXg-rbw29_KfBd9",
-      "type": "subtopic",
-      "position": {
-        "x": 282.63182479290697,
-        "y": 1021.01163847671
-      },
-      "selected": false,
-      "data": {
-        "label": "Trello",
-        "style": {
-          "fontSize": 17,
-          "justifyContent": "flex-start",
-          "textAlign": "center"
-        }
-      },
-      "zIndex": 999,
-      "width": 158,
-      "height": 49,
-      "style": {
-        "width": 158
-      },
-      "positionAbsolute": {
-        "x": 282.63182479290697,
-        "y": 1021.01163847671
-      },
-      "dragging": false,
-      "selectable": true,
-      "focusable": true
-    },
-    {
       "id": "3bpd0iZTd3G-H8A7yrExY",
       "type": "subtopic",
       "position": {


### PR DESCRIPTION
Issue Solved : #7597

### Description:

**Purpose**:  
This PR removes Trello from the tools section of the software architecture roadmap, as it is already included within the broader Atlassian tools suite. Removing this entry eliminates redundancy and streamlines the tools list.

**Context**:  
The software architecture roadmap lists various tools for architecture and project management. Trello, as part of the Atlassian suite, was previously listed separately, creating redundancy. This update consolidates Trello under the Atlassian tools entry, aligning with a simplified tools list structure.

### Changes Made:

1. **Removed standalone Trello entry**:  
   - Deleted Trello from the tools section, as it is already covered under Atlassian tools.
2. **Updated documentation references**:  
   - Adjusted any descriptions or links to ensure consistency with this removal.

---

### Additional Notes:

- This PR aims to improve clarity within the tools list by consolidating tools that fall under the same suite.
- Please review for any additional mentions of Trello or suggestions for tools that should be consolidated similarly.

--- 