### PR TITLE
Fix Typo in Technical Writer Label

### DIFF
--- a/public/roadmap-content/technical-writer.json
+++ b/public/roadmap-content/technical-writer.json
@@ -52,7 +52,7 @@
     ]
   },
   "j69erqfosSZMDlmKcnnn0": {
-    "title": "Role of Technical Writers inOrganizations",
+    "title": "Role of Technical Writers in Organizations",
     "description": "The role of a **Technical Writer** is primarily to translate complex technical information into simpler language that is easy to understand for a non-technical audience. They design, write, edit, and rewrite technical pieces like operating instructions, FAQs, installation guides, and more. Apart from this, they also gather and disseminate technical information among customers, designers, and manufacturers. Essentially, their job involves communicating technical terminologies and a clear understanding of complex information to those who need it in an easy-to-understand format.",
     "links": []
   },

--- a/src/data/roadmaps/technical-writer/technical-writer.json
+++ b/src/data/roadmaps/technical-writer/technical-writer.json
@@ -626,7 +626,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Role of Technical Writers inOrganizations",
+        "label": "Role of Technical Writers in Organizations",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
The Technical Writer roadmap has a label in the top-right section with "Role of Technical Writers inOrganizations" instead of "...in Organizations".