### PR TITLE
fix: correct AWS service name from VPN to VPC

### DIFF
--- a/src/data/roadmaps/full-stack/content/basic-aws-services@cUOfvOlQ_0Uu1VX3i67kJ.md
+++ b/src/data/roadmaps/full-stack/content/basic-aws-services@cUOfvOlQ_0Uu1VX3i67kJ.md
@@ -1,6 +1,6 @@
 # Basic AWS Services
 
-AWS has several services but you don't need to know all of them. Some common ones that you can start with are EC2, VPN, S3, Route 53, and SES.
+AWS has several services but you don't need to know all of them. Some common ones that you can start with are EC2, VPC, S3, Route 53, and SES.
 
 Here are some of the resources to get you started:
 


### PR DESCRIPTION
**Summary**:
Changed VPN to VPC (Virtual Private Cloud) in AWS services list as VPC is the correct AWS service being referenced in src/data/roadmaps/full-stack/content/basic-aws-services@cUOfvOlQ_0Uu1VX3i67kJ.md.

**Fixes**: #8354