### PR TITLE
Fix Go roadmap: wrong link to article in Slices section

### DIFF
--- a/public/roadmap-content/golang.json
+++ b/public/roadmap-content/golang.json
@@ -437,7 +437,7 @@
       },
       {
         "title": "The new() vs make() Functions in Go",
-        "url": "https://nitish08.medium.com/loops-in-golang-d44fb39b08e",
+        "url": "https://www.freecodecamp.org/news/new-vs-make-functions-in-go/",
         "type": "article"
       },
       {

--- a/src/data/roadmaps/golang/content/slices@3aoMFQXIh3Qdo04isHwe_.md
+++ b/src/data/roadmaps/golang/content/slices@3aoMFQXIh3Qdo04isHwe_.md
@@ -5,5 +5,5 @@ Dynamic arrays built on top of arrays. Reference types with length and capacity.
 Visit the following resources to learn more:
 
 - [@official@make](https://go.dev/tour/moretypes/13)
-- [@article@The new() vs make() Functions in Go](https://nitish08.medium.com/loops-in-golang-d44fb39b08e)
+- [@article@The new() vs make() Functions in Go](https://www.freecodecamp.org/news/new-vs-make-functions-in-go/)
 - [@article@Slice Arrays Correctly](https://labex.io/tutorials/go-how-to-slice-arrays-correctly-418936)


### PR DESCRIPTION
This PR fixes a link in Slices section of Go roadmap.

<img width="1216" height="518" alt="Bildschirmfoto 2025-10-16 um 10 24 23" src="https://github.com/user-attachments/assets/43cad21e-874d-4575-b4d5-0bd27a6ad2ed" />
