### PR TITLE
Replace broken resource URL with a better FreeCodeCamp article

### DIFF
--- a/src/data/roadmaps/php/content/object-relational-mapping-orm@SeqGIfcLuveZ2z5ZSXcOd.md
+++ b/src/data/roadmaps/php/content/object-relational-mapping-orm@SeqGIfcLuveZ2z5ZSXcOd.md
@@ -11,4 +11,4 @@ $entityManager->flush();
 
 Visit the following resources to learn more:
 
-- [@article@Object Relational Mapping (ORM)](https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/tutorials/getting-started.html)
+- [@article@What is an Object Relational Mapping (ORM)](https://www.freecodecamp.org/news/what-is-an-orm-the-meaning-of-object-relational-mapping-database-tools)

--- a/src/data/roadmaps/php/content/object-relational-mapping-orm@SeqGIfcLuveZ2z5ZSXcOd.md
+++ b/src/data/roadmaps/php/content/object-relational-mapping-orm@SeqGIfcLuveZ2z5ZSXcOd.md
@@ -11,4 +11,4 @@ $entityManager->flush();
 
 Visit the following resources to learn more:
 
-- [@article@What is an Object Relational Mapping (ORM)](https://www.freecodecamp.org/news/what-is-an-orm-the-meaning-of-object-relational-mapping-database-tools)
+- [@article@What is an Object Relational Mapping (ORM)](https://stackoverflow.com/questions/1279613/what-is-an-orm-how-does-it-work-and-how-should-i-use-one#answer-1279678)


### PR DESCRIPTION
Replace broken resource URL with a better FreeCodeCamp article  

The previous resource URL was not found, so I replaced it with a more relevant article from FreeCodeCamp:   https://www.freecodecamp.org/news/what-is-an-orm-the-meaning-of-object-relational-mapping-database-tools