### PR TITLE
fix: typo "serviece" to "service"

### DIFF
--- a/src/data/roadmaps/aws/content/metrics@2vQPmVNk1QpMM-15RKG8b.md
+++ b/src/data/roadmaps/aws/content/metrics@2vQPmVNk1QpMM-15RKG8b.md
@@ -1,6 +1,6 @@
 # Metrics
 
-In Amazon CloudWatch, **metrics** are fundamental concepts that you work with. A metric is the fundamental concept in CloudWatch and represents a time-ordered set of data points that are published to CloudWatch. Think of a metric as a variable to monitor, and the data points as representing the values of that variable over time. Metrics are uniquely defined by a name, a namespace, and zero or more dimensions up to 30 dimensions per metric. Every data point must have a timestamp. You can retrieve statistics about those data points as an ordered set of time-series data. CloudWatch provides metrics for every serviece in AWS.
+In Amazon CloudWatch, **metrics** are fundamental concepts that you work with. A metric is the fundamental concept in CloudWatch and represents a time-ordered set of data points that are published to CloudWatch. Think of a metric as a variable to monitor, and the data points as representing the values of that variable over time. Metrics are uniquely defined by a name, a namespace, and zero or more dimensions up to 30 dimensions per metric. Every data point must have a timestamp. You can retrieve statistics about those data points as an ordered set of time-series data. CloudWatch provides metrics for every service in AWS.
 
 Learn more from the following resources:
 


### PR DESCRIPTION
Corrected a small typo in the "Metrics" section of AWS roadmap.