### PR TITLE
fix: SQL Tuning Broken link

### DIFF
--- a/src/data/roadmaps/system-design/content/sql-tuning@fY8zgbB13wxZ1CFtMSdZZ.md
+++ b/src/data/roadmaps/system-design/content/sql-tuning@fY8zgbB13wxZ1CFtMSdZZ.md
@@ -10,5 +10,5 @@ Benchmarking and profiling might point you to the following optimizations.
 Visit the following resources to learn more:
 
 - [@official@Introduction to SQL Tuning - Oracle](https://docs.oracle.com/en/database/oracle/oracle-database/23/tgsql/introduction-to-sql-tuning.html#GUID-B653E5F3-F078-4BBC-9516-B892960046A2)
-- [@article@Query Optimization for Mere Humans in PostgreSQL]([https://towardsdatascience.com/how-we-optimized-postgresql-queries-100x-ff52555eabe?gi=13caf5bcf32e](https://towardsdatascience.com/query-optimization-for-mere-humans-in-postgresql-875ab864390a/))
+- [@article@Query Optimization for Mere Humans in PostgreSQL](https://towardsdatascience.com/query-optimization-for-mere-humans-in-postgresql-875ab864390a/)
 - [@feed@Explore top posts about SQL](https://app.daily.dev/tags/sql?ref=roadmapsh)


### PR DESCRIPTION
Article mentioned in the scope is expired, this commit suggests a newer article from the same source.