### PR TITLE
docs: update Development section (SSH, HTTPS, shallow clone examples)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,8 @@ Please consider sharing a post about [roadmap.sh](https://roadmap.sh) and the va
 
 Clone the repository, install the dependencies and start the application
 
+- uses SSH (requires you to set up SSH keys with GitHub)  ex.[git@github.com:...]
+
 ```bash
 git clone git@github.com:kamranahmedse/developer-roadmap.git
 cd developer-roadmap
@@ -136,7 +138,20 @@ npm install
 npm run dev
 ```
 
+- uses HTTPS (works out of the box, no keys needed ex.[https://github.com/...]
+
+```bash
+git clone https://github.com/kamranahmedse/developer-roadmap.git
+cd developer-roadmap
+npm install
+npm run dev
+```
+
 Note: use the `depth` parameter to reduce the clone size and speed up the clone.
+
+```sh
+git clone --depth=1 https://github.com/kamranahmedse/developer-roadmap.git
+```
 
 ```sh
 git clone --depth=1 https://github.com/kamranahmedse/developer-roadmap.git


### PR DESCRIPTION
### Summary
This PR updates the README `Development` section to make the setup instructions clearer and more concise.

### Changes
- Added clear subheadings for **SSH**, **HTTPS**, and **Shallow Clone** options
- Removed duplicate `--depth=1` example
- Included `cd developer-roadmap` step in the shallow clone instructions
- Improved formatting for better readability

### Why
The previous section had some duplication and could confuse first-time contributors.  
This update makes it easier for developers to choose the right cloning method quickly.
