### PR TITLE
Moved PostgreSQL to Skill-based section

### DIFF
--- a/src/components/Roadmaps/RoadmapsPage.tsx
+++ b/src/components/Roadmaps/RoadmapsPage.tsx
@@ -276,7 +276,7 @@ const groups: GroupType[] = [
       {
         title: 'PostgreSQL',
         link: '/postgresql-dba',
-        type: 'role',
+        type: 'skill',
         otherGroups: ['Web Development'],
       },
       {

--- a/src/data/roadmaps/postgresql-dba/postgresql-dba.md
+++ b/src/data/roadmaps/postgresql-dba/postgresql-dba.md
@@ -43,7 +43,7 @@ sitemap:
 tags:
   - 'roadmap'
   - 'main-sitemap'
-  - 'role-roadmap'
+  - 'skill-roadmap'
 ---
 The intent of this guide is to give you an idea about the DBA landscape and to help guide your learning if you are confused. The roadmap is highly opinionated — neither, knowing everything listed in the roadmap, nor the order of items given in the roadmap is required to be followed in order to be a DBA.
 


### PR DESCRIPTION
## Objective:

- Should be able to see `PostgreSQL` under **skill-based roadmaps**

## Description:

- Updated PostgreSQL from role to skill based section in RoadmapsPage.tsx and postgresql-dba.md files

## How to test:

- If you go to `home page` of roadmap and `/roadmaps` -> `All Roadmaps`
- You could see `PostgreSQL` under `SKILL BASED ROADMAPS`

## Screenshots:

**Home screen**
<img width="1208" alt="Screenshot 2024-10-28 at 2 05 28 PM" src="https://github.com/user-attachments/assets/1b972fd7-5b63-448c-b10d-165c430c9e4c">

**All roadmaps screen**
<img width="1328" alt="Screenshot 2024-10-28 at 2 06 08 PM" src="https://github.com/user-attachments/assets/6bfe2db7-3d6c-48ea-80e4-638d626ce9a3">


