### PR TITLE
fix: remove official resource link for comma-ok idiom in golang roadmap

### DIFF
--- a/src/data/roadmaps/golang/content/comma-ok-idiom@dMdOz2kUc8If3LcLZEfYf.md
+++ b/src/data/roadmaps/golang/content/comma-ok-idiom@dMdOz2kUc8If3LcLZEfYf.md
@@ -4,7 +4,6 @@ Pattern for safely testing map key existence or type assertion success using `va
 
 Visit the following resources to learn more:
 
-- [@official@Comma Ok](https://go.dev/tour/basics/10)
 - [@article@The Comma Ok Idiom ](https://dev.to/saurabh975/comma-ok-in-go-l4f)
 - [@article@How the Comma Ok Idiom and Package System Work in Go](https://www.freecodecamp.org/news/how-the-comma-ok-idiom-and-package-system-work-in-go/)
 - [@article@Statement Idioms in Go](https://medium.com/@nateogbonna/statement-idioms-in-go-writing-clean-idiomatic-go-code-6fe92e6e8ab4)


### PR DESCRIPTION
The official resource points to "Short variable declarations" which is a different topic