### PR TITLE
fix(expense tracker): a small logical error in desctiption

### DIFF
--- a/src/data/projects/expense-tracker.md
+++ b/src/data/projects/expense-tracker.md
@@ -62,7 +62,7 @@ $ expense-tracker list
 $ expense-tracker summary
 # Total expenses: $30
 
-$ expense-tracker delete --id 1
+$ expense-tracker delete --id 2
 # Expense deleted successfully
 
 $ expense-tracker summary


### PR DESCRIPTION
If we are referencing by id and not index then --id 1 would remove the first element making the summary 10 and not 20

Solution: delete the second element instead to make the summary add up correctly.