### PR TITLE
Update missing content in the `Server-Side Game Developer` Roadmap.

### DIFF
--- a/src/data/roadmaps/server-side-game-developer/content/epoll@qaWv4gxnnj3uX8lEm9KQ4.md
+++ b/src/data/roadmaps/server-side-game-developer/content/epoll@qaWv4gxnnj3uX8lEm9KQ4.md
@@ -3,7 +3,7 @@
 **epoll** is a high-performance I/O event notification system in Linux, essential for handling 
 large-scale asynchronous network operations in server-side game development. Unlike `select` 
 or `poll`, it uses an event-driven model, reducing CPU overhead and improving scalability. 
-Game servers leverage epoll to efficiently manage thousands of concurrent connections, 
+Game servers leverage `epoll` to efficiently manage thousands of concurrent connections, 
 responding only when events occur, minimizing system calls, and optimizing resource 
 usage—making it ideal for multiplayer games and real-time applications.
 

--- a/src/data/roadmaps/server-side-game-developer/content/epoll@qaWv4gxnnj3uX8lEm9KQ4.md
+++ b/src/data/roadmaps/server-side-game-developer/content/epoll@qaWv4gxnnj3uX8lEm9KQ4.md
@@ -1,0 +1,14 @@
+# epoll  
+
+**epoll** is a high-performance I/O event notification system in Linux, essential for handling 
+large-scale asynchronous network operations in server-side game development. Unlike `select` 
+or `poll`, it uses an event-driven model, reducing CPU overhead and improving scalability. 
+Game servers leverage epoll to efficiently manage thousands of concurrent connections, 
+responding only when events occur, minimizing system calls, and optimizing resource 
+usage—making it ideal for multiplayer games and real-time applications.
+
+Visit the following resources to learn more:
+
+- [@documentation@Linux epoll API](https://man7.org/linux/man-pages/man7/epoll.7.html)  
+- [@article@Understanding epoll for Scalable Network Servers](https://medium.com/@copyconstruct/the-method-to-epolls-madness-d9d2d6378642)
+- [@article@epoll vs select vs poll](https://devarea.com/linux-io-multiplexing-select-vs-poll-vs-epoll/)

--- a/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
+++ b/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
@@ -1,4 +1,4 @@
-# io_uring**  
+# io_uring
 
 **io_uring** is a modern asynchronous I/O framework introduced in Linux 5.1, designed to 
 provide high-performance, low-latency I/O operations. It is widely used in server-side game 

--- a/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
+++ b/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
@@ -1,0 +1,13 @@
+# io_uring**  
+
+**io_uring** is a modern asynchronous I/O framework introduced in Linux 5.1, designed to 
+provide high-performance, low-latency I/O operations. It is widely used in server-side game 
+development to efficiently handle network and disk operations, making it ideal for real-time 
+multiplayer games. Unlike `epoll` or traditional polling mechanisms, `io_uring` minimizes 
+system calls by using a shared memory ring buffer between the kernel and user space, reducing 
+context switching overhead. This results in improved scalability and responsiveness, allowing 
+game servers to handle thousands of concurrent connections with minimal CPU usage.  
+
+Resources:  
+- [@documentation@Linux io_uring_enter](https://man7.org/linux/man-pages/man2/io_uring_enter.2.html)
+- [@article@Efficient Networking with io_uring](https://lwn.net/Articles/776703/)

--- a/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
+++ b/src/data/roadmaps/server-side-game-developer/content/io_uring@YH7u1FKh85wz78J0stuzS.md
@@ -8,6 +8,7 @@ system calls by using a shared memory ring buffer between the kernel and user sp
 context switching overhead. This results in improved scalability and responsiveness, allowing 
 game servers to handle thousands of concurrent connections with minimal CPU usage.  
 
-Resources:  
+Visit the following resources to learn more:
+
 - [@documentation@Linux io_uring_enter](https://man7.org/linux/man-pages/man2/io_uring_enter.2.html)
 - [@article@Efficient Networking with io_uring](https://lwn.net/Articles/776703/)

--- a/src/data/roadmaps/server-side-game-developer/content/iocp@7pgdOZomhGilBTwfJLMbm.md
+++ b/src/data/roadmaps/server-side-game-developer/content/iocp@7pgdOZomhGilBTwfJLMbm.md
@@ -1,0 +1,13 @@
+# IOCP (I/O Completion Ports)  
+
+**I/O Completion Ports (IOCP)** is a high-performance asynchronous I/O mechanism in Windows, 
+designed to efficiently handle large numbers of concurrent network connections. It is widely 
+used in server-side game development to optimize networking performance, making it ideal for 
+MMORPGs and real-time multiplayer games. Unlike `select` or `WSA-Poll`, IOCP uses a thread 
+pool and a queue-based event system to process completed I/O operations asynchronously, 
+minimizing CPU overhead and improving scalability. By leveraging IOCP, game servers can 
+efficiently handle thousands of connections with minimal latency, making it the preferred 
+choice for high-performance Windows-based game networking.  
+
+Resources:  
+- [@documentation@Microsoft IOCP Documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports)  

--- a/src/data/roadmaps/server-side-game-developer/content/iocp@7pgdOZomhGilBTwfJLMbm.md
+++ b/src/data/roadmaps/server-side-game-developer/content/iocp@7pgdOZomhGilBTwfJLMbm.md
@@ -9,5 +9,6 @@ minimizing CPU overhead and improving scalability. By leveraging IOCP, game serv
 efficiently handle thousands of connections with minimal latency, making it the preferred 
 choice for high-performance Windows-based game networking.  
 
-Resources:  
+Visit the following resources to learn more:
+
 - [@documentation@Microsoft IOCP Documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports)  

--- a/src/data/roadmaps/server-side-game-developer/content/kqueue@caK32NMMrn-3BGAXZoPPr.md
+++ b/src/data/roadmaps/server-side-game-developer/content/kqueue@caK32NMMrn-3BGAXZoPPr.md
@@ -1,0 +1,14 @@
+# kqueue  
+
+**kqueue** is an efficient event notification system available on BSD-based operating systems, 
+including macOS and FreeBSD. It is designed to handle large numbers of concurrent connections 
+with minimal CPU overhead, making it well-suited for server-side game development. Similar 
+to `epoll` on Linux, `kqueue` operates in an event-driven manner, allowing game servers to 
+efficiently manage network events, timers, and file system changes. By reducing unnecessary 
+polling and system calls, `kqueue` helps improve the scalability and responsiveness of 
+multiplayer game servers, ensuring low-latency interactions and optimized resource usage.  
+
+Visit the following resources to learn more:
+
+- [@documentation@FreeBSD kqueue Documentation](https://man.freebsd.org/cgi/man.cgi?query=kqueue)  
+- [@documentation@macOS kqueue API Reference](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/kqueue.2.html)

--- a/src/data/roadmaps/server-side-game-developer/content/registered-io@94hJX1iGifDzIuaU3zU5j.md
+++ b/src/data/roadmaps/server-side-game-developer/content/registered-io@94hJX1iGifDzIuaU3zU5j.md
@@ -12,4 +12,4 @@ and lower latency.
 
 Visit the following resources to learn more:
 
-- [@official@Microsoft Registered I/O (RIO)](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh997032(v=ws.11))  
+- [@documentation@Microsoft Registered I/O (RIO)](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh997032(v=ws.11))  

--- a/src/data/roadmaps/server-side-game-developer/content/registered-io@94hJX1iGifDzIuaU3zU5j.md
+++ b/src/data/roadmaps/server-side-game-developer/content/registered-io@94hJX1iGifDzIuaU3zU5j.md
@@ -1,0 +1,15 @@
+# Registered I/O  
+
+**Registered I/O** is an optimization technique that enhances the performance of asynchronous 
+I/O operations by pre-registering resources such as file descriptors, memory buffers, or 
+network sockets with the operating system. This reduces the overhead of repeated system calls 
+and resource management, making it highly beneficial for server-side game development, where 
+low-latency and high-throughput are critical. Technologies like `io_uring` and Windows
+`RIO (Registered I/O)` API leverage this approach to minimize kernel interactions, improving 
+efficiency for handling large-scale multiplayer game servers. By reducing context switching 
+and memory allocation overhead, Registered I/O helps game servers achieve smoother performance 
+and lower latency.  
+
+Visit the following resources to learn more:
+
+- [@official@Microsoft Registered I/O (RIO)](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh997032(v=ws.11))  

--- a/src/data/roadmaps/server-side-game-developer/content/select@5-5toy2CblZPCV9d5QPEo.md
+++ b/src/data/roadmaps/server-side-game-developer/content/select@5-5toy2CblZPCV9d5QPEo.md
@@ -8,6 +8,7 @@ a large number of concurrent connections. Despite its drawbacks, it remains usef
 simpler applications or legacy systems. Modern alternatives like `epoll` or `kqueue` offer 
 better performance and scalability.  
 
-Resources:  
+Visit the following resources to learn more:
+
 - [@documentation@Linux select API](https://man7.org/linux/man-pages/man2/select.2.html)
 - [@article@select vs epoll vs poll](https://devarea.com/linux-io-multiplexing-select-vs-poll-vs-epoll/)

--- a/src/data/roadmaps/server-side-game-developer/content/select@5-5toy2CblZPCV9d5QPEo.md
+++ b/src/data/roadmaps/server-side-game-developer/content/select@5-5toy2CblZPCV9d5QPEo.md
@@ -1,0 +1,13 @@
+# select  
+
+**select** is a multiplexing system call in Linux used for monitoring multiple file descriptors
+to check if they are ready for I/O operations. It is commonly used in server-side game 
+development for handling multiple connections asynchronously. However, `select` has 
+limitations, as it scans all file descriptors linearly, making it inefficient for handling 
+a large number of concurrent connections. Despite its drawbacks, it remains useful for 
+simpler applications or legacy systems. Modern alternatives like `epoll` or `kqueue` offer 
+better performance and scalability.  
+
+Resources:  
+- [@documentation@Linux select API](https://man7.org/linux/man-pages/man2/select.2.html)
+- [@article@select vs epoll vs poll](https://devarea.com/linux-io-multiplexing-select-vs-poll-vs-epoll/)

--- a/src/data/roadmaps/server-side-game-developer/content/semaphore@DYvzGc_r0SlOArPPc1gNI.md
+++ b/src/data/roadmaps/server-side-game-developer/content/semaphore@DYvzGc_r0SlOArPPc1gNI.md
@@ -8,5 +8,5 @@ handling to avoid deadlocks and ensure efficient thread scheduling. Commonly use
 semaphores help maintain stability in high-performance multiplayer environments.
 
 Visit the following resources to learn more:
-  
+
 - [@article@Semaphores in Process Synchronization](https://www.geeksforgeeks.org/semaphores-in-process-synchronization/)

--- a/src/data/roadmaps/server-side-game-developer/content/semaphore@DYvzGc_r0SlOArPPc1gNI.md
+++ b/src/data/roadmaps/server-side-game-developer/content/semaphore@DYvzGc_r0SlOArPPc1gNI.md
@@ -1,0 +1,12 @@
+# Semaphores
+
+**Semaphores** are crucial synchronization mechanisms in server-side game development, ensuring controlled access to shared resources and 
+preventing race conditions. They are widely used for managing concurrent processes, such as limiting the number of active players in a 
+session, regulating access to database connections, and synchronizing threads in physics or AI computations. By using semaphores, 
+developers can optimize performance by preventing resource starvation and contention. Implementing them correctly requires careful 
+handling to avoid deadlocks and ensure efficient thread scheduling. Commonly used in conjunction with mutexes and condition variables, 
+semaphores help maintain stability in high-performance multiplayer environments.
+
+Visit the following resources to learn more:
+  
+- [@article@Semaphores in Process Synchronization](https://www.geeksforgeeks.org/semaphores-in-process-synchronization/)

--- a/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
+++ b/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
@@ -8,5 +8,6 @@ connections. However, it is generally less efficient than `epoll` on Linux due t
 scanning mechanism. For high-performance game servers on Windows, IOCP (I/O Completion Ports) 
 is often preferred over `WSA-Poll`.  
 
-Resources:  
+Visit the following resources to learn more:
+
 - [@documentation@Microsoft WSA-Poll Documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll)

--- a/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
+++ b/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
@@ -1,0 +1,12 @@
+# WSA-Poll**  
+
+**WSA-Poll** is a Windows-specific alternative to `poll`, used for monitoring multiple sockets 
+for readiness in non-blocking network applications. It is commonly utilized in server-side 
+game development to handle multiple client connections efficiently. Unlike `select`, `WSA-Poll`
+eliminates the limitation of FD_SETSIZE, allowing it to scale better for a larger number of 
+connections. However, it is generally less efficient than `epoll` on Linux due to its linear 
+scanning mechanism. For high-performance game servers on Windows, IOCP (I/O Completion Ports) 
+is often preferred over `WSA-Poll`.  
+
+Resources:  
+- [@documentation@Microsoft WSA-Poll Documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll)

--- a/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
+++ b/src/data/roadmaps/server-side-game-developer/content/wsa-poll@D9Yeyn8phDhB1ohMWccgr.md
@@ -1,4 +1,4 @@
-# WSA-Poll**  
+# WSA-Poll
 
 **WSA-Poll** is a Windows-specific alternative to `poll`, used for monitoring multiple sockets 
 for readiness in non-blocking network applications. It is commonly utilized in server-side 


### PR DESCRIPTION
This pull request enhances the `Server-Side Game Developer` Roadmap by adding missing content to improve clarity and usability for developers. The updates include detailed information on the following topics:  

- **semaphore**
- **epoll**
- **wsa-poll**
- **select**
- **iocp**
- **io_uring**
- **registered-io**
- **kqueue**

These additions aim to make the roadmap more comprehensive and valuable for developers working on server-side game development.

issue: #8406