### PR TITLE
fix: broken link with archived link

### DIFF
--- a/public/roadmap-content/java.json
+++ b/public/roadmap-content/java.json
@@ -307,7 +307,7 @@
     "links": [
       {
         "title": "Java Method Chaining - Java Explained",
-        "url": "https://bito.ai/resources/java-method-chaining-java-explained",
+        "url": "https://web.archive.org/web/20231201042016/https://bito.ai/resources/java-method-chaining-java-explained/",
         "type": "article"
       },
       {


### PR DESCRIPTION
with this https://web.archive.org/web/20231201042016/https://bito.ai/resources/java-method-chaining-java-explained/