### PR TITLE
[fix]:change update url in In Databases -> Relational -> PostgreSQL

### DIFF
--- a/src/data/roadmaps/aspnet-core/content/107-databases/102-relational/101-postgresql.md
+++ b/src/data/roadmaps/aspnet-core/content/107-databases/102-relational/101-postgresql.md
@@ -8,5 +8,5 @@ For more information, visit the following resources:
 
 - [@official@Postgresql - Open Source Relational Database](https://www.postgresql.org/)
 - [@article@What is Postgresql?](https://postgresqltutorial.com/postgresql-getting-started/what-is-postgresql/)
-- [@article@Introduction, Advantages & Disadvantages of PostgreSQL](https://guru99.com/introduction-postgresql.htmlPostgresql)
+- [@article@Introduction, Advantages & Disadvantages of PostgreSQL](https://www.guru99.com/introduction-postgresql.html)
 - [@feed@Explore top posts about PostgreSQL](https://app.daily.dev/tags/postgresql?ref=roadmapsh)


### PR DESCRIPTION
I contribute  fix  simple issue is developer-roadmap project by suggesting an improvement to the ASP.NET Core roadmap to change url, 
under Databases → Relational → PostgreSQL,
 I updating the PostgreSQL link to point directly to https://www.guru99.com/introduction-postgresql.html.