### PR TITLE
Fix: Improve grep command to filter files ending with .txt

### DIFF
--- a/src/data/roadmaps/linux/content/104-text-processing/109-pipe.md
+++ b/src/data/roadmaps/linux/content/104-text-processing/109-pipe.md
@@ -5,10 +5,10 @@ The pipe (`|`) is a powerful feature in Linux used to connect two or more comman
 Here is a simple example of piping two commands, `ls` and `grep`, to list all the text files in the current directory:
 
 ```bash
-ls | grep .txt
+ls | grep '\.txt$'
 ```
 
-In this example, `ls` lists the files in the current directory and `grep .txt` filters out any files that don't end with `.txt`. The pipe command, `|`, takes the output from `ls` and uses it as the input to `grep .txt`. The output of the entire command is the list of text files in the current directory.
+In this example, `ls` lists the files in the current directory and `grep '\.txt$'` filters out any files that don't end with `.txt`. The pipe command, `|`, takes the output from `ls` and uses it as the input to `grep '\.txt$'`. The output of the entire command is the list of text files in the current directory.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Updated the grep command in the example to match files specifically ending in ".txt". The original command `ls | grep .txt` would match any filename containing ".txt" anywhere in its name, which could lead to unintended matches. The revised command uses `grep '\.txt$'` to filter for files ending with ".txt" precisely.