### PR TITLE
Add two articles that are very informative to the Options and Results page

### DIFF
--- a/src/data/roadmaps/rust/content/option-and-result-enumerations@wQHkBydWsiGEOZMdKmz40.md
+++ b/src/data/roadmaps/rust/content/option-and-result-enumerations@wQHkBydWsiGEOZMdKmz40.md
@@ -6,3 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Option & unwrap](https://doc.rust-lang.org/rust-by-example/error/option_unwrap.html)
 - [@official@Result](https://doc.rust-lang.org/rust-by-example/error/result.html)
+- [@article@Error Handling in Rust - Andrew Gallant's Blog](https://burntsushi.net/rust-error-handling)
+- [@article@Using unwrap() in Rust is Okay - Andrew Gallant's Blog](https://burntsushi.net/unwrap/)


### PR DESCRIPTION
Andrew Gallant, the author of ripgrep, wrote a pair of articles that break down error handling very well, starting from the basics to more advanced scenarios of using Options and Results effectively. These articles have helped me and continue to serve as a reference point in my rust journey.