### PR TITLE
Updated dead article link ( bito.ai ) for Method Chaining to new link ( geeksforgeeks )

### DIFF
--- a/src/data/roadmaps/java/content/method-chaining@Ax2ouIZgN1DpPzKDy4fwp.md
+++ b/src/data/roadmaps/java/content/method-chaining@Ax2ouIZgN1DpPzKDy4fwp.md
@@ -4,5 +4,4 @@ Method chaining is a programming technique where multiple method calls are made 
 
 Visit the following resources to learn more:
 
-- [@article@Method Chaining In Java with Examples](https://www.geeksforgeeks.org/java/method-chaining-in-java-with-examples/)
 - [@stackoverflow@How to achieve method chaining in Java](https://stackoverflow.com/questions/21180269/how-to-achieve-method-chaining-in-java)


### PR DESCRIPTION
The old article link ( https://bito.ai/resources/java-method-chaining-java-explained ) is not valid anymore. It gives a 404 page.
<img width="1532" height="745" alt="image" src="https://github.com/user-attachments/assets/e661c6be-6f96-48a5-877f-b7996da121ce" />

I have updated the link with a new link ( https://www.geeksforgeeks.org/java/method-chaining-in-java-with-examples/ ) 