### PR TITLE
Add Redux Toolkit to React roadmap

### DIFF
--- a/public/roadmap-content/react.json
+++ b/public/roadmap-content/react.json
@@ -1717,5 +1717,26 @@
         "type": "video"
       }
     ]
+  },
+  "redux-toolkit": {
+    "title": "Redux Toolkit",
+    "description": "Redux Toolkit is the official, recommended way to use Redux for writing scalable and maintainable state management logic. It reduces boilerplate and includes built-in support for slices, async logic, middleware, and dev tools.",
+    "links": [
+      {
+        "title": "Redux Toolkit Docs",
+        "url": "https://redux-toolkit.js.org/",
+        "type": "article"
+      },
+      {
+        "title": "Redux Essentials Tutorial",
+        "url": "https://redux.js.org/tutorials/essentials/part-1-overview-concepts",
+        "type": "article"
+      },
+      {
+        "title": "Redux Toolkit Crash Course",
+        "url": "https://www.youtube.com/watch?v=9zySeP5vH9c",
+        "type": "video"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## ✨ Summary

This PR adds **Redux Toolkit** under the React roadmap content file (`public/roadmap-content/react.json`).  
Redux Toolkit is the **official, recommended approach** to using Redux in modern React apps.  
It simplifies Redux usage by abstracting boilerplate and providing built-in support for slices, middleware, and async logic.

---

## 📚 Resources Added

- [Redux Toolkit Docs](https://redux-toolkit.js.org/) — @Article@
- [Redux Essentials Tutorial](https://redux.js.org/tutorials/essentials/part-1-overview-concepts) — @Article@
- [Redux Toolkit Crash Course](https://www.youtube.com/watch?v=9zySeP5vH9c) — @video@

---

## ✅ Justification

Redux Toolkit is widely used and officially supported.  
It offers a maintainable and scalable approach to global state management in large React apps.  
It deserves a spot in the roadmap alongside Zustand, MobX, and Jotai due to its real-world relevance and support in the React ecosystem.

Let me know if I should adjust the description format or links!

---

Closes #8902