### PR TITLE
Add article resource to Linux roadmap on soft and hard links

### DIFF
--- a/src/data/roadmaps/linux/content/103-working-with-files/103-soft-hard-links.md
+++ b/src/data/roadmaps/linux/content/103-working-with-files/103-soft-hard-links.md
@@ -17,3 +17,7 @@ ln -s source_file.txt soft_link.txt
 ```
 
 Please, understand that `source_file.txt` is the original file and `hard_link.txt` & `soft_link.txt` are the hard and soft links respectively.
+
+Learn more from the following resources:
+
+- [@article@How to understand the difference between hard and symbolic links in Linux](https://labex.io/tutorials/linux-how-to-understand-the-difference-between-hard-and-symbolic-links-in-linux-409929)


### PR DESCRIPTION
# Motivation

There is no resource listed for [Linux roadmap](https://roadmap.sh/linux) on soft and hard links at the moment.

# What This PR Does

This PR adds [an excellent resource from LabEx on soft and hard links](https://labex.io/tutorials/linux-how-to-understand-the-difference-between-hard-and-symbolic-links-in-linux-409929) to the list of resources. 

LabEx has been used as resource on the roadmap a few times now, so this PR adds a level of consistency to the roadmap as well.