### PR TITLE
Adding 2 videos links to Aws Roadmap - Lambda-Creating and Lambda-Layers subtopics

### DIFF
--- a/src/data/roadmaps/aws/content/116-lambda/100-creating-invoking.md
+++ b/src/data/roadmaps/aws/content/116-lambda/100-creating-invoking.md
@@ -5,3 +5,4 @@ To create a Lambda function in AWS, navigate to the AWS Management Console, sele
 Visit the following resources to learn more:
 
 - [@official@Create Your First Lambda Function](https://docs.aws.amazon.com/lambda/latest/dg/getting-started.html)
+- [@video@First AWS Lambda Function](https://www.youtube.com/watch?v=e1tkFsFOBHA)

--- a/src/data/roadmaps/aws/content/116-lambda/101-layers.md
+++ b/src/data/roadmaps/aws/content/116-lambda/101-layers.md
@@ -5,3 +5,4 @@ AWS Lambda layers are distribution mechanisms for libraries, custom runtimes, an
 Visit the following resources to learn more:
 
 - [@official@AWS Lambda Layers](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html)
+- [@video@Create and Use Lambda Layers](https://www.youtube.com/watch?v=jyuZDkiHe2Q)


### PR DESCRIPTION
First commit is adding a link to an updated video from Tiny Technical Tutorials which overview the lambda and show how to create an practical example.

Second commit is adding a link to a Vincent Stevenson video explaining and creating an layer to a python script.

I think both videos are great to see a practical example and understand the basic of each topic.
