### PR TITLE
Update deprecated link in React Native roadmap

### DIFF
--- a/src/data/roadmaps/react-native/content/115-using-native-modules/100-for-ios.md
+++ b/src/data/roadmaps/react-native/content/115-using-native-modules/100-for-ios.md
@@ -2,5 +2,5 @@
 
 Visit the Native Modules documentation in react native documentation to learn more about this topic.
 
-- [@article@iOS Native Modules](https://reactnative.dev/docs/native-modules-ios)
+- [@article@iOS Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction?platforms=android)
 - [@feed@Explore top posts about iOS](https://app.daily.dev/tags/ios?ref=roadmapsh)

--- a/src/data/roadmaps/react-native/content/115-using-native-modules/101-for-android.md
+++ b/src/data/roadmaps/react-native/content/115-using-native-modules/101-for-android.md
@@ -2,5 +2,5 @@
 
 Visit the Native Modules documentation in react native documentation to learn more about this topic.
 
-- [@article@Android Native Modules](https://reactnative.dev/docs/native-modules-android)
+- [@article@Android Native Modules](https://reactnative.dev/docs/turbo-native-modules-introduction?platforms=android)
 - [@feed@Explore top posts about Android](https://app.daily.dev/tags/android?ref=roadmapsh)


### PR DESCRIPTION
In the React Native roadmap, the penultimate section, "Using Native Modules", contained two deprecated links that redirected to "Page not found" on the site. I updated the links to their correct destinations. Closes #7956 