### PR TITLE
Add resource for linux service management

### DIFF
--- a/src/data/roadmaps/linux/content/108-service-management/index.md
+++ b/src/data/roadmaps/linux/content/108-service-management/index.md
@@ -17,3 +17,7 @@ sudo systemctl status sshd
 ```
 
 Managing services is a key skill in Linux system administration and essential for maintaining a secure and stable system.
+
+Learn more from the following resources:
+
+- [@article@How to Master Linux Service Management with Systemctl](https://labex.io/tutorials/linux-how-to-master-linux-service-management-with-systemctl-392864)


### PR DESCRIPTION
# Motivation
There was no resource available for Linux service management in the [Linux roadmap](https://roadmap.sh/linux).

# What This PR Does
Adds hands-on resource for Linux service management for the betterment of the roadmap.
LabEx provides an excellent guide which explores Linux service management through systemd and systemctl.

