### PR TITLE
fix: update create-react-app to the latest link

### DIFF
--- a/src/data/roadmaps/react/content/cli-tools@tU4Umtnfu01t9gLlnlK6b.md
+++ b/src/data/roadmaps/react/content/cli-tools@tU4Umtnfu01t9gLlnlK6b.md
@@ -2,6 +2,5 @@
 
 Here is the list of most common CLI tools for React development:
 
-- [@article@create-react-app](https://create-react-app.dev/docs/getting-started)
 - [@article@vite](https://vitejs.dev)
 - [@feed@Explore top posts about CLI](https://app.daily.dev/tags/cli?ref=roadmapsh)

--- a/src/data/roadmaps/react/content/cli-tools@tU4Umtnfu01t9gLlnlK6b.md
+++ b/src/data/roadmaps/react/content/cli-tools@tU4Umtnfu01t9gLlnlK6b.md
@@ -2,6 +2,6 @@
 
 Here is the list of most common CLI tools for React development:
 
-- [@article@create-react-app](https://create-react-app.dev)
+- [@article@create-react-app](https://create-react-app.dev/docs/getting-started)
 - [@article@vite](https://vitejs.dev)
 - [@feed@Explore top posts about CLI](https://app.daily.dev/tags/cli?ref=roadmapsh)


### PR DESCRIPTION
Create React App is [deprecated](https://react.dev/blog/2025/02/14/sunsetting-create-react-app). so updated the link with the official modern solution.