### PR TITLE
Remove redundant close button from `LeavingRoadmapWarningModal`

### DIFF
--- a/src/components/Projects/LeavingRoadmapWarningModal.tsx
+++ b/src/components/Projects/LeavingRoadmapWarningModal.tsx
@@ -53,13 +53,6 @@ export function LeavingRoadmapWarningModal(
         <ArrowUpRight className="h-5 w-5" />
         Continue to Solution
       </a>
-
-      <button
-        className="absolute right-2.5 top-2.5 text-gray-600 hover:text-black"
-        onClick={onClose}
-      >
-        <X className="h-5 w-5" />
-      </button>
     </Modal>
   );
 }

--- a/src/components/Schedule/ScheduleEventModal.tsx
+++ b/src/components/Schedule/ScheduleEventModal.tsx
@@ -197,12 +197,6 @@ Visit the roadmap at https://roadmap.sh/${roadmapId}
       overlayClassName="items-start md:items-center"
     >
       <div className="rounded-xl bg-white px-3">
-        <button
-          className="absolute right-4 top-4 text-gray-400 hover:text-black"
-          onClick={onClose}
-        >
-          <X className="h-4 w-4 stroke-[2.5]" />
-        </button>
 
         <div className="flex flex-col items-center p-4 py-6 text-center">
           {selectedCalendar && (


### PR DESCRIPTION
This pull request removes redundant close buttons from two modal components in the project. These changes simplify the UI and reduce duplication, as the modals already have other mechanisms to close.

Changes to modal components:

* [`src/components/Projects/LeavingRoadmapWarningModal.tsx`](diffhunk://#diff-8a956104438536221771306c164e975d35e5c411e09316fc551837c578f89185L56-L62): Removed the close button (`<button>` element) from the modal, which was positioned at the top-right corner.
* [`src/components/Schedule/ScheduleEventModal.tsx`](diffhunk://#diff-1d01aa64c14f241e3c416ba940aa663f86f7a5112b7b76ef0f72a0e2ab30ce59L200-L205): Removed the close button (`<button>` element) from the modal, which was positioned at the top-right corner.


| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/b942286f-a3ab-477d-a24f-13b606757bf9) | ![After](https://github.com/user-attachments/assets/f3fb5211-8037-42b8-9f5e-86d92b51053b) |
| ![Screenshot from 2025-06-29 17-55-31](https://github.com/user-attachments/assets/929a86eb-b20d-48c2-9c3f-65df4ef3ec28) | ![finalfinal](https://github.com/user-attachments/assets/493c3e80-9554-4ff0-b2f7-08452856ad07)
|
