### PR TITLE
fix: updated link - Redis URL Docs

### DIFF
--- a/src/data/projects/weather-api-wrapper-service.md
+++ b/src/data/projects/weather-api-wrapper-service.md
@@ -32,7 +32,7 @@ In this project, instead of relying on our own weather data, we will build a wea
 
 As for the actual weather API to use, you can use your favorite one, as a suggestion, here is a link to [Visual Crossing’s API](https://www.visualcrossing.com/weather-api), it’s completely FREE and easy to use.
 
-Regarding the in-memory cache, a pretty common recommendation is to use [Redis](https://redis.io/), you can read more about it [here](https://redis.io/docs/manual/client-side-caching/), and as a recommendation, you could use the city code entered by the user as the key, and save there the result from calling the API.
+Regarding the in-memory cache, a pretty common recommendation is to use [Redis](https://redis.io/), you can read more about it [here](https://redis.io/docs/latest/develop/clients/client-side-caching/), and as a recommendation, you could use the city code entered by the user as the key, and save there the result from calling the API.
 
 At the same time, when you “set” the value in the cache, you can also give it an expiration time in seconds (using the `EX` flag on the `SET` command). That way the cache (the keys) will automatically clean itself when the data is old enough (for example, giving it a 12-hours expiration time).
 


### PR DESCRIPTION
In the current version, when clicking on:

read more about it **here**, the link sends to a page with a 404 response.

Changes have been made to resolve this error.