### PR TITLE
fix: update official resource for raw string in go-roadmap

### DIFF
--- a/src/data/roadmaps/golang/content/raw-string-literals@nzPe6XVqhtOZFbea6f2Hg.md
+++ b/src/data/roadmaps/golang/content/raw-string-literals@nzPe6XVqhtOZFbea6f2Hg.md
@@ -4,5 +4,5 @@ Enclosed in backticks (\`) and interpret characters literally without escape seq
 
 Visit the following resources to learn more:
 
-- [@official@Carriage Returns](https://go.dev/ref/spec)
+- [@official@Strings in Go](https://go.dev/blog/strings#what-is-a-string)
 - [@article@Golang Quick Reference: Strings. Introduction ](https://medium.com/@golangda/golang-quick-reference-strings-0d68bb036c29)


### PR DESCRIPTION
Updated the official resource for `Raw String Literal` by correcting the link pointing to the valid official Go blog on the string literal topic. The previous link pointed to a generic Go Docs page and contained an invalid resource label.