### PR TITLE
Fixes typo in 104-proc-priorities.md

### DIFF
--- a/src/data/roadmaps/linux/content/106-process-management/104-proc-priorities.md
+++ b/src/data/roadmaps/linux/content/106-process-management/104-proc-priorities.md
@@ -15,5 +15,5 @@ ps -eo pid,pri,user
 To change the priority of any process, you can use the `renice` command:
 
 ```sh
-renice +5 -p [PID]   # Increase priority by 5 units for process ID [PID]
+renice -5 -p [PID]   # Increase priority by 5 units for process ID [PID]
 ```


### PR DESCRIPTION
Old: renice +5
New: renice -5

From my research, after reading the topic in the Linux roadmap, it didnt make sense that increasing the priority of a process was made by +5, the topic said that a negative number makes the priority higher, so do many articles on the internet.