### PR TITLE
Update index.md

### DIFF
--- a/src/data/roadmaps/design-system/content/100-design-system-basics/index.md
+++ b/src/data/roadmaps/design-system/content/100-design-system-basics/index.md
@@ -6,5 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@Design Systems 101](https://www.nngroup.com/articles/design-systems-101/)
 - [@video@What is a Design System? Design Systems 101 for Designers](https://www.youtube.com/watch?v=wc5krC28ynQ)
-- [@article@How_to_build_your_design_system](https://www.figma.com/blog/design-systems-102-how-to-build-your-design-system/)
+- [@article@How to build your design system](https://www.figma.com/blog/design-systems-102-how-to-build-your-design-system/)
 - [@article@Everything you need to know about Design Systems](https://uxdesign.cc/everything-you-need-to-know-about-design-systems-54b109851969)

--- a/src/data/roadmaps/design-system/content/100-design-system-basics/index.md
+++ b/src/data/roadmaps/design-system/content/100-design-system-basics/index.md
@@ -6,5 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@Design Systems 101](https://www.nngroup.com/articles/design-systems-101/)
 - [@video@What is a Design System? Design Systems 101 for Designers](https://www.youtube.com/watch?v=wc5krC28ynQ)
-- [@article@A comprehensive guide to design systems](https://www.invisionapp.com/inside-design/guide-to-design-systems/)
+- [@article@How_to_build_your_design_system](https://www.figma.com/blog/design-systems-102-how-to-build-your-design-system/)
 - [@article@Everything you need to know about Design Systems](https://uxdesign.cc/everything-you-need-to-know-about-design-systems-54b109851969)


### PR DESCRIPTION
Fix Broken Link for Design System Basics in Design System Roadmap.

This MR fixes the issue with the broken link in the design system roadmap for the `Design System Basics` resource. The previous link was returning a 404 error.

Link to the issue: #7967