### PR TITLE
Update using-pg_ctlcluster@v3SoKmeCh6uxKW5GAAMje.md

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/using-pg_ctlcluster@v3SoKmeCh6uxKW5GAAMje.md
+++ b/src/data/roadmaps/postgresql-dba/content/using-pg_ctlcluster@v3SoKmeCh6uxKW5GAAMje.md
@@ -4,4 +4,4 @@
 
 Learn more from the following resources:
 
-- [@official@pg_ctlcluster](https://www.postgresql.org/docs/current/pgctlcluster.html)
+- [@article@pg_ctlcluster](https://manpages.ubuntu.com/manpages/focal/man1/pg_ctlcluster.1.html)


### PR DESCRIPTION
Fix Broken Link for Using pg_ctlcluster DBA in PostgreSQL DBA Roadmap.
This MR fixes the issue with the broken link in the PostgreSQL DBA roadmap for the `Using pg_ctlcluster` resource. The previous link was returning a 404 error.

Link to the issue: #7980