### PR TITLE
Update link for defining dependency providers

### DIFF
--- a/src/data/roadmaps/angular/content/provider@dOMvz__EQjO-3p-Nzm-7P.md
+++ b/src/data/roadmaps/angular/content/provider@dOMvz__EQjO-3p-Nzm-7P.md
@@ -4,5 +4,5 @@ Configure the injector of component with a token that maps to a provider of a de
 
 Visit the following resources to learn more:
 
-- [@official@Configuring Dependency Providers](https://angular.dev/guide/di/dependency-injection-providers)
+- [@official@Defining dependency providers](https://angular.dev/guide/di/defining-dependency-providers)
 - [@official@Component API](https://angular.dev/api/core/Component#providers)


### PR DESCRIPTION
Page https://angular.dev/guide/di/guide/di/defining-dependency-providers does not exist anymore.
It got replaced with an updated one.