### PR TITLE
Cloudflare Roadmap - ANy Frontend Framework + Wrangler 

### DIFF
--- a/src/data/roadmaps/cloudflare/content/any-frontend-framework@zSwio18XdBfqwSneAx_AP.md
+++ b/src/data/roadmaps/cloudflare/content/any-frontend-framework@zSwio18XdBfqwSneAx_AP.md
@@ -1,1 +1,21 @@
 # Any Frontend Framework
+
+When building frontend applications using Cloudflare Pages there are a few things kept in mind. Cloudflare Pages are mostly built on client-server architecture or a full-stack application. Those applications can be known as using React to create a frontend that dynamically interacts with the API without full-page reloads.
+
+## Known Frameworks
+There are a lot of frameworks which support this type of frontend handling. If you already know a framework feel free to check out if it supports the Cloudflare pages, also known as edge runtime. 
+
+Frontend frameworks that are well known:
+- Next.js ([Cloudflare-next-on-pages](https://github.com/cloudflare/next-on-pages))
+- Astro ([astrojs/cloudflare](https://docs.astro.build/en/guides/integrations-guide/cloudflare/))
+- Remix ([remix-run/cloudflare](https://remix.run/resources/remix-worker-template))
+- [Nuxt 3](https://developers.cloudflare.com/workers/frameworks/framework-guides/nuxt/) (Experimental Cloudflare Support)
+
+## Static HTML
+Although you can use a framework to be at ease with some factors you can also use static HTML websites. If you manage your website without using a framework or static site generator, or if your framework is not listed in Framework guides, you can still deploy it using this guide. 
+
+Visit the following resources to learn more:
+
+- [@official@Cloudflare docs - Framework guides](https://developers.cloudflare.com/pages/framework-guides/)
+- [@official@Cloudflare docs - Static HTML](https://developers.cloudflare.com/pages/framework-guides/deploy-anything/)
+- [@video@Build a Full-Stack API with Cloudflare Pages Functions](https://www.youtube.com/watch?v=3zTJL3M57rE)

--- a/src/data/roadmaps/cloudflare/content/wrangler@Tzx93tvoGrc9_fKQqkorN.md
+++ b/src/data/roadmaps/cloudflare/content/wrangler@Tzx93tvoGrc9_fKQqkorN.md
@@ -1,1 +1,51 @@
 # Wrangler
+
+Cloudflare Wrangler is a command-line tool (CLI) designed to help developers manage and deploy Cloudflare Workers, which are serverless functions that run at the edge of Cloudflare's network. It also manages Cloudflare services like KV Storage, Durable Objects, and R2.
+
+It is made for developers to deploy their applications more easily towards the Cloudflare network so that you don't need to use their UI.
+
+## Configuration
+Wrangler optionally uses a configuration file to customize the development and deployment setup for a Worker. Make sure to not commit keys and/or information about wrangler. if required use the secret variables to deploy an application and/or a dot env file. a wrangler file is written in JSON or a TOML file. JSON is released since v3.91 so any versions before that should contain a wrangler.toml file.
+
+An example JSON file can be found below
+```json
+{
+  "name": "my-worker",
+  "main": "src/index.js",
+  "compatibility_date": "2022-07-12",
+  "workers_dev": false,
+  "route": {
+    "pattern": "example.org/*",
+    "zone_name": "example.org"
+  },
+  "kv_namespaces": [
+    {
+      "binding": "<MY_NAMESPACE>",
+      "id": "<KV_ID>"
+    }
+  ],
+  "env": {
+    "staging": {
+      "name": "my-worker-staging",
+      "route": {
+        "pattern": "staging.example.org/*",
+        "zone_name": "example.org"
+      },
+      "kv_namespaces": [
+        {
+          "binding": "<MY_NAMESPACE>",
+          "id": "<STAGING_KV_ID>"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Commands
+Wrangler is a CLI tool that has a lot of commands to create, update or delete functions in the Cloudflare Network API. Most likely when having a configuration file you will need to 
+
+Visit the following resources to learn more:
+- [@official@Cloudflare - Wrangler Documentation](https://developers.cloudflare.com/workers/wrangler/)
+- [@official@Cloudflare - Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/commands/)
+- [@video@Deploy your React App to Cloudflare Workers](https://www.youtube.com/watch?v=B2bLUc3iOsI)


### PR DESCRIPTION
Since I have been more advanced for 2 years with Cloudflare works I thought I shared how I've learned the documentation. I will update this in the coming days.

So far the following things have been added;
- Added official documentation link to Wrangler
- Added official documentation link to Any frontend Application
- Added videos to the Wrangler
- Added an example config for the wrangler file
- Added common frameworks and their respective links for the items.
- Added an option to use static HTML inside the frontend framework. 
  - To always keep the developer know 'simple is also possible"
