### PR TITLE
Clarify IoC description: container manages object creation, not objects themselves

### DIFF
--- a/src/data/roadmaps/spring-boot/content/spring-ioc@PlUU_vzFQ3Xx6Z5XREIYP.md
+++ b/src/data/roadmaps/spring-boot/content/spring-ioc@PlUU_vzFQ3Xx6Z5XREIYP.md
@@ -1,6 +1,6 @@
 # Spring IOC
 
-Inversion of Control (IoC) is a design pattern that is often used in conjunction with the Dependency Injection (DI) pattern. The basic idea behind IoC is to invert the flow of control in a program, so that instead of the program controlling the flow of logic and the creation of objects, the objects themselves control the flow of logic and the creation of other objects.
+Inversion of Control (IoC) is a design pattern that is often used in conjunction with the Dependency Injection (DI) pattern. The basic idea behind IoC is to invert the flow of control in a program, so that instead of the program controlling the flow of logic and the creation of objects, IoC container (the framework) controls the flow of logic and the creation and wiring of objects.
 
 Spring is a popular Java framework that uses IoC and DI to provide a more flexible, modular approach to software development. The Spring IoC container is responsible for managing the creation and configuration of objects in a Spring-based application.
 


### PR DESCRIPTION
The current text says:

"Inversion of Control (IoC) … instead of the program controlling the flow of logic and the creation of objects, the objects themselves control the flow of logic and the creation of other objects."

This can be misleading. In IoC, the **container/framework** controls object creation and dependency injection, not the objects themselves. 

This PR updates the sentence to clarify that point, keeping the description accurate while preserving the original intent.