### PR TITLE
Remove unavailable video resource (Closes #8049)

### DIFF
--- a/src/data/roadmaps/golang/content/101-go-advanced/100-go-modules.md
+++ b/src/data/roadmaps/golang/content/101-go-advanced/100-go-modules.md
@@ -7,5 +7,4 @@ Visit the following resources to learn more:
 - [@official@Go Modules](https://go.dev/blog/using-go-modules)
 - [@article@DigitalOcean: How to use Go Modules](https://www.digitalocean.com/community/tutorials/how-to-use-go-modules)
 - [@video@Go Modules](https://www.youtube.com/watch?v=9cV1KESTJRc)
-- [@video@Go Modules Explained in 5 Minutes](https://youtu.be/7xSxIwWJ9R4)
 - [@feed@Explore top posts about Golang](https://app.daily.dev/tags/golang?ref=roadmapsh)


### PR DESCRIPTION
# Motivation
There is an unavailable resource in [Golang roadmap](https://roadmap.sh/golang), mentioned in #8049 .

# What This PR Does
Closes #8049 by removing the unavailable resource from the markdown file.

I decided against replacing with another resource because there were plenty other resources already provided for this topic (Go module).