### PR TITLE
docs: fix moved link Managed Resources --> Managing Workloads

### DIFF
--- a/src/data/roadmaps/kubernetes/content/resource-management/index.md
+++ b/src/data/roadmaps/kubernetes/content/resource-management/index.md
@@ -4,6 +4,6 @@ Resource management in Kubernetes involves managing CPU, memory, and storage res
 
 Learn more from the following links:
 
-- [@official@Managing Resources - Documentation](https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/)
+- [@official@Managing Workloads - Documentation](https://kubernetes.io/docs/concepts/workloads/management/)
 - [@article@Managing Kubernetes resources: 5 things to remember](https://enterprisersproject.com/article/2020/8/managing-kubernetes-resources-5-things-remember)
 - [@video@Resource Management in Kubernetes](https://www.youtube.com/watch?v=MbgFIQoVh6w)


### PR DESCRIPTION
I spent some time to be sure that the link on the card `Resource Management` on roadmap website was pointing to that kubernetes doc https://kubernetes.io/docs/concepts/workloads/management/ and yes it is. 

Kubernetes website MR is https://github.com/kubernetes/website/pull/45212

I don't understand why the card `Resource Management` uses that guide, but if you do, we can at least use the newest page title. In my opinion, we can remove the link instead of accepting this MR, as it's not related to `Resource management`

Hope this MR will help to make roadmap.sh a little better than what it is already <3