### PR TITLE
Use consistent formatting

### DIFF
--- a/src/data/roadmaps/cpp/content/100-introduction/101-why-cpp.md
+++ b/src/data/roadmaps/cpp/content/100-introduction/101-why-cpp.md
@@ -42,7 +42,7 @@ int main() {
 
     // High-level programming
     std::vector<int> myVector = {1, 2, 3};
-    for(const auto &i: myVector) {
+    for (const auto &i: myVector) {
         std::cout << i << std::endl;
     }
 }

--- a/src/data/roadmaps/cpp/content/105-pointers-and-references/smart-pointers/100-weak-ptr.md
+++ b/src/data/roadmaps/cpp/content/105-pointers-and-references/smart-pointers/100-weak-ptr.md
@@ -26,7 +26,7 @@ int main() {
         std::shared_ptr<MyClass> shared = std::make_shared<MyClass>();
         weak = shared;
 
-        if(auto sharedFromWeak = weak.lock()) {
+        if (auto sharedFromWeak = weak.lock()) {
             sharedFromWeak->DoSomething(); // Safely use the object
             std::cout << "Shared uses count: " << sharedFromWeak.use_count() << '\n'; // 2
         }
@@ -34,7 +34,7 @@ int main() {
 
     // shared goes out of scope and the MyClass object is destroyed
 
-    if(auto sharedFromWeak = weak.lock()) {
+    if (auto sharedFromWeak = weak.lock()) {
         // This block will not be executed because the object is destroyed
     }
     else {

--- a/src/data/roadmaps/cpp/content/110-stl/index.md
+++ b/src/data/roadmaps/cpp/content/110-stl/index.md
@@ -77,7 +77,7 @@ For example, to iterate through a vector and print its elements, you can use the
 
 ```cpp
 std::vector<int> my_vec = {1, 2, 3, 4, 5};
-for(auto it = my_vec.begin(); it != my_vec.end(); ++it) {
+for (auto it = my_vec.begin(); it != my_vec.end(); ++it) {
     std::cout << *it << " ";
 }
 ```

--- a/src/data/roadmaps/cpp/content/112-idioms/106-copy-write.md
+++ b/src/data/roadmaps/cpp/content/112-idioms/106-copy-write.md
@@ -20,7 +20,7 @@ public:
     // Make a copy only if we want to modify the data.
     void write(const std::string &str) {
         // Check if there's more than one reference.
-        if(data.use_count() > 1) {
+        if (data.use_count() > 1) {
             data = std::make_shared<std::string>(*data);
             std::cout << "Copy is actually made for writing." << std::endl;
         }

--- a/src/data/roadmaps/cpp/content/113-standards/101-cpp17.md
+++ b/src/data/roadmaps/cpp/content/113-standards/101-cpp17.md
@@ -5,7 +5,7 @@ C++17, also known as C++1z, is the version of the C++ programming language publi
 ## Key Features:
 - If-init-statement: Introduces a new syntax for writing conditions with scope inside if and switch statements.
 ```cpp
-if(auto it = map.find(key); it != map.end())
+if (auto it = map.find(key); it != map.end())
 {
     // Use it
 }

--- a/src/data/roadmaps/cpp/content/libraries/101-open-cv.md
+++ b/src/data/roadmaps/cpp/content/libraries/101-open-cv.md
@@ -19,7 +19,7 @@ Here's a simple example using OpenCV in C++ to read and display an image:
 #include <iostream>
 
 int main(int argc, char** argv) {
-    if(argc != 2) {
+    if (argc != 2) {
         std::cout << "Usage: display_image ImageToLoadAndDisplay" << std::endl;
         return -1;
     }
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     cv::Mat image;
     image = cv::imread(argv[1], cv::IMREAD_COLOR);
 
-    if(!image.data) {
+    if (!image.data) {
         std::cout << "Could not open or find the image" << std::endl;
         return -1;
     }

--- a/src/data/roadmaps/cpp/content/libraries/108-opencl.md
+++ b/src/data/roadmaps/cpp/content/libraries/108-opencl.md
@@ -23,14 +23,14 @@ Here is a simple OpenCL code example that illustrates how to implement vector ad
 #include <iostream>
 #include <vector>
 
-const char *kernelSource = "__kernel void vector_add(__global int *A, __global int *B, __global int *C, const int N){"
+const char *kernelSource = "__kernel void vector_add(__global int *A, __global int *B, __global int *C, const int N) {"
                             "  int i = get_global_id(0);"
-                            "  if (i < N){"
+                            "  if (i < N) {"
                             "    C[i] = A[i] + B[i];"
                             "  }"
                             "}";
 
-int main(){
+int main() {
     // Initialize data vectors
     std::vector<int> A = {1, 2, 3};
     std::vector<int> B = {4, 5, 6};

--- a/src/data/roadmaps/cpp/content/libraries/108-opencl.md
+++ b/src/data/roadmaps/cpp/content/libraries/108-opencl.md
@@ -25,7 +25,7 @@ Here is a simple OpenCL code example that illustrates how to implement vector ad
 
 const char *kernelSource = "__kernel void vector_add(__global int *A, __global int *B, __global int *C, const int N){"
                             "  int i = get_global_id(0);"
-                            "  if(i < N){"
+                            "  if (i < N){"
                             "    C[i] = A[i] + B[i];"
                             "  }"
                             "}";


### PR DESCRIPTION
This PR essentially adds the missing space after the keywords like `if` and `for`. This makes the C++ code examples more consistent.

It turned out that all the examples are properly formatted around `while` and `switch`.