### PR TITLE
Add correct link for GraphQL Mutations 

### DIFF
--- a/src/data/roadmaps/graphql/content/mutations/what-are-mutations.md
+++ b/src/data/roadmaps/graphql/content/mutations/what-are-mutations.md
@@ -6,4 +6,4 @@ A mutation typically includes fields that specify the data to be changed and the
 
 Learn more from the following resources:
 
-- [@official@Get started with Mutations](https://graphql.org/learn/queries/#mutations)
+- [@official@Get started with Mutations](https://graphql.org/learn/mutations/)


### PR DESCRIPTION
The "Get started with Mutations" link in the GraphQL roadmap points to the GraphQL Queries documentation.
Fixes - Added the correct link in the .md file