### PR TITLE
Python roadmap: Fixed Typo in Sphinx

### DIFF
--- a/src/data/roadmaps/python/content/sphinx@maYNuTKYyZndxk1z29-UY.md
+++ b/src/data/roadmaps/python/content/sphinx@maYNuTKYyZndxk1z29-UY.md
@@ -4,4 +4,4 @@ Sphinx is a tool that makes it easy to create intelligent and beautiful document
 
 Visit the following resources to learn more:
 
-- [@official@Shpinx Website](https://www.sphinx-doc.org/en/master/)
+- [@official@Sphinx Website](https://www.sphinx-doc.org/en/master/)


### PR DESCRIPTION
What is the URL where the issue is happening
https://roadmap.sh/python


Fixed Typo in roadmaps/python/content/sphinx 
-line 7

Changed "Shpinx" to "Sphinx"
![chrome_3661](https://github.com/user-attachments/assets/2d2930a1-5b21-4ba3-930f-37103317aeae)
