### PR TITLE
Make the code example `c++20` compliant

### DIFF
--- a/src/data/roadmaps/cpp/content/112-idioms/106-copy-write.md
+++ b/src/data/roadmaps/cpp/content/112-idioms/106-copy-write.md
@@ -20,7 +20,7 @@ public:
     // Make a copy only if we want to modify the data.
     void write(const std::string &str) {
         // Check if there's more than one reference.
-        if(!data.unique()) {
+        if(data.use_count() > 1) {
             data = std::make_shared<std::string>(*data);
             std::cout << "Copy is actually made for writing." << std::endl;
         }


### PR DESCRIPTION
[`std::shared_ptr<T>::unique`](https://en.cppreference.com/w/cpp/memory/shared_ptr/unique) was removed in `c++20`. This PR updates the provided code example to use [`std::shared_ptr<T>::use_count`](https://en.cppreference.com/w/cpp/memory/shared_ptr/use_count).

Side remark: the original example still compiles fine in g++ and clang++, but fails in the newest MSVC.
