### PR TITLE
Swap out a 404ing link from Backend Architectural patterns with its new location

### DIFF
--- a/src/data/roadmaps/backend/content/architectural-patterns@tHiUpG9LN35E5RaHddMv5.md
+++ b/src/data/roadmaps/backend/content/architectural-patterns@tHiUpG9LN35E5RaHddMv5.md
@@ -5,4 +5,3 @@ An architectural pattern is a general, reusable solution to a commonly occurring
 Visit the following resources to learn more:
 
 - [@article@14 Architectural Patterns to know](https://www.redhat.com/architect/14-software-architecture-patterns)
-- [@article@Architectural Patterns in a nutshell](https://towardsdatascience.com/10-common-software-architectural-patterns-in-a-nutshell-a0b47a1e9013)

--- a/src/data/roadmaps/backend/content/architectural-patterns@tHiUpG9LN35E5RaHddMv5.md
+++ b/src/data/roadmaps/backend/content/architectural-patterns@tHiUpG9LN35E5RaHddMv5.md
@@ -5,3 +5,4 @@ An architectural pattern is a general, reusable solution to a commonly occurring
 Visit the following resources to learn more:
 
 - [@article@14 Architectural Patterns to know](https://www.redhat.com/architect/14-software-architecture-patterns)
+- [@article@10 Common Software Architectural Patterns in a nutshell](https://theiotacademy.medium.com/10-common-software-architectural-patterns-in-a-nutshell-1b1f6cf5036b)


### PR DESCRIPTION
This article is 404ing so I've replaced with the links new location on Medium