### PR TITLE
fix(android): correct migration mapping for recyclerview

### DIFF
--- a/src/data/roadmaps/android/migration-mapping.json
+++ b/src/data/roadmaps/android/migration-mapping.json
@@ -30,7 +30,7 @@
   "interface-and-navigation:layouts:linear": "U8iMGGOd2EgPxSuwSG39Z",
   "interface-and-navigation:layouts:relative": "yE0qAQZiEC9R8WvCdskpr",
   "interface-and-navigation:layouts:constraint": "3fFNMhQIuuh-NRzSXYpXO",
-  "interface-and-navigation:layouts:recycle-view": "xIvplWfe-uDr9iHjPT1Mx",
+  "interface-and-navigation:layouts:recycler-view": "xIvplWfe-uDr9iHjPT1Mx",
   "interface-and-navigation": "4_e76QafrB419S2INOeKd",
   "interface-and-navigation:jetpack-compose": "60Vm-77rseUqpMiFvp-dA",
   "interface-and-navigation:app-shortcuts": "xV475jHTlLuHtpHZeXb7P",


### PR DESCRIPTION
Follow up to PR: https://github.com/kamranahmedse/developer-roadmap/pull/8706

This patch fixes an oversight in the original PR where the migration mapping key for RecyclerView was not updated. While the node label and markdown file were corrected, the outdated slug (recycle-view) in the mapping logic caused the node to not update.

This change updates the mapping to use the correct slug: `recycler-view`.