### PR TITLE
fixes the gitignore link error in git-github roadmap

### DIFF
--- a/src/data/roadmaps/git-github/content/gitignore@oz2oRAhaEQb0Fm3aRJQG8.md
+++ b/src/data/roadmaps/git-github/content/gitignore@oz2oRAhaEQb0Fm3aRJQG8.md
@@ -4,7 +4,7 @@ Ignored files are tracked in a special file named `.gitignore` that is checked i
 
 Visit the following resources to learn more:
 
-- [@official@gitignore Documentation](https://git-scm.com/docs/gitignore/en)
+- [@official@gitignore Documentation](https://git-scm.com/docs/gitignore)
 - [@article@.gitignore file - ignoring files in Git | Atlassian Git Tutorial](https://www.atlassian.com/git/tutorials/saving-changes/gitignore)
 - [@article@Ignoring files - GitHub Docs](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files)
 - [@opensource@gitignore - A collection of useful .gitignore templates](https://github.com/github/gitignore)


### PR DESCRIPTION
Hey, I have fixed the gitignore documentation link error for the gitignore.
updated the line: [@official@gitignore Documentation](https://git-scm.com/docs/gitignore)

![image](https://github.com/user-attachments/assets/200203ed-54b3-4bd0-a223-972492e13170)

Thanks.