### PR TITLE
Fix color mismatch between legend and roadmap sections

### DIFF
--- a/src/data/roadmaps/react/react.json
+++ b/src/data/roadmaps/react/react.json
@@ -3637,7 +3637,7 @@
         "legends": [
           {
             "id": "Z0WmUXWj-7draje3jE1WR",
-            "color": "#2d72d2",
+            "color": "#874efe",
             "label": "Personal Recommendation (Opinion)"
           },
           {


### PR DESCRIPTION
This pull request fixes the legend section color coding to match that of the roadmap sections of the website (blue changed to purple).
Link to the issue: https://github.com/kamranahmedse/developer-roadmap/issues/7723