### PR TITLE
fix: update c# site to resolve missing images

### DIFF
--- a/src/data/roadmaps/aspnet-core/content/c@fxANnSiTb2VzA9u-YeBL1.md
+++ b/src/data/roadmaps/aspnet-core/content/c@fxANnSiTb2VzA9u-YeBL1.md
@@ -4,6 +4,6 @@ C# is a modern coding language that was developed by Microsoft that focuses on a
 
 Visit the following resources to learn more:
 
-- [@article@C# official website?](https://learn.microsoft.com/en-us/dotnet/csharp//)
+- [@article@C# official website?](https://learn.microsoft.com/en-us/dotnet/csharp/)
 - [@video@C# Full Course - Learn C# 10 and .NET 6 in 7 hours](https://www.youtube.com/watch?v=q_F4PyW8GTg)
 - [@feed@Explore top posts about C#](https://app.daily.dev/tags/csharp?ref=roadmapsh)


### PR DESCRIPTION
Fixes images missing due to double slash at the end.
![image](https://github.com/user-attachments/assets/a7b2d4c6-4281-4d3e-9468-bd51b24eede3)
