### PR TITLE
Fix resource link on Data Analyst roadmap (Closes #8123)

### DIFF
--- a/src/data/roadmaps/data-analyst/content/finding-outliers@-rQ8h_6NFxEOhxXgo7LHo.md
+++ b/src/data/roadmaps/data-analyst/content/finding-outliers@-rQ8h_6NFxEOhxXgo7LHo.md
@@ -4,4 +4,4 @@ In the field of data analysis, data cleaning is an essential and preliminary ste
 
 Visit the following resources to learn more:
 
-- [@article@Outliers]([https://www.mathsisfun.com/data/outliers.html)
+- [@article@Outliers](https://www.mathsisfun.com/data/outliers.html)


### PR DESCRIPTION
# Motivation

A resource link on Data Analyst roadmap is invalid due to broken URL, mentioned in #8123.

# What This PR Does

This PR closes #8123 by fixing the broken resource link (removing the unnecessary "`[`" at the beginning on the link).