### PR TITLE
Fixed some typos on redis rodemap

### DIFF
--- a/src/data/roadmaps/redis/content/atomicity-in-redis@jrgaoDnt_RxTu79hk4hCD.md
+++ b/src/data/roadmaps/redis/content/atomicity-in-redis@jrgaoDnt_RxTu79hk4hCD.md
@@ -5,4 +5,4 @@ Atomicity in Redis refers to the property that ensures a set of operations is ex
 Learn more from the following resources:
 
 - [@official@Atomicity with Lua](https://redis.io/learn/develop/java/spring/rate-limiting/fixed-window/reactive-lua)
--[@article@Atomicity in Redis operations](https://lucaspin.medium.com/atomicity-in-redis-operations-a1d7bc9f4a90)
+- [@article@Atomicity in Redis operations](https://lucaspin.medium.com/atomicity-in-redis-operations-a1d7bc9f4a90)

--- a/src/data/roadmaps/redis/content/rpop@brUGqWZ287EWtvl9uUbNt.md
+++ b/src/data/roadmaps/redis/content/rpop@brUGqWZ287EWtvl9uUbNt.md
@@ -4,4 +4,4 @@ The RPOP command removes and then returns the last elements of the list stored a
 
 Learn more from the following resources:
 
-- [@official@RPOP Documentation](https://redis.io/docs/latest/commands/rpush/)
+- [@official@RPOP Documentation](https://redis.io/docs/latest/commands/rpop/)


### PR DESCRIPTION
1. Fixed a link pointing to a wrong address
2. Fixed typo causing links to display improperly
![image](https://github.com/user-attachments/assets/8192c938-83e7-44e9-90a4-4d46f054f543)
