### PR TITLE
add:  journalct in auth  logs  linux roadmap

### DIFF
--- a/src/data/roadmaps/linux/content/105-server-review/101-auth-logs.md
+++ b/src/data/roadmaps/linux/content/105-server-review/101-auth-logs.md
@@ -1,6 +1,6 @@
 # Auth Logs 
 
-When dealing with a Linux server and its maintenance, one of the most critical components to regularly review is the auth logs. These logs, usually located in /var/log/auth.log (for Debian-based distributions) or /var/log/secure (for Red Hat and CentOS), record all authentication-related events and activities which have occurred on the server. This includes, among others, system logins, password changes, and issued sudo commands. 
+When dealing with a Linux server and its maintenance, one of the most critical components to regularly review is the auth logs. These logs, usually located in /var/log/auth.log (for Debian-based distributions) or /var/log/secure (for Red Hat and CentOS) for servers using `syslog`, record all authentication-related events and activities which have occurred on the server. This includes, among others, system logins, password changes, and issued sudo commands. 
 
 Auth logs are an invaluable tool for monitoring and analyzing the security of your Linux server. They can indicate brute force login attacks, unauthorized access attempts, and any suspicious behavior. Regular analysis of these logs is a fundamental task in ensuring server security and data integrity.
 
@@ -10,4 +10,17 @@ Here is an example of how you can use the `tail` command to view the last few en
 tail /var/log/auth.log
 ```
 
+If the server uses `Journal` instead of the default `syslog`, you can utilize the `journalctl` command to gather auth logs.
+
+Here is an example:
+
+```bash
+journalctl -u ssh.service
+```
+
 Get yourself familiar with reading and understanding auth logs, as it's one essential way to keep your server secure.
+
+Learn more from the following resources:
+
+- [@opensource@joaurnal native protocol](https://systemd.io/JOURNAL_NATIVE_PROTOCOL/)
+- [@official@RFC 5424: The Syslog Protocol](https://datatracker.ietf.org/doc/html/rfc5424)


### PR DESCRIPTION
This pull request includes updates to the documentation for reviewing authentication logs on Linux servers. The changes clarify the usage of different logging systems and provide additional resources for further learning.

Documentation updates:

* [`src/data/roadmaps/linux/content/105-server-review/101-auth-logs.md`](diffhunk://#diff-920527fb51a03ebb4a32269547c93bcf48d538789d70a74c5ecae1dd98dc5be1L3-R3): Specified that auth logs are located in `/var/log/auth.log` or `/var/log/secure` for servers using `syslog`, and added instructions for using `journalctl` for servers using `Journal`. 
* Added links to resources for further reading on the `Journal` native protocol and the Syslog protocol.