### PR TITLE
Fix: typo in getting started page Engineering Manager card title

### DIFF
--- a/src/pages/get-started.astro
+++ b/src/pages/get-started.astro
@@ -389,7 +389,7 @@ import { TipItem } from '../components/GetStarted/TipItem';
 
     <RoadmapCard
       icon={UsersRound}
-      title='Engineering Engineer'
+      title='Engineering Manager'
       link='/engineering-manager'
       description='Learn all you need to become an Engineering Manager.'
     />


### PR DESCRIPTION
On the page `/get-started`.

| Before  | After |
| ------------- | ------------- |
| <img width="491" alt="image" src="https://github.com/user-attachments/assets/636c67c7-29fa-4e86-8286-3a57ce5ec0dc" /> | <img width="491" alt="image" src="https://github.com/user-attachments/assets/10e945f8-0458-4534-922b-264444bdd122" /> |