### PR TITLE
fix(label) Issue #8959 : Corrected navigation button label from 'Frontend Roadmap' to 'Java Roadmap'

### DIFF
--- a/src/data/roadmaps/spring-boot/spring-boot.json
+++ b/src/data/roadmaps/spring-boot/spring-boot.json
@@ -297,7 +297,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Frontend Roadmap",
+        "label": "Java Roadmap",
         "href": "https://roadmap.sh/java",
         "color": "#FFf",
         "backgroundColor": "#4136D6",


### PR DESCRIPTION
Updated the label of the navigation button at the bottom of the Spring Boot Roadmap page. The button previously read "Frontend Roadmap", which was misleading, as it actually links to the Java Roadmap page.

This change aligns the label with the correct destination URL, which is intentional and consistent with the content referenced in spring-boot.pdf, where it clearly mentions the Java Roadmap. No URL changes were made, as the link is correctly pointing to the Java roadmap.