### PR TITLE
update official supabase vector reference

### DIFF
--- a/src/data/roadmaps/ai-engineer/content/supabase@9kT7EEQsbeD2WDdN9ADx7.md
+++ b/src/data/roadmaps/ai-engineer/content/supabase@9kT7EEQsbeD2WDdN9ADx7.md
@@ -4,5 +4,5 @@ Supabase Vector is an extension of the Supabase platform, specifically designed 
 
 Learn more from the following resources:
 
-- [@official@Supabase Vector](https://supabase.com/vector)
+- [@official@Supabase Vector](https://supabase.com/docs/guides/ai)
 - [@video@Supabase Vector: The Postgres Vector database](https://www.youtube.com/watch?v=MDxEXKkxf2Q)


### PR DESCRIPTION
current reference is https://supabase.com/docs/guides/ai/vector-columns

previous reference was https://supabase.com/vector which is now a 404