### PR TITLE
Fix: Update Broken Link in Joints Section 

### DIFF
--- a/src/data/roadmaps/game-developer/content/joints@m2_wUW2VHMCXHnn5B91qr.md
+++ b/src/data/roadmaps/game-developer/content/joints@m2_wUW2VHMCXHnn5B91qr.md
@@ -4,5 +4,6 @@ Joints in game development primarily refer to the connections between two object
 
 Visit the following resources to learn more:
 
-- [@article@Game Character Rigging Fundamentals](https://learn.unity.com/project/game-character-rigging-fundamentals)
+- [@official@Introduction to joints](https://docs.unity3d.com/Manual/Joints.html)
+- [@article@Character Rigging for Video Games](https://game-ace.com/blog/character-rigging-for-video-games/)
 - [@article@Joints in Unity](https://simonpham.medium.com/joints-in-unity-f9b602212524)


### PR DESCRIPTION
Update Broken Link in Joints Section

The Game Character Rigging Fundamentals link led to unavailable page.  

Changes:  
- Replaced the broken link with accessible resource on game character rigging.  
- Added a new link pointing to the official Unity documentation for accurate information.  

Related Issue: #8232