### PR TITLE
[API Design Roadmap] Replacing HTTP cookies article about  JS API with more relevant one

### DIFF
--- a/src/data/roadmaps/api-design/content/cookies@UFuX8wcxZQ7dvaQF_2Yp8.md
+++ b/src/data/roadmaps/api-design/content/cookies@UFuX8wcxZQ7dvaQF_2Yp8.md
@@ -5,4 +5,4 @@ Cookies play an instrumental role in the field of API (Application Programming I
 Learn more from the following resources:
 
 - [@article@What Are API Cookies? How to Send it?](https://apidog.com/articles/what-are-api-cookies/)
-- [@article@Cookies - Mozilla](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies)
+- [@article@Using HTTP cookies - Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies)


### PR DESCRIPTION
The Cookies step is under the HTTP group and I'm expecting to find high-level articles there about different aspects of HTTP and not about JS API. Hence the link is replaced with a more relevant article from the same source.