### PR TITLE
Fixed a bad link about typed forms in Angular Roadmap

### DIFF
--- a/src/data/roadmaps/angular/content/typed-forms@XC_K1Wahl2ySqOXoym4YU.md
+++ b/src/data/roadmaps/angular/content/typed-forms@XC_K1Wahl2ySqOXoym4YU.md
@@ -4,7 +4,7 @@ Since Angular 14, reactive forms are strictly typed by default. You don't have t
 
 Visit the following resources to learn more:
 
-- [@official@Angular Official Docs - @let](https://angular.dev/api/core/@let)
+- [@official@Angular Official Docs - Typed Forms](https://angular.dev/guide/forms/typed-forms)
 - [@article@Angular Strictly Typed Forms (Complete Guide)](https://blog.angular-university.io/angular-typed-forms/)
 - [@video@Getting started with typed reactive forms in Angular](https://www.youtube.com/watch?v=mT3UR0TdDnU)
 - [@video@Angular TYPED Forms: Are You Using Them Correctly?](https://www.youtube.com/watch?v=it2BZoIvBPc)


### PR DESCRIPTION
The @let link was included inside the typed-forms part of angular, where typef-forms docs of angular was missing