### PR TITLE
Replace unavailable resource link on PHP roadmap (Closes #8149)

### DIFF
--- a/src/data/roadmaps/php/content/null-safe-operator@1NXSk8VZDr89jQTTkOL7x.md
+++ b/src/data/roadmaps/php/content/null-safe-operator@1NXSk8VZDr89jQTTkOL7x.md
@@ -4,4 +4,5 @@ The Null Safe Operator is a handy feature in PHP which deals with an issue that 
 
 Visit the following resources to learn more:
 
-- [@official@Null Safe Operator](https://www.php.net/manual/en/language.oop5.nullsafe.php)
+- [@official@The Basics - Manual](https://www.php.net/manual/en/language.oop5.basic.php)
+- [@official@PHP RFC: Nullsafe operator](https://wiki.php.net/rfc/nullsafe_operator)


### PR DESCRIPTION
# Motivation

There is [an unavailable resource link which currently returns `404`](https://www.php.net/manual/en/language.oop5.nullsafe.php) on [PHP roadmap](https://roadmap.sh/php), as mentioned in #8149 

# What This PR Does

This PR closes #8149 by removing the unavailable link and adding two official resources for the topic `Nullsafe Operator`:
- [PHP The Basics - Manual](https://www.php.net/manual/en/language.oop5.basic.php): there is a section for `Nullsafe Operator`. I assume the the official doc was moved here.
- [PHP RFC: Nullsafe operator](https://wiki.php.net/rfc/nullsafe_operator): PHP RFCs (Request for Comments) proposal for `Nullsafe Operator`, which explains the reasoning, design decisions, and implementation details.