### PR TITLE
Fixes issue #8940

### DIFF
--- a/src/lib/guide-renderer.tsx
+++ b/src/lib/guide-renderer.tsx
@@ -102,10 +102,10 @@ export class GuideRenderer {
             topicSlug = 'beginner-level';
           } else if (topic.toLowerCase() === 'intermediate') {
             topicText = 'Intermediate Level';
-            topicSlug = 'intermediate-level';
+            topicSlug = 'intermediate';
           } else if (topic.toLowerCase() === 'advanced') {
             topicText = 'Advanced Level';
-            topicSlug = 'advanced-level';
+            topicSlug = 'advanced';
           }
 
           return {


### PR DESCRIPTION
**This pull request makes the following changes:**

*Fixes issue #8940  
- Updates the Table of Contents slugs for "Intermediate Level" and "Advanced Level"  
  so they match the existing heading IDs (`id="intermediate"` and `id="advanced"`).  

This ensures that the links correctly scroll to the intended sections.

Note: "Beginner Level" already works both with `beginner` and `beginner-level`, 
because of the way `slugify("Beginners")` is handled.