### PR TITLE
[Server Side Game Developer] Fix: Update correct link for client side game development

### DIFF
--- a/src/data/roadmaps/server-side-game-developer/server-side-game-developer.json
+++ b/src/data/roadmaps/server-side-game-developer/server-side-game-developer.json
@@ -6218,7 +6218,7 @@
       "selected": false,
       "data": {
         "label": "Client-side game Development",
-        "href": "https://roadmap.sh/backend",
+        "href": "https://roadmap.sh/game-developer",
         "color": "#FFFFFf",
         "backgroundColor": "#4136D4",
         "style": {


### PR DESCRIPTION
This PR fixes the link on [Server Side Game Developer](https://roadmap.sh/server-side-game-developer) for [Client-side game Development](https://roadmap.sh/game-developer), which is at the end of roadmap, under the section that points to next relevant roadmaps.
Previously, it was pointing to [Backend Developer](https://roadmap.sh/backend).