### PR TITLE
[Backend roadmap] Fixed broken Session Based Authentication guide URL in Authentication content

### DIFF
--- a/src/data/roadmaps/backend/content/authentication@PY9G7KQy8bF6eIdr1ydHf.md
+++ b/src/data/roadmaps/backend/content/authentication@PY9G7KQy8bF6eIdr1ydHf.md
@@ -5,7 +5,7 @@ API authentication verifies client identity to ensure only authorized access to 
 Visit the following resources to learn more:
 
 - [@article@Basic Authentication](https://roadmap.sh/guides/basic-authentication)
-- [@article@Session Based Authentication](https://roadmap.sh/guides/session-authentication)
+- [@article@Session Based Authentication](https://roadmap.sh/guides/session-based-authentication)
 - [@article@Token Based Authentication](https://roadmap.sh/guides/token-authentication)
 - [@article@JWT Authentication](https://roadmap.sh/guides/jwt-authentication)
 - [@article@OAuth - Open Authorization](https://roadmap.sh/guides/oauth)


### PR DESCRIPTION
In the [backend](https://roadmap.sh/backend) roadmap, the content card "Authentication" refers to the "Session Based Authentication" Article (roadmap.sh guide). However, the current URL is https://roadmap.sh/guides/session-authentication, which returns 404 Not Found.
I fixed it by adding -based in the resource name: https://roadmap.sh/guides/session-based-authentication -  it seems to be the target article to link.