### PR TITLE
Replace `System Design` Track with `Software Architect` in Suggested Learning Paths

### DIFF
--- a/src/data/roadmaps/system-design/system-design.json
+++ b/src/data/roadmaps/system-design/system-design.json
@@ -6128,8 +6128,8 @@
       },
       "selected": false,
       "data": {
-        "label": "System Design",
-        "href": "https://roadmap.sh/system-design",
+        "label": "Software Architect",
+        "href": "https://roadmap.sh/software-architect",
         "color": "#FFFFFf",
         "backgroundColor": "#4136D6",
         "style": {


### PR DESCRIPTION
This PR replaces the `System Design` track from the suggested learning paths at the end of the System Design roadmap with `Software Architect`. This change prevents looping back to the same roadmap and provides a more relevant learning direction.

Issue: #8428