### PR TITLE
fix inaccuracy in Git and GitHub roadmap topic content

### DIFF
--- a/src/data/roadmaps/git-github/content/unstaged-changes@uxqJzQFRcALqatNRIWR0w.md
+++ b/src/data/roadmaps/git-github/content/unstaged-changes@uxqJzQFRcALqatNRIWR0w.md
@@ -1,6 +1,8 @@
 # Unstaged Changes
 
-For changes that are not yet staged with `git add`, such as untracked new files or modified existing ones, use `git diff --unified`. This command compares your working directory against the latest committed version of each file. It's a useful tool for reviewing any local modifications before deciding whether to stage them for future commits.
+For changes that are not yet staged with `git add`, such as untracked new files or modified existing ones , use `git diff`. This command compares your working directory (your current changes) against the staging area (changes already staged with `git add`). It’s a useful tool for reviewing local modifications before deciding whether to stage them for future commits.
+
+The `--unified` option (or -U) controls the number of context lines shown in the diff output. By default, Git shows 3 lines of context around each change. For example, `git diff --unified=5` will display 5 lines of context around each change, making it easier to understand the surrounding code or content.
 
 - [@article@What are unstaged changes in GitHub?](https://stackoverflow.com/questions/10954329/whats-the-unstaged-changes-in-github)
 - [@article@How to unstage files in Git](https://www.git-tower.com/learn/git/faq/git-unstage)


### PR DESCRIPTION
The topic (unstaged changes) content in Git and GitHub roadmap incorrectly described the behavior of `git diff` and the purpose of the `--unified` option. This commit fixes the definition to accurately reflect how `git diff` works and the role of `--unified`.

Changes:
- Clarify that `git diff` compares the working directory against the staging area for unstaged changes, not directly against the latest commit.
- Explain that `--unified` controls the number of context lines shown in the diff output, rather than being a mode for comparing unstaged changes.
- Add examples to illustrate the correct usage of `git diff` and `--unified`.

This update ensures users have a clear and accurate understanding of how to review changes and customize diff output.