### PR TITLE
fix: correct spelling of "RecyclerView" in Android roadmap

### DIFF
--- a/src/data/roadmaps/android/android.json
+++ b/src/data/roadmaps/android/android.json
@@ -1854,7 +1854,7 @@
       },
       "selected": false,
       "data": {
-        "label": "RecycleView",
+        "label": "RecyclerView",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",

--- a/src/data/roadmaps/android/content/recyclerview@xIvplWfe-uDr9iHjPT1Mx.md
+++ b/src/data/roadmaps/android/content/recyclerview@xIvplWfe-uDr9iHjPT1Mx.md
@@ -1,0 +1,9 @@
+# RecyclerView
+
+RecyclerView is the most commonly used and powerful list management tool in Android development. It makes it easy to efficiently display large sets of data. You supply the data and define how each item looks, and the RecyclerView library dynamically creates the elements when they're needed.
+
+As the name implies, RecyclerView recycles those individual elements. When an item scrolls off the screen, RecyclerView doesn't destroy its view. Instead, RecyclerView reuses the view for new items that have scrolled onscreen. RecyclerView improves performance and your app's responsiveness, and it reduces power consumption.
+
+Learn more from the following resources:
+
+- [@official@Create Dynamic Lists with RecyclerView](https://developer.android.com/develop/ui/views/layout/recyclerview)

--- a/src/data/roadmaps/android/content/recyclerview@xIvplWfe-uDr9iHjPT1Mx.md
+++ b/src/data/roadmaps/android/content/recyclerview@xIvplWfe-uDr9iHjPT1Mx.md
@@ -4,6 +4,7 @@ RecyclerView is the most commonly used and powerful list management tool in Andr
 
 As the name implies, RecyclerView recycles those individual elements. When an item scrolls off the screen, RecyclerView doesn't destroy its view. Instead, RecyclerView reuses the view for new items that have scrolled onscreen. RecyclerView improves performance and your app's responsiveness, and it reduces power consumption.
 
-Learn more from the following resources:
+Visit the following resources to learn more:
 
-- [@official@Create Dynamic Lists with RecyclerView](https://developer.android.com/develop/ui/views/layout/recyclerview)
+- [@official@RecyclerView Reference (Android Docs)](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView)
+- [@official@Create Dynamic Lists with RecyclerView (Android Docs)](https://developer.android.com/develop/ui/views/layout/recyclerview)

--- a/src/data/roadmaps/android/content/recycleview@xIvplWfe-uDr9iHjPT1Mx.md
+++ b/src/data/roadmaps/android/content/recycleview@xIvplWfe-uDr9iHjPT1Mx.md
@@ -1,6 +1,6 @@
 # RecyclerView
 
-RecyclerView is the most commonly used and powerful list management tool in Android development. Witch makes it easy to efficiently display large sets of data. You supply the data and define how each item looks, and the RecyclerView library dynamically creates the elements when they're needed.
+RecyclerView is the most commonly used and powerful list management tool in Android development. It makes it easy to efficiently display large sets of data. You supply the data and define how each item looks, and the RecyclerView library dynamically creates the elements when they're needed.
 
 As the name implies, RecyclerView recycles those individual elements. When an item scrolls off the screen, RecyclerView doesn't destroy its view. Instead, RecyclerView reuses the view for new items that have scrolled onscreen. RecyclerView improves performance and your app's responsiveness, and it reduces power consumption.
 

--- a/src/data/roadmaps/android/content/recycleview@xIvplWfe-uDr9iHjPT1Mx.md
+++ b/src/data/roadmaps/android/content/recycleview@xIvplWfe-uDr9iHjPT1Mx.md
@@ -1,9 +1,0 @@
-# RecyclerView
-
-RecyclerView is the most commonly used and powerful list management tool in Android development. It makes it easy to efficiently display large sets of data. You supply the data and define how each item looks, and the RecyclerView library dynamically creates the elements when they're needed.
-
-As the name implies, RecyclerView recycles those individual elements. When an item scrolls off the screen, RecyclerView doesn't destroy its view. Instead, RecyclerView reuses the view for new items that have scrolled onscreen. RecyclerView improves performance and your app's responsiveness, and it reduces power consumption.
-
-Learn more from the following resources:
-
-- [@official@Create Dynamic Lists with RecyclerView](https://developer.android.com/develop/ui/views/layout/recyclerview)


### PR DESCRIPTION
- Renamed the content file from `recycleview@x1vpIWfe-uDr9iHjPTlMx.md` to `recyclerview@x1vpIWfe-uDr9iHjPTlMx.md`
- Updated the roadmap graph node label from `"RecycleView"` to `"RecyclerView"` in `android.json`
- Fixed grammar and word clarity in the content markdown

Official Android documentation for RecyclerView:
https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView