### PR TITLE
[Golang roadmap] - Moving links to a more relevant section of the map and adding relevant ones

### DIFF
--- a/public/roadmap-content/golang.json
+++ b/public/roadmap-content/golang.json
@@ -595,7 +595,7 @@
     "links": [
       {
         "title": "Structs",
-        "url": "https://go.dev/wiki/Well-known-struct-tags",
+        "url": "https://go.dev/tour/moretypes/2",
         "type": "article"
       },
       {
@@ -615,7 +615,7 @@
     "description": "Struct tags provide metadata about fields using backticks with key-value pairs. JSON tags control field names, omit empty fields, or skip fields. Example: `json:\"name,omitempty\"`. Essential for APIs and data serialization formats.\n\nVisit the following resources to learn more:",
     "links": [
       {
-        "title": "Structs",
+        "title": "Struct tags",
         "url": "https://go.dev/wiki/Well-known-struct-tags",
         "type": "article"
       },

--- a/public/roadmap-content/golang.json
+++ b/public/roadmap-content/golang.json
@@ -599,13 +599,8 @@
         "type": "article"
       },
       {
-        "title": "Working with JSON and Struct Tags",
-        "url": "https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0",
-        "type": "article"
-      },
-      {
-        "title": "Understanding Struct Tags and JSON Encoding in Go",
-        "url": "https://towardsdev.com/understanding-struct-tags-and-json-encoding-in-go-9e51d551c0ce",
+        "title": "Go Struct: A Deep Dive",
+        "url": "https://leapcell.medium.com/deep-dive-into-go-struct-103961431c64",
         "type": "article"
       }
     ]
@@ -622,6 +617,11 @@
       {
         "title": "Working with JSON and Struct Tags",
         "url": "https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0",
+        "type": "article"
+      },
+      {
+        "title": "Understanding Struct Tags and JSON Encoding in Go",
+        "url": "https://towardsdev.com/understanding-struct-tags-and-json-encoding-in-go-9e51d551c0ce",
         "type": "article"
       }
     ]

--- a/src/data/roadmaps/golang/content/struct-tags--json@SW2uMlhfC-dnQakShs2km.md
+++ b/src/data/roadmaps/golang/content/struct-tags--json@SW2uMlhfC-dnQakShs2km.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Struct tags](https://go.dev/wiki/Well-known-struct-tags)
 - [@article@Working with JSON and Struct Tags](https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0)
+- [@article@Understanding Struct Tags and JSON Encoding in Go](https://towardsdev.com/understanding-struct-tags-and-json-encoding-in-go-9e51d551c0ce)

--- a/src/data/roadmaps/golang/content/struct-tags--json@SW2uMlhfC-dnQakShs2km.md
+++ b/src/data/roadmaps/golang/content/struct-tags--json@SW2uMlhfC-dnQakShs2km.md
@@ -4,5 +4,5 @@ Struct tags provide metadata about fields using backticks with key-value pairs. 
 
 Visit the following resources to learn more:
 
-- [@official@Structs](https://go.dev/wiki/Well-known-struct-tags)
+- [@official@Struct tags](https://go.dev/wiki/Well-known-struct-tags)
 - [@article@Working with JSON and Struct Tags](https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0)

--- a/src/data/roadmaps/golang/content/structs@wRwt9JHZPmq8uapxMjn0a.md
+++ b/src/data/roadmaps/golang/content/structs@wRwt9JHZPmq8uapxMjn0a.md
@@ -5,5 +5,4 @@ Custom data types grouping related fields under single name. Similar to classes 
 Visit the following resources to learn more:
 
 - [@official@Structs](https://go.dev/tour/moretypes/2)
-- [@article@Working with JSON and Struct Tags](https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0)
-- [@article@Understanding Struct Tags and JSON Encoding in Go](https://towardsdev.com/understanding-struct-tags-and-json-encoding-in-go-9e51d551c0ce)
+- [@article@Go Struct: A Deep Dive](https://leapcell.medium.com/deep-dive-into-go-struct-103961431c64)

--- a/src/data/roadmaps/golang/content/structs@wRwt9JHZPmq8uapxMjn0a.md
+++ b/src/data/roadmaps/golang/content/structs@wRwt9JHZPmq8uapxMjn0a.md
@@ -4,6 +4,6 @@ Custom data types grouping related fields under single name. Similar to classes 
 
 Visit the following resources to learn more:
 
-- [@official@Structs](https://go.dev/wiki/Well-known-struct-tags)
+- [@official@Structs](https://go.dev/tour/moretypes/2)
 - [@article@Working with JSON and Struct Tags](https://medium.com/@sanyamdubey28/working-with-json-and-struct-tags-in-go-0e6a7c4fc6b0)
 - [@article@Understanding Struct Tags and JSON Encoding in Go](https://towardsdev.com/understanding-struct-tags-and-json-encoding-in-go-9e51d551c0ce)


### PR DESCRIPTION
## Problem
- The section on "Structs" contains links that are unrelated to its content: they focus on "Struct Tags" rather than core struct concepts.
- These links are also duplicated in the "Struct Tags" section.

## Solution - what PR does
- Removed the irrelevant links from the "Structs" section.
- Added relevant links that directly address core struct concepts.
- Relocated links related to "Struct Tags" to the appropriate section in the roadmap.