### PR TITLE
Add beginner-friendly article to REST Assured Section in Java Roadmap

### DIFF
--- a/src/data/roadmaps/java/content/107-testing-java-apps/106-rest-assured.md
+++ b/src/data/roadmaps/java/content/107-testing-java-apps/106-rest-assured.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Rest-assured](https://rest-assured.io/)
 - [@opensource@Rest-assured Documentation](https://github.com/rest-assured/rest-assured/wiki)
+- [@article@A Guide to REST-assured](https://www.baeldung.com/rest-assured-tutorial)
 - [@feed@Explore top posts about REST API](https://app.daily.dev/tags/rest-api?ref=roadmapsh)


### PR DESCRIPTION
## Content

I’ve added a beginner-friendly article, [A Guide to REST-assured](https://www.baeldung.com), from Baeldung to the REST Assured section. If there’s anything that doesn’t meet the format, please feel free to comment. Thanks😊.

## Issue
Fixed #7736