### PR TITLE
Added another great free article (programiz.com) resource of golang type assertions

### DIFF
--- a/src/data/roadmaps/golang/content/101-go-advanced/102-types-and-type-assertions.md
+++ b/src/data/roadmaps/golang/content/101-go-advanced/102-types-and-type-assertions.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Types Assertions](https://go.dev/tour/methods/15)
 - [@video@Go Syntax - Type Assertions](https://youtube.com/watch?v=vtGbi9bGr3s)
+- [@article@Golang - Type Assertions](https://www.programiz.com/golang/type-assertions)


### PR DESCRIPTION
This pull request includes a small change to the `src/data/roadmaps/golang/content/101-go-advanced/102-types-and-type-assertions.md` file. The change adds a new resource link to the list of learning resources for type assertions in Golang.

* [`src/data/roadmaps/golang/content/101-go-advanced/102-types-and-type-assertions.md`](diffhunk://#diff-7a56a95b02b59861858a11c1e5fb8038b3771b167573688fb6f5685c00aa8fbdR9): Added a new article [link](https://www.programiz.com/golang/type-assertions) to the list of resources.