### PR TITLE
Fix the TYPO))

### DIFF
--- a/src/data/projects/github-user-activity.md
+++ b/src/data/projects/github-user-activity.md
@@ -46,7 +46,7 @@ The application should run from the command line, accept the GitHub username as 
   Output:
   - Pushed 3 commits to kamranahmedse/developer-roadmap
   - Opened a new issue in kamranahmedse/developer-roadmap
-  - Starred kamranahmedse/developer-roadmap
+  - Started kamranahmedse/developer-roadmap
   - ...
   ```
   You can [learn more about the GitHub API here](https://docs.github.com/en/rest/activity/events?apiVersion=2022-11-28).


### PR DESCRIPTION
<img width="863" height="711" alt="sss" src="https://github.com/user-attachments/assets/b06fe19d-b2d1-494a-a698-1d55902a7b84" />


I think in Project "Github User activity  CLI", there is a typo in word "Starred" in readme file, I think it supposed to be "Started"