### PR TITLE
Fix/resource tag inconsistencies

### DIFF
--- a/src/data/roadmaps/javascript/content/apply@-BtF34cEzI6J8sZCDRlRE.md
+++ b/src/data/roadmaps/javascript/content/apply@-BtF34cEzI6J8sZCDRlRE.md
@@ -4,4 +4,4 @@ The apply() method of Function instances calls this function with a given this v
 
 Visit the following resources to learn more:
 
-- [@official@apply() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)
+- [@article@apply() - MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply)

--- a/src/data/roadmaps/javascript/content/bind@dbercnxXVTJXMpYSDNGb2.md
+++ b/src/data/roadmaps/javascript/content/bind@dbercnxXVTJXMpYSDNGb2.md
@@ -4,6 +4,6 @@ The `bind()` method in JavaScript allows you to create a new function with a spe
 
 Visit the following resources to learn more:
 
-- [@official@bind()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
+- [@article@bind()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
 - [@article@Function binding](https://javascript.info/bind)
 - [@article@Javascript Function Bind()](https://www.w3schools.com/js/js_function_bind.asp)


### PR DESCRIPTION
# Description

The articles by MDN on `bind` and `apply` methods were tagged official (when it's not), whereas in other places articles by MDN are tagged as `article`.

This PR changes these tags to `article`, thereby fixing inconsistencies that may be misleading for some people.

Thank you for your awesome work!
