### PR TITLE
Allow mutation of guide template for HTML unescaping

### DIFF
--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -241,19 +241,19 @@ async function generateGuideOpenGraph() {
     const image =
       author?.imageUrl || 'https://roadmap.sh/images/default-avatar.png';
     const isExternalImage = image?.startsWith('http');
-    let authorImageExtention = '';
+    let authorImageExtension = '';
     let authorAvatar;
     if (!isExternalImage) {
       authorAvatar = await fs.readFile(path.join(ALL_AUTHOR_IMAGE_DIR, image));
-      authorImageExtention = image?.split('.')[1];
+      authorImageExtension = image?.split('.')[1];
     }
 
-    const template = getGuideTemplate({
+    let template = getGuideTemplate({
       ...guide,
       authorName: author.name,
       authorAvatar: isExternalImage
         ? image
-        : `data:image/${authorImageExtention};base64,${authorAvatar.toString('base64')}`,
+        : `data:image/${authorImageExtension};base64,${authorAvatar.toString('base64')}`,
     });
     if (
       hasSpecialCharacters(guide.title) ||


### PR DESCRIPTION
## PR Summary
This small PR fixes a bug where `const` was used for a `template` variable that may be reassigned after unescaping HTML. The fix replaces `const` with `let` to allow mutation of template when special characters are present in guide metadata. This resolves runtime errors and ensures proper rendering of OG images for guides with special characters in titles or descriptions. It also fixes a small typo along the way.