### PR TITLE
typo in docker roadmap : (act to acr)

### DIFF
--- a/src/data/roadmaps/docker/docker.json
+++ b/src/data/roadmaps/docker/docker.json
@@ -2496,7 +2496,7 @@
                   "y": "10",
                   "properties": {
                     "size": "17",
-                    "text": "Others (ghcr, ecr, gcr, act, etc)"
+                    "text": "Others (ghcr, ecr, gcr, acr, etc)"
                   }
                 }
               ]


### PR DESCRIPTION
There was a typo in docker roadmap,
(ghcr, ecr, gcr, act, etc) in this act was out of context and **acr** was correct 
as **acr = Azure Container Registry** which matches the context

![Screenshot 2025-02-10 015004](https://github.com/user-attachments/assets/639f10fd-8787-454a-b00d-4faef84ef343)
 