### PR TITLE
Update description of Godot game engine in game dev roadmap

### DIFF
--- a/src/data/roadmaps/game-developer/content/godot@7OffO2mBmfBKqPBTZ9ngI.md
+++ b/src/data/roadmaps/game-developer/content/godot@7OffO2mBmfBKqPBTZ9ngI.md
@@ -1,6 +1,6 @@
 # Godot
 
-Godot is an open-source, multi-platform game engine that is known for being feature-rich and user-friendly. It is developed by hundreds of contributors from around the world and supports the creation of both 2D and 3D games. Godot uses its own scripting language, GDScript, which is similar to Python, but it also supports C# and visual scripting. It is equipped with a unique scene system and comes with a multitude of tools that can expedite the development process. Godot's design philosophy centers around flexibility, extensibility, and ease of use, providing a handy tool for both beginners and pros in game development.
+Godot is an open-source, multi-platform game engine that is known for being feature-rich and user-friendly. It is developed by hundreds of contributors from around the world and supports the creation of both 2D and 3D games. Godot uses its own scripting language, GDScript, which is similar to Python, but it also supports C#. It is equipped with a unique scene system and comes with a multitude of tools that can expedite the development process. Godot's design philosophy centers around flexibility, extensibility, and ease of use, providing a handy tool for both beginners and pros in game development.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
The **visual scripting** is no longer available in the latest version of Godot Engine. Therefore, it is removed from the description.