### PR TITLE
TS roadmap: fix typo in link to `any` official doc

### DIFF
--- a/src/data/roadmaps/typescript/content/as-any@afTNr36VqeXoJpHxm2IoS.md
+++ b/src/data/roadmaps/typescript/content/as-any@afTNr36VqeXoJpHxm2IoS.md
@@ -14,4 +14,4 @@ anyValue = true;
 
 Learn more from the following links:
 
-- [@official@Arrays](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any)
+- [@official@any](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any)


### PR DESCRIPTION
Link to `any` type documentation is named as `Array`:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/b82ad2aa-3cf4-4150-bd34-edfae17ab1af" />


This PR sets the proper name for the link