### PR TITLE
Update intersection-types@RWYXEZMODUrqwRWf_Lqi9.md

### DIFF
--- a/src/data/roadmaps/typescript/content/intersection-types@RWYXEZMODUrqwRWf_Lqi9.md
+++ b/src/data/roadmaps/typescript/content/intersection-types@RWYXEZMODUrqwRWf_Lqi9.md
@@ -10,7 +10,7 @@ type typeAB = typeA & typeB;
 
 The `typeAB` will have all properties from both typeA and typeB.
 
-Note that the union type uses the `|` operator that defines a variable which can hold a value of either `typeA` or `typeB`
+Note that the union type uses the `|` operator that defines a variable which can hold `typeA` value, or `typeB` value, or both altogether.
 
 Learn more from the following links:
 


### PR DESCRIPTION
Hello. I think it's crucial to mention that "typeA | typeB" type can hold both values altogether. not only either typeA or typeB