### PR TITLE
Fixing Incorrect Android Gradle link - 7952

### DIFF
--- a/public/roadmap-content/android.json
+++ b/public/roadmap-content/android.json
@@ -158,7 +158,7 @@
       },
       {
         "title": "Get going with Gradle - PDF",
-        "url": "https://assets.gradlehero.com/get-going-with-gradle/get-going-with-gradle-book.pdf",
+        "url": "https://assets.tomgregory.com/get-going-with-gradle/get-going-with-gradle-book.pdf",
         "type": "article"
       },
       {


### PR DESCRIPTION
I have fixed the issue of incorrect link placed in the Gradle section under android roadmap

Fix #7952 