### PR TITLE
Logo redirects to roadmap.sh in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/images/brand.png" height="128">
+  <a href="https://roadmap.sh/"><img src="public/images/brand.png" height="128"></a>
   <h2 align="center"><a href="https://roadmap.sh">roadmap.sh</a></h2>
   <p align="center">Community driven roadmaps, articles and resources for developers<p>
   <p align="center">


### PR DESCRIPTION
Clicking used to redirect to [the logo](https://github.com/kamranahmedse/developer-roadmap/blob/master/public/images/brand.png), now to [roadmap.sh](https://roadmap.sh/).