### PR TITLE
Fix: Add missing /opt explanation to Linux directory hierarchy

### DIFF
--- a/src/data/roadmaps/linux/content/navigation-basics/directory-hierarchy.md
+++ b/src/data/roadmaps/linux/content/navigation-basics/directory-hierarchy.md
@@ -11,6 +11,7 @@ In Linux, understanding the directory hierarchy is crucial for efficient navigat
 - `/usr`: User programs and data.
 - `/lib`: Shared libraries.
 - `/tmp`: Temporary files.
+- `/opt`: Third-party applications.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
This PR adds a brief explanation of the `/opt` directory to the Linux roadmap's "directory-hierarchy.md" content file.

- Describes `/opt` as the place for third-party applications.
- Keeps style consistent with the rest of the section.

This small addition improves clarity and completeness of the Linux filesystem overview.