### PR TITLE
fix: ajust multiple mutation fields description

### DIFF
--- a/src/data/roadmaps/graphql/content/multiple-fields-in-mutation@AySlY8AyI6jE-cy-qKKOU.md
+++ b/src/data/roadmaps/graphql/content/multiple-fields-in-mutation@AySlY8AyI6jE-cy-qKKOU.md
@@ -1,6 +1,6 @@
 # Multiple Mutation Fields
 
-GraphQL allows multiple mutations in a single query by including multiple mutation fields, called batching or chaining mutations. This enables performing several data modifications atomically, improving efficiency and ensuring consistent state changes across related operations.
+GraphQL allows multiple mutations in a single query by including multiple mutation fields, a practice often called batching mutations. This approach improves network efficiency by reducing the number of round-trips between the client and server.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
# Multiple Mutation Fields are **NOT** atomic!

It is crucial to understand that these operations are not atomic by default. According to the specification, mutation fields within a single request are executed serially (one after the other). If one mutation fails, it does not roll back any previously successful mutations in the same request. This means your application must be prepared to handle partially successful data changes.

### **If the first mutation succeeds but the second mutation fails, the first one will not be rolled back.**