### PR TITLE
Update PostgreSQL docs link to current version

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/databases@DU-D3-j9h6i9Nj5ci8hlX.md
+++ b/src/data/roadmaps/postgresql-dba/content/databases@DU-D3-j9h6i9Nj5ci8hlX.md
@@ -4,5 +4,4 @@ In PostgreSQL, a database is a named collection of tables, indexes, views, store
 
 Learn more from the following resources:
 
-- [@official@Managing Databases](https://www.postgresql.org/docs/8.1/managing-databases.html)
-- [@official@Managing a Database](https://www.postgresql.org/docs/7.1/start-manage-db.html)
+- [@official@Managing Databases](https://www.postgresql.org/docs/current/managing-databases.html)


### PR DESCRIPTION
- Removed outdated link to PostgreSQL 7.1 documentation.
- Updated remaining link from version 8.1 to current to ensure long-term accuracy and relevance.
- This change ensures that users are directed to the latest stable PostgreSQL documentation.