### PR TITLE
`std` is not an abbreviation for STL

### DIFF
--- a/src/data/roadmaps/cpp/content/running-your-first-program@SEq0D2Zg5WTsIDtd1hW9f.md
+++ b/src/data/roadmaps/cpp/content/running-your-first-program@SEq0D2Zg5WTsIDtd1hW9f.md
@@ -42,7 +42,7 @@ To output text to the console, we use the `std::cout` object and the insertion o
 ```cpp
 std::cout << "Hello, World!" << '\n';
 ```
-- `std`: This is the namespace where C++ standard library entities (classes and functions) reside. It stands for "standard" and is an abbreviation for the Standard Template Library (STL).
+- `std`: This is the namespace where C++ standard library entities (classes and functions) reside. It stands for "standard"
 - `std::cout`: The standard "character output" stream that writes to the console
 - `"Hello, World!"`: The string literal to print
 - `'\n'`: The "end line" manipulator that inserts a newline character and flushes the output buffer


### PR DESCRIPTION
Same as:
- #8252

@kamranahmedse please have a look.