### PR TITLE
Remvoe broken link of why should you use kubernetes

### DIFF
--- a/src/data/roadmaps/kubernetes/content/why-use-kubernetes@q-Ky0ietZGpyUcBQfh-BJ.md
+++ b/src/data/roadmaps/kubernetes/content/why-use-kubernetes@q-Ky0ietZGpyUcBQfh-BJ.md
@@ -5,6 +5,5 @@ Kubernetes (k8s) is needed because it provides a powerful and flexible platform 
 Learn more from the following resources:
 
 - [@official@Why you need Kubernetes and what it can do](https://kubernetes.io/docs/concepts/overview/#why-you-need-kubernetes-and-what-can-it-do)
-- [@article@Why should you use Kubernetes?](https://www.predicagroup.com/blog/why-kubernetes-2022/)
 - [@article@Primer: How Kubernetes Came to Be, What It Is, and Why You Should Care](https://thenewstack.io/primer-how-kubernetes-came-to-be-what-it-is-and-why-you-should-care/)
 - [@feed@Explore top posts about Kubernetes](https://app.daily.dev/tags/kubernetes?ref=roadmapsh)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/10e74075-231e-416a-af1c-06398e38a0d1)
https://www.predicagroup.com/blog/why-kubernetes-2022/
The above link is broken
When clicked on **Why should you use Kubernetes** in (Introduction -> Why Kubernetes), it displays this. 

I am thinking instead of that, if we replace that link with any of the below: 
- https://faun.pub/why-you-should-use-kubernetes-bf395bef52de
- https://spacelift.io/blog/kubernetes-use-cases

Waiting for your reply.