### PR TITLE
Fix incorrect descriptions of asymptotic notations

### DIFF
--- a/src/data/roadmaps/computer-science/content/asymptotic-notation@UpBrpmrUwYUB9eesNxCq5.md
+++ b/src/data/roadmaps/computer-science/content/asymptotic-notation@UpBrpmrUwYUB9eesNxCq5.md
@@ -14,3 +14,4 @@ Visit the following resources to learn more:
 - [@video@Asymptotic Notation - CS50](https://www.youtube.com/watch?v=iOq5kSKqeR4)
 - [@article@CS 61B Lecture 19: Asymptotic Analysis](https://archive.org/details/ucberkeley_webcast_VIS4YDpuP98)
 - [@article@Big-O Cheat Sheet](https://www.bigocheatsheet.com/)
+- [@article@Big O Notation | Brilliant Math & Science Wiki](https://brilliant.org/wiki/big-o-notation/)

--- a/src/data/roadmaps/computer-science/content/big-o@c-NrTtJuNihbHzyPEOKTW.md
+++ b/src/data/roadmaps/computer-science/content/big-o@c-NrTtJuNihbHzyPEOKTW.md
@@ -1,6 +1,6 @@
 # Big O Notation
 
-Big O Notation describes, how well an algorithm scales with the input size. It is used to describe the worst case scenario of an algorithm. It is used to compare algorithms and to determine which algorithm is better.
+The Big O notation can be used to describe how the running time of an algorithm scales with the growth of the input size, ignoring implementation details such as programming language and computer speed. Specifically, it denotes the upper bound of the growth rate of a function that relates the running time of an algorithm to its input size. It can be used to compare algorithms and determine which one is better.
 
 Visit the following resources to learn more:
 
@@ -8,3 +8,4 @@ Visit the following resources to learn more:
 - [@video@Big O Notations](https://www.youtube.com/watch?v=V6mKVRU1evU)
 - [@article@moviesCS 61B Lecture 19: Asymptotic Analysis](https://archive.org/details/ucberkeley_webcast_VIS4YDpuP98)
 - [@video@Big Oh Notation (and Omega and Theta)](https://www.youtube.com/watch?v=ei-A_wy5Yxw&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN&index=3)
+- [@article@Big O Notation | Brilliant Math & Science Wiki](https://brilliant.org/wiki/big-o-notation/)

--- a/src/data/roadmaps/computer-science/content/big-omega@X33735aeAVSlJ6yv9GS-h.md
+++ b/src/data/roadmaps/computer-science/content/big-omega@X33735aeAVSlJ6yv9GS-h.md
@@ -1,8 +1,9 @@
 # Big Omega Notation
 
-Big Omega notation is used to describe the lower bound of a function. It is the opposite of Big O notation. While Big O is used to describe the worst case scenario of an algorithm, Big Omega is used to describe the best case scenario of an algorithm.
+The Big Omega notation is similar to the Big O notation. The only difference is that it denotes the lower bound on the growth rate of a function.
 
 Visit the following resources to learn more:
 
 - [@video@Big Oh Notation (and Omega and Theta)](https://www.youtube.com/watch?v=ei-A_wy5Yxw&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN&index=3)
 - [@video@Asymptotic Notation - CS50](https://www.youtube.com/watch?v=iOq5kSKqeR4)
+- [@article@Big O Notation | Brilliant Math & Science Wiki](https://brilliant.org/wiki/big-o-notation/)

--- a/src/data/roadmaps/computer-science/content/big-theta@ThLpVZQIJ4diY5m0dik8m.md
+++ b/src/data/roadmaps/computer-science/content/big-theta@ThLpVZQIJ4diY5m0dik8m.md
@@ -1,8 +1,9 @@
 # Big Theta Notation
 
-While Big O Notation refers to the upper bound of a function, Big Theta Notation refers to the exact bound of a function. Big Theta Notation is used to describe the exact growth rate of a function. It is denoted by the symbol Θ.
+If a function has the same Big O and Big Omega, they also become the function's Big Theta. Big Theta is used to describe the exact growth rate of a function. It is denoted by the symbol Θ.
 
 Visit the following resources to learn more:
 
 - [@video@Big Oh Notation (and Omega and Theta)](https://www.youtube.com/watch?v=ei-A_wy5Yxw&list=PL1BaGV1cIH4UhkL8a9bJGG356covJ76qN&index=3)
 - [@video@Asymptotic Notation - CS50](https://www.youtube.com/watch?v=iOq5kSKqeR4)
+- [@article@Big O Notation | Brilliant Math & Science Wiki](https://brilliant.org/wiki/big-o-notation/)


### PR DESCRIPTION
It seems that the current descriptions of the Big O and Big Omega notations reflect a common misconception that they correspond to the worst and best cases of an algorithm. Based on what I've learned from my research, every algorithm can have its best case, worst case, and average case runtimes, and each of these runtimes can be represented by a function. The growth rate of such a function can be constrained by upper and lower bounds, and these bounds are what the Big O and Big Omega notations represent.

This PR rewrites the descriptions of the different asymptotic notations based on the above understanding, while adding a new article that provides a thorough explanation of these concepts. Please feel free to share your views on the changes.