### PR TITLE
Fixed Typo

### DIFF
--- a/src/data/roadmaps/rust/rust.json
+++ b/src/data/roadmaps/rust/rust.json
@@ -2819,7 +2819,7 @@
       "draggable": true,
       "deletable": true,
       "data": {
-        "label": "Ownsership System",
+        "label": "Ownership System",
         "style": {
           "fontSize": 17
         },
@@ -2853,7 +2853,7 @@
       "draggable": true,
       "deletable": true,
       "data": {
-        "label": "Ownsership Rules & Memory Safety",
+        "label": "Ownership Rules & Memory Safety",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
The Ownership and Memory Safety was previously written as 'Ownsership and Memory Safety'.