### PR TITLE
Fix: update broken link

### DIFF
--- a/src/data/roadmaps/react-native/content/115-using-native-modules/index.md
+++ b/src/data/roadmaps/react-native/content/115-using-native-modules/index.md
@@ -4,4 +4,4 @@ Sometimes a React Native app needs to access a native platform API that is not a
 
 The NativeModule system exposes instances of Java/Objective-C/C++ (native) classes to JavaScript (JS) as JS objects, thereby allowing you to execute arbitrary native code from within JS. While we don't expect this feature to be part of the usual development process, it is essential that it exists. If React Native doesn't export a native API that your JS app needs you should be able to export it yourself!
 
-- [@article@Native Modules Introduction](https://reactnative.dev/docs/native-modules-intro)
+- [@article@Native Modules Introduction](https://reactnative.dev/docs/native-platform)


### PR DESCRIPTION
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/3adde429-30f4-45ab-a09a-32b734be7c27" />

`https://reactnative.dev/docs/native-modules-intro` doesn't exist anymore, so this PR updates the link to the new link.