### PR TITLE
Update cloning-repositories@1Koej79yTv-OAswVZwgGq.md

### DIFF
--- a/src/data/roadmaps/git-github/content/cloning-repositories@1Koej79yTv-OAswVZwgGq.md
+++ b/src/data/roadmaps/git-github/content/cloning-repositories@1Koej79yTv-OAswVZwgGq.md
@@ -4,7 +4,7 @@ Cloning a repository in Git and GitHub involves creating a local copy of a remot
 
 Visit the following resources to learn more:
 
-- [@official@git clone](https://git-scm.com/docs/git-clone/en)
+- [@official@git clone](https://git-scm.com/docs/git-clone)
 - [@official@Cloning a Repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository)
 - [@article@Clone a Git Repository](https://www.atlassian.com/git/tutorials/setting-up-a-repository/git-clone)
 - [@video@Cloning Remote Repository into local machine](https://youtu.be/xeQih8LVtZM?si=djlyTDpLNS0oyqQH)


### PR DESCRIPTION
**Reasons for making this change:** 
The link to the "git-clone" official documentation in the "Learn Git and GitHub" section of the roadmap (https://roadmap.sh/git-github) is broken. This fix updates the link to ensure that users are directed to the correct resource when learning how to clone repositories.

Link to the issue: https://github.com/kamranahmedse/developer-roadmap/issues/7733