### PR TITLE
fix: dedupe the same redirect link(#8037)

### DIFF
--- a/src/data/roadmaps/frontend/content/content-security-policy@rmcm0CZbtNVC9LZ14-H6h.md
+++ b/src/data/roadmaps/frontend/content/content-security-policy@rmcm0CZbtNVC9LZ14-H6h.md
@@ -5,6 +5,5 @@ Content Security Policy (CSP) is a security standard implemented by web browsers
 Visit the following resources to learn more:
 
 - [@article@MDN Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
-- [@article@Google Devs Content Security Policy (CSP)](https://developers.google.com/web/fundamentals/security/csp)
 - [@article@Web.dev - Content Security Policy (CSP)](https://web.dev/csp/)
 - [@feed@Explore top posts about Security](https://app.daily.dev/tags/security?ref=roadmapsh)


### PR DESCRIPTION
Hi.
Deleted the same redirect link which closes #8037.
Seems `web.dev` is the newer link for `developers.google.com/web` .