### PR TITLE
Remove outdated PostgreSQL 7.1 documentation link

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/rows@Rd3RLpyLMGQZzrxQrxDGo.md
+++ b/src/data/roadmaps/postgresql-dba/content/rows@Rd3RLpyLMGQZzrxQrxDGo.md
@@ -4,5 +4,4 @@ A row in PostgreSQL represents a single, uniquely identifiable record with a spe
 
 Learn more from the following resources:
 
-- [@official@Concepts](https://www.postgresql.org/docs/7.1/query-concepts.html)
 - [@official@PostgreSQL - Rows](https://www.postgresql.org/docs/current/functions-comparisons.html)


### PR DESCRIPTION
A reference to the outdated PostgreSQL 7.1 documentation was removed, which incorrectly states that every row has an OID. This no longer reflects PostgreSQL behavior since version 8.1.