### PR TITLE
Remove duplicate "Data Types" node from DDL Queries

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/data-types@fvEgtFP7xvkq_D4hYw3gz.md
+++ b/src/data/roadmaps/postgresql-dba/content/data-types@fvEgtFP7xvkq_D4hYw3gz.md
@@ -1,8 +1,0 @@
-# Data Types in PostgreSQL
-
-PostgreSQL offers a comprehensive set of data types to cater to diverse data needs, including numeric types like `INTEGER`, `FLOAT`, and `SERIAL` for auto-incrementing fields; character types such as `VARCHAR` and `TEXT` for variable-length text; and temporal types like `DATE`, `TIME`, and `TIMESTAMP` for handling date and time data. Additionally, PostgreSQL supports `BOOLEAN` for true/false values, `ENUM` for enumerated lists, and composite types for complex structures. It also excels with `JSON` and `JSONB` for storing and querying semi-structured data, arrays for storing multiple values in a single field, and geometric types for spatial data. These data types ensure flexibility and robust data management for various applications.
-
-Learn more from the following resources:
-
-- [@article@PostgreSQL® Data Types: Mappings to SQL, JDBC, and Java Data Types](https://www.instaclustr.com/blog/postgresql-data-types-mappings-to-sql-jdbc-and-java-data-types/)
-- [@official@Data Types](https://www.postgresql.org/docs/current/datatype.html)


### PR DESCRIPTION
There are currently two separate content files titled "Data Types in PostgreSQL" in the PostgreSQL DBA roadmap:

1. [`data-types@fvEgtFP7xvkq_D4hYw3gz.md`](https://github.com/kamranahmedse/developer-roadmap/blob/master/src/data/roadmaps/postgresql-dba/content/data-types%40fvEgtFP7xvkq_D4hYw3gz.md) — linked from the DDL Queries section
2. [`data-types@4Pw7udOMIsiaKr7w9CRxc.md`](https://github.com/kamranahmedse/developer-roadmap/blob/master/src/data/roadmaps/postgresql-dba/content/data-types%404Pw7udOMIsiaKr7w9CRxc.md) — listed earlier in the roadmap structure

Both nodes cover essentially the same content and concepts, with minor wording differences. To reduce redundancy and simplify the roadmap, this PR proposes to:

- **Remove** the content file and node `data-types@fvEgtFP7xvkq_D4hYw3gz.md` (from the DDL Queries section)
- **Keep** `data-types@4Pw7udOMIsiaKr7w9CRxc.md` as the main authoritative node on PostgreSQL data types

The second version (the one we keep) is more comprehensive, includes PostGIS, and provides a more detailed overview and references. Removing the duplicate avoids confusion and keeps the learning path clean.