### PR TITLE
Update broken URL

### DIFF
--- a/src/data/roadmaps/java/content/exception-handling@g9P3548F38tYGjevBc42w.md
+++ b/src/data/roadmaps/java/content/exception-handling@g9P3548F38tYGjevBc42w.md
@@ -11,4 +11,4 @@ There are three types of exceptions -
 Visit the following resources to learn more:
 
 - [@video@Understanding Java Exceptions](https://www.youtube.com/watch?v=W-N2ltgU-X4)
-- [@article@Exception Handling in Java](https://www.javatpoint.com/exception-handling-in-java)
+- [@article@Exception Handling in Java](https://www.tpointtech.com/exception-handling-in-java)


### PR DESCRIPTION
- The previous URL for the article "Exception Handling in Java" in the Java Developer Roadmap was not working. 
- Replaced it with a working URL.