### PR TITLE
Move Protobuf Video from Buffers Section to Protocol Buffers Section

### DIFF
--- a/src/data/roadmaps/golang/content/101-go-advanced/107-buffer.md
+++ b/src/data/roadmaps/golang/content/101-go-advanced/107-buffer.md
@@ -6,4 +6,3 @@ Visit the following resources to learn more:
 
 - [@official@Buffer Examples](https://pkg.go.dev/bytes#example-Buffer)
 - [@article@Buffer](https://www.educba.com/golang-buffer/)
-- [@video@Buffers in Golang](https://www.youtube.com/watch?v=NoDRq6Twkts)

--- a/src/data/roadmaps/golang/content/109-go-microservices/105-protocol-buffers.md
+++ b/src/data/roadmaps/golang/content/109-go-microservices/105-protocol-buffers.md
@@ -14,4 +14,5 @@ Visit the following resources to learn more:
 - [@opensource@Protobuf](https://github.com/protocolbuffers/protobuf/)
 - [@article@Protobuf Doc](https://developers.google.com/protocol-buffers/)
 - [@article@Protobuf with Go](https://developers.google.com/protocol-buffers/docs/gotutorial/)
+- [@video@Buffers in Golang](https://www.youtube.com/watch?v=NoDRq6Twkts)
 - [@feed@Explore top posts about Backend Development](https://app.daily.dev/tags/backend?ref=roadmapsh)

--- a/src/data/roadmaps/golang/content/109-go-microservices/105-protocol-buffers.md
+++ b/src/data/roadmaps/golang/content/109-go-microservices/105-protocol-buffers.md
@@ -14,5 +14,5 @@ Visit the following resources to learn more:
 - [@opensource@Protobuf](https://github.com/protocolbuffers/protobuf/)
 - [@article@Protobuf Doc](https://developers.google.com/protocol-buffers/)
 - [@article@Protobuf with Go](https://developers.google.com/protocol-buffers/docs/gotutorial/)
-- [@video@Buffers in Golang](https://www.youtube.com/watch?v=NoDRq6Twkts)
+- [@video@Protocol Buffers in Golang](https://www.youtube.com/watch?v=NoDRq6Twkts)
 - [@feed@Explore top posts about Backend Development](https://app.daily.dev/tags/backend?ref=roadmapsh)


### PR DESCRIPTION
In Step by step guide to becoming a Go developer in 2024,
I noticed that there was a protobuf video in buffer section, so i changed it 👍 