### PR TITLE
Fix typo in grpc@priDGksAvJ05YzakkTFtM.md

### DIFF
--- a/src/data/roadmaps/software-architect/content/grpc@priDGksAvJ05YzakkTFtM.md
+++ b/src/data/roadmaps/software-architect/content/grpc@priDGksAvJ05YzakkTFtM.md
@@ -1,4 +1,4 @@
-# gPRC
+# gRPC
 
 gRPC is a platform agnostic serialization protocol that is used to communicate between services. Designed by Google in 2015, it is a modern alternative to REST APIs. It is a binary protocol that uses HTTP/2 as a transport layer. It is a high performance, open source, general-purpose RPC framework that puts mobile and HTTP/2 first.
 


### PR DESCRIPTION
The title is spelt gPRC instead of GRPC