### PR TITLE
fix: replace unavailable resource and add more description (closes #8078)

### DIFF
--- a/src/data/roadmaps/system-design/content/sql-tuning@fY8zgbB13wxZ1CFtMSdZZ.md
+++ b/src/data/roadmaps/system-design/content/sql-tuning@fY8zgbB13wxZ1CFtMSdZZ.md
@@ -1,6 +1,6 @@
 # SQL Tuning
 
-SQL tuning is a broad topic and many books have been written as reference. It's important to benchmark and profile to simulate and uncover bottlenecks.
+SQL tuning is the attempt to diagnose and repair SQL statements that fail to meet a performance standard. It is a broad topic and many books have been written as reference. It's important to benchmark and profile to simulate and uncover bottlenecks.
 
 - Benchmark - Simulate high-load situations with tools such as ab.
 - Profile - Enable tools such as the slow query log to help track performance issues.
@@ -9,6 +9,6 @@ Benchmarking and profiling might point you to the following optimizations.
 
 To learn more, visit the following links:
 
-- [@article@Optimizing MySQL Queries](https://aiddroid.com/10-tips-optimizing-mysql-queries-dont-suck/)
+- [@official@Introduction to SQL Tuning - Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/23/tgsql/introduction-to-sql-tuning.html#GUID-B653E5F3-F078-4BBC-9516-B892960046A2)
 - [@article@How we optimized PostgreSQL queries 100x](https://towardsdatascience.com/how-we-optimized-postgresql-queries-100x-ff52555eabe?gi=13caf5bcf32e)
 - [@feed@Explore top posts about SQL](https://app.daily.dev/tags/sql?ref=roadmapsh)


### PR DESCRIPTION
# Motivation

There is an unavailable resource in the System Design roadmap on the topic of SQL Tuning. (See the issue #8078)

# What This PR Does

This PR closes #8078 by replacing the unavailable resource with [Oracle's excellent article](https://docs.oracle.com/en/database/oracle/oracle-database/23/tgsql/introduction-to-sql-tuning.html#GUID-B653E5F3-F078-4BBC-9516-B892960046A2) from their course on SQL Tuning.
This PR also adds an additional sentence that briefly describes SQL Tuning.

