### PR TITLE
Update git@uyDm1SpOQdpHjq9zBAdck.md

### DIFF
--- a/src/data/roadmaps/devops/content/git@uyDm1SpOQdpHjq9zBAdck.md
+++ b/src/data/roadmaps/devops/content/git@uyDm1SpOQdpHjq9zBAdck.md
@@ -6,7 +6,7 @@ Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
 - [@course@Git by Example - Learn Version Control with Bite-sized Lessons](https://antonz.org/git-by-example/)
-- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
+- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=vA5TTz6BXhY)
 - [@article@Learn Git with Tutorials, News and Tips - Atlassian](https://www.atlassian.com/git)
 - [@article@Git Cheat Sheet](https://cs.fyi/guide/git-cheatsheet)
 - [@feed@Explore top posts about Git](https://app.daily.dev/tags/git?ref=roadmapsh)


### PR DESCRIPTION
Included a updated version of git & github crash course as earlier version was 8 years old by travesy Media , updated link is 2025 course by traversy media ,so the content is up to date

fixes #9090 

<img width="1110" height="611" alt="image" src="https://github.com/user-attachments/assets/2b0c0e49-492e-460e-9428-30e34a759cc6" />
