### PR TITLE
fix: c++ node label typo

### DIFF
--- a/src/data/roadmaps/cpp/cpp.json
+++ b/src/data/roadmaps/cpp/cpp.json
@@ -3117,7 +3117,7 @@
       "position": { "x": 227.76444711909286, "y": 2041.110352538959 },
       "selected": true,
       "data": {
-        "label": "Standardds",
+        "label": "Standards",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
Resolves #8443 