### PR TITLE
Fix inappropriate resource types on Git-GitHub Roadmap (Closes #8111)

### DIFF
--- a/src/data/roadmaps/git-github/content/github-wikis@lONqOqD-4slxa9B5i9ADX.md
+++ b/src/data/roadmaps/git-github/content/github-wikis@lONqOqD-4slxa9B5i9ADX.md
@@ -5,4 +5,4 @@ GitHub Wikis are collaborative documentation spaces integrated directly into Git
 Visit the following resources to learn more:
 
 - [@official@About Wikis](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)
-- [@article@Documenting your project with Wikis](https://docs.github.com/en/communities/documenting-your-project-with-wikis)
+- [@official@Documenting your project with Wikis](https://docs.github.com/en/communities/documenting-your-project-with-wikis)

--- a/src/data/roadmaps/git-github/content/workflow-context@BnPiTu1Jw2kIW560a2A5T.md
+++ b/src/data/roadmaps/git-github/content/workflow-context@BnPiTu1Jw2kIW560a2A5T.md
@@ -4,5 +4,5 @@ Workflow context in GitHub Actions refers to the environment and variables that 
 
 Learn more from the following resources:
 
-- [@article@GitHub Actions Contexts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts)
+- [@official@GitHub Actions Contexts](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/contexts)
 - [@video@Working with contexts in GitHub Actions](https://www.youtube.com/watch?v=16WT_r0zjYE)

--- a/src/data/roadmaps/git-github/content/workflow-runners@6QwlY3dEvjfAOPALcWKXQ.md
+++ b/src/data/roadmaps/git-github/content/workflow-runners@6QwlY3dEvjfAOPALcWKXQ.md
@@ -4,5 +4,5 @@ Workflow runners are the environments where GitHub Actions workflows are execute
 
 Learn more from the following resources:
 
+- [@official@GitHub Actions Runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)
 - [@video@GitHub Actions Self-hosted runners](https://www.youtube.com/watch?v=aLHyPZO0Fy0)
-- [@article@GitHub Actions Runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)

--- a/src/data/roadmaps/git-github/content/workflow-triggers@55uHPFNwYPVZx8Cy3c985.md
+++ b/src/data/roadmaps/git-github/content/workflow-triggers@55uHPFNwYPVZx8Cy3c985.md
@@ -4,5 +4,5 @@ Workflow triggers are events that initiate a GitHub Actions workflow. They can b
 
 Learn more from the following resources:
 
-- [@article@GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [@article@GitHub Actions Triggers](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)
+- [@official@GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [@official@GitHub Actions Triggers](https://docs.github.com/en/actions/reference/events-that-trigger-workflows)


### PR DESCRIPTION
# Motivation

A few [GitHub docs](https://docs.github.com/en) are tagged as `article` when they should be `official` as I understand it from [contribution.md](https://github.com/kamranahmedse/developer-roadmap/blob/bcf4126b3a4b3622acc8cfc80b1b1095cf2d11f2/contributing.md), mentioned in #8111.

# What This PR Does

Closes #8111 by fixing the types, specifically changing them from `article` to `official`.