### PR TITLE
Duplicate labels with literally the same content, one of them is deleted in this PR

### DIFF
--- a/src/data/roadmaps/data-engineer/content/streaming@wwPO5Uc6qnwYgibrbPn7y.md
+++ b/src/data/roadmaps/data-engineer/content/streaming@wwPO5Uc6qnwYgibrbPn7y.md
@@ -1,3 +1,0 @@
-# Streaming
-
-Streaming processing, also known as real-time processing, involves the immediate ingestion, as well as analysis, of data as it is generated, providing instantaneous insights and enabling timely decisions in time-sensitive applications like financial trading, medical monitoring, and autonomous vehicles. This differs from batch processing, which handles data in later batches, and typically involves continuous data streaming, low latency, and high availability to deliver immediate outcomes for critical tasks.


### PR DESCRIPTION
In **_Data Engineering_** roadmap at _**Types of Data Ingestion**_ section, there are 2 sub-labels with actually the same content and same meaning, I suggest them to be combined into just 1 label weather it's named as _**Streaming**_ or **_Realtime_**.

[Streaming Label](https://github.com/kamranahmedse/developer-roadmap/blob/master/src/data/roadmaps/data-engineer/content/streaming%40wwPO5Uc6qnwYgibrbPn7y.md)
<img width="400" height="300" alt="Image" src="https://github.com/user-attachments/assets/319ec26e-9a9d-4595-802c-c1932c58fc2c" />
[Realtime Label](https://github.com/kamranahmedse/developer-roadmap/blob/master/src/data/roadmaps/data-engineer/content/realtime%40oqxNr0Lj34mgRi5Z5wJt_.mdhttps://github.com/kamranahmedse/developer-roadmap/blob/master/src/data/roadmaps/data-engineer/content/realtime%40oqxNr0Lj34mgRi5Z5wJt_.md)
<img width="400" height="300" alt="Image" src="https://github.com/user-attachments/assets/8a214898-c3a4-4ae5-a035-c51fe1d3acb3" />

_So, I have just removed the Streaming label and left the Realtime as they both literally representing the same concept and meaning._