### PR TITLE
Fix broken link to the article on common algorithms.

### DIFF
--- a/src/data/roadmaps/computer-science/content/common-algorithms@7a6-AnBI-3tAU1dkOvPkx.md
+++ b/src/data/roadmaps/computer-science/content/common-algorithms@7a6-AnBI-3tAU1dkOvPkx.md
@@ -16,4 +16,4 @@ Here are some common algorithms that you should know. You can find more informat
 
 Visit the following resources to learn more:
 
-- [@article@Top Algorithms and Data Structures](https://towardsdatascience.com/top-algorithms-and-data-structures-you-really-need-to-know-ab9a2a91c7b5)
+- [@article@Top Algorithms and Data Structures](https://medium.com/data-science/top-algorithms-and-data-structures-you-really-need-to-know-ab9a2a91c7b5)


### PR DESCRIPTION
### Summary  
The existing link to the article on common algorithms is broken. I found what seems to be the correct link, as it has the same slug and appears to match the intended content.  

### Changes  
- Replaced the broken link with the new one.  

### Why this is needed  
- The previous link led to a 404 page.  
- The new link is likely correct based on its structure, but please review to confirm.  

### Additional Context  
- If this is not the correct article, let me know, and I can update it accordingly.  