### PR TITLE
Update abstract class link

### DIFF
--- a/src/data/roadmaps/software-design-architecture/content/abstract-classes@RMkEE7c0jdVFqZ4fmjL6Y.md
+++ b/src/data/roadmaps/software-design-architecture/content/abstract-classes@RMkEE7c0jdVFqZ4fmjL6Y.md
@@ -6,4 +6,4 @@ Abstract classes are used to provide a common interface and implementation for a
 
 Learn more from the following resources:
 
-- [@article@What is an Abstract Class in Object Oriented Programming](https://computinglearner.com/abstract-class-in-object-oriented-programming/)
+- [@article@What is an Abstract Class in Object Oriented Programming](https://www.theserverside.com/definition/abstract-class)


### PR DESCRIPTION
The original [link](https://computinglearner.com/abstract-class-in-object-oriented-programming/) re-directed to some online store that looks rather [spammy](https://microtunnellink.com/). This PR changes the link to an [article](https://www.theserverside.com/definition/abstract-class) from The Server Side that describes abstract classes without relying on any specific language.