### PR TITLE
fix: update outdated link to old angular website

### DIFF
--- a/src/data/roadmaps/angular/content/custom-validators@kxRtLsB3y_th8j-HjmJgK.md
+++ b/src/data/roadmaps/angular/content/custom-validators@kxRtLsB3y_th8j-HjmJgK.md
@@ -4,5 +4,5 @@ Custom validators in Angular are functions that allow you to define your own val
 
 Learn more from the following resources:
 
-- [@official@Defining custom validators](https://v17.angular.io/guide/form-validation#custom-validators)
+- [@official@Defining custom validators](https://angular.dev/guide/forms/form-validation#defining-custom-validators)
 - [@video@How to create custom validator in Angular 17](https://youtu.be/3TwmS0Gdg9I?si=1w4EX-HifJ70-CxT)


### PR DESCRIPTION
In the Angular roadmap at **Forms** (Custom Validators) section the link to the official documentation was pointing to the old website of angular. 