### PR TITLE
Fix: Fit footer social media icons in one line

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -62,13 +62,13 @@ import Icon from './AstroIcon.astro';
         <div class='text-sm text-gray-400'>
           <p>
             &copy; roadmap.sh
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a href='/terms' class='hover:text-white'>Terms</a>
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a href='/privacy' class='hover:text-white'>Privacy</a>
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a href='/advertise' class='hover:text-white'>Advertise</a>
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a
               aria-label='Write us an email'
               href='mailto:info@roadmap.sh'
@@ -120,13 +120,13 @@ import Icon from './AstroIcon.astro';
               target='_blank'
               class='text-gray-400 hover:text-white'>DevOps</a
             >
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a
               href='https://thenewstack.io/category/kubernetes?utm_source=roadmap.sh&utm_medium=Referral&utm_campaign=Footer'
               target='_blank'
               class='text-gray-400 hover:text-white'>Kubernetes</a
             >
-            <span class='mx-1.5'>&middot;</span>
+            <span class='mx-1.5 ml-[0.2109rem] mr-[0.2109rem]'>&middot;</span>
             <a
               href='https://thenewstack.io/category/cloud-native?utm_source=roadmap.sh&utm_medium=Referral&utm_campaign=Footer'
               target='_blank'


### PR DESCRIPTION
Adjusting tailwind's left and right margin on Footer.astro middots from 0.375rem to 0.2109rem made all the social media icons (mail, youtube and x/twitter) fit into one line. I chose 0.2109rem because after experimenting with it, it was the highest number that did the job.