### PR TITLE
Update named-arguments@RkNjYva8o_jXp9suz5YdG.md

### DIFF
--- a/src/data/roadmaps/php/content/named-arguments@RkNjYva8o_jXp9suz5YdG.md
+++ b/src/data/roadmaps/php/content/named-arguments@RkNjYva8o_jXp9suz5YdG.md
@@ -4,10 +4,10 @@ Named arguments in PHP, introduced with PHP 8.0, allow you to specify the values
 
 ```php
 <?php
-$a = array_fill(start_index: 0, num: 100, value: 50);
+$a = array_fill(start_index: 0, count: 100, value: 50);
 ```
 
-In this code snippet, the parameters are passed by their names ('start_index', 'num', 'value'), not by their order in the function definition.
+In this code snippet, the parameters are passed by their names ('start_index', 'count', 'value'), not by their order in the function definition.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Fix: Use correct parameter name "count" instead of "num" in array_fill()

Updated the array_fill() function to use "count" as the second parameter, aligning with the official PHP documentation.