### PR TITLE
Added frontend fix for signup name max length validation typo

### DIFF
--- a/src/components/AuthenticationFlow/EmailSignupForm.tsx
+++ b/src/components/AuthenticationFlow/EmailSignupForm.tsx
@@ -46,9 +46,11 @@ export function EmailSignupForm(props: EmailSignupFormProps) {
     if (error || response?.status !== 'ok') {
       setIsLoading(false);
       setIsDisabled?.(false);
-      setError(
-        error?.message || 'Something went wrong. Please try again later.',
-      );
+
+      const errorMessage = error?.message || 'Something went wrong. Please try again later.';
+      const correctedErrorMessage = errorMessage.replace(/Mame must be/g, 'Name must be');
+
+      setError(correctedErrorMessage);
 
       return;
     }


### PR DESCRIPTION
This is a frontend fix (should be temporary - may need to be handled from backend) of 'Name' typo in Signup Api response #9281
