### PR TITLE
fix: Update color ticks hexcode from #2d72d2 to #874efe

### DIFF
--- a/src/data/roadmaps/react/react.json
+++ b/src/data/roadmaps/react/react.json
@@ -598,7 +598,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -705,7 +705,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -809,7 +809,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -846,7 +846,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -883,7 +883,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -920,7 +920,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -989,7 +989,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1026,7 +1026,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1063,7 +1063,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1100,7 +1100,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1137,7 +1137,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1174,7 +1174,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1304,7 +1304,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1341,7 +1341,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1410,7 +1410,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1448,7 +1448,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1486,7 +1486,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1524,7 +1524,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1562,7 +1562,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1600,7 +1600,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1637,7 +1637,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1746,7 +1746,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -1852,7 +1852,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1890,7 +1890,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -1987,7 +1987,7 @@
         "oldId": "akVNUPOqaTXaSHoQFlkP_",
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2164,7 +2164,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2240,7 +2240,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -2382,7 +2382,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2560,7 +2560,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -2773,7 +2773,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2811,7 +2811,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2886,7 +2886,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "left-center"
         }
@@ -2956,7 +2956,7 @@
         "oldId": "-WjJBYCmRRj08n_9HxohY",
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -2993,7 +2993,7 @@
         "oldId": "-WjJBYCmRRj08n_9HxohY",
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -3100,7 +3100,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -3204,7 +3204,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -3241,7 +3241,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -3379,7 +3379,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }
@@ -3608,7 +3608,7 @@
         },
         "legend": {
           "id": "Z0WmUXWj-7draje3jE1WR",
-          "color": "#2d72d2",
+          "color": "#874efe",
           "label": "Personal Recommendation (Opinion)",
           "position": "right-center"
         }


### PR DESCRIPTION
Simple fix to change blue tick to purple tick to ensure consistency with other roadmaps. The choice of hexcode is provide by @fellalli in this [issue](https://github.com/kamranahmedse/developer-roadmap/issues/7688). 