### PR TITLE
Add ability to show partner avatar on project card

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -3,6 +3,6 @@
 		"enabled": false
 	},
 	"_variables": {
-		"lastUpdateCheck": 1729612578122
+		"lastUpdateCheck": 1730730439924
 	}
 }

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -12,6 +12,7 @@ type ProjectCardProps = {
   project: ProjectFileType;
   userCount?: number;
   status?: 'completed' | 'started' | 'none';
+  avatar?: string;
 };
 
 const badgeVariants: Record<ProjectDifficultyType, string> = {
@@ -21,8 +22,9 @@ const badgeVariants: Record<ProjectDifficultyType, string> = {
 };
 
 export function ProjectCard(props: ProjectCardProps) {
-  const { project, userCount = 0, status } = props;
+  const { project, userCount = 0, status, avatar } = props;
   const { frontmatter, id } = project;
+  const partnerAvatar = frontmatter.partner?.avatar;
 
   const isLoadingStatus = status === undefined;
   const userStartedCount = status !== 'none' && userCount === 0 ? userCount + 1 : userCount;
@@ -46,8 +48,8 @@ export function ProjectCard(props: ProjectCardProps) {
       <span className="flex min-h-[22px] items-center justify-between gap-2 text-xs text-gray-400">
         {isLoadingStatus ? (
           <>
-            <span className="h-5 w-24 animate-pulse rounded bg-gray-200" />{' '}
-            <span className="h-5 w-20 animate-pulse rounded bg-gray-200" />{' '}
+            <span className="h-5 w-24 animate-pulse rounded bg-gray-200" />
+            <span className="h-5 w-20 animate-pulse rounded bg-gray-200" />
           </>
         ) : (
           <>
@@ -59,24 +61,41 @@ export function ProjectCard(props: ProjectCardProps) {
                 <>Be the first to solve!</>
               )}
             </span>
-
-            {status !== 'none' && (
-              <span
-                className={cn(
-                  'flex items-center gap-1.5 rounded-full border border-current px-2 py-0.5 capitalize',
-                  status === 'completed' && 'text-green-500',
-                  status === 'started' && 'text-yellow-500',
-                )}
-              >
+            <span className="flex items-center gap-2">
+              {status !== 'none' && (
                 <span
-                  className={cn('inline-block h-2 w-2 rounded-full', {
-                    'bg-green-500': status === 'completed',
-                    'bg-yellow-500': status === 'started',
-                  })}
-                />
-                {status}
-              </span>
-            )}
+                  className={cn(
+                    'flex items-center gap-1.5 rounded-full border border-current px-2 py-0.5 capitalize',
+                    status === 'completed' && 'text-green-500',
+                    status === 'started' && 'text-yellow-500',
+                  )}
+                >
+                  <span
+                    className={cn('inline-block h-2 w-2 rounded-full', {
+                      'bg-green-500': status === 'completed',
+                      'bg-yellow-500': status === 'started',
+                    })}
+                  />
+                  {status}
+                </span>
+              )}
+              {partnerAvatar && frontmatter.partner?.url && (
+                <a
+                  href={frontmatter.partner.url}
+                  target="_blank"
+                  rel="noopener"
+                  onClick={(e) => e.stopPropagation()}
+                  className="flex-shrink-0"
+                  title={frontmatter.partner.name}
+                >
+                  <img
+                    src={partnerAvatar}
+                    alt={`${frontmatter.partner.name} avatar`}
+                    className="h-6 w-6 rounded-full object-cover"
+                  />
+                </a>
+              )}
+            </span>
           </>
         )}
       </span>

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -48,8 +48,8 @@ export function ProjectCard(props: ProjectCardProps) {
       <span className="flex min-h-[22px] items-center justify-between gap-2 text-xs text-gray-400">
         {isLoadingStatus ? (
           <>
-            <span className="h-5 w-24 animate-pulse rounded bg-gray-200" />
-            <span className="h-5 w-20 animate-pulse rounded bg-gray-200" />
+            <span className="h-5 w-24 animate-pulse rounded bg-gray-200" />{' '}
+            <span className="h-5 w-20 animate-pulse rounded bg-gray-200" />{' '}
           </>
         ) : (
           <>

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -23,6 +23,11 @@ export interface ProjectFrontmatter {
     ogImageUrl: string;
   };
   roadmapIds: string[];
+  partner?: {
+    name: string;
+    avatar: string;
+    url: string;
+  };
 }
 
 export type ProjectFileType = MarkdownFileType<ProjectFrontmatter> & {


### PR DESCRIPTION
## I've added the option of including a partner avatar on partnered projects (see image).

![Screenshot 2024-11-04 at 14 43 09](https://github.com/user-attachments/assets/fc38b978-7e17-4a63-978f-a14a662b52e3)

Avatars are added via frontmatter like so:

```markdown
partner:
  name: "Deno"
  avatar: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Deno_Logo_2024.svg/2048px-Deno_Logo_2024.svg.png"
  url: "https://deno.com/"
```

Users can click the avatar to be sent to the partner site. I've opted for not having `noreferral` in the anchor tag as we want them to know people came from us.

@arikchakma I cannot test this changes when the user is logged in and has **status** pills on the card so would you be able to test that whenever you have the time as I lack the permissions 🙏🏻 I tried to adjust things around so that the different card elements will work together but I was writing it in the dark 😅 