### PR TITLE
Fix typo and related broken link

### DIFF
--- a/public/roadmap-content/technical-writer.json
+++ b/public/roadmap-content/technical-writer.json
@@ -51,8 +51,8 @@
       }
     ]
   },
-  "role-of-technical-writers-inorganizations@j69erqfosSZMDlmKcnnn0.md": {
-    "title": "Role of Technical Writers inOrganizations",
+  "role-of-technical-writers-in-organizations@j69erqfosSZMDlmKcnnn0.md": {
+    "title": "Role of Technical Writers in Organizations",
     "description": "",
     "links": []
   },


### PR DESCRIPTION
This PR adds a space to separate the words: in and Organization.

This change should update:
1. the content in the UI Button/ link "Role of Technical Writers inOrganizations"
2. the link for "Help us add resources to this topic" at the bottom of the card when you click on the button.

Review 1 and 2 in screenshot below:

<img width="2556" height="1864" alt="Brave Browser 2025-10-11 17 51 03" src="https://github.com/user-attachments/assets/8712b989-8b4f-4c0c-8a20-534eef84199d" />
