### PR TITLE
Fix Python roadmap and Frontend roadmap links

### DIFF
--- a/src/data/roadmaps/full-stack/content/monit@y1SFX7uvWaCy4OYBnECLu.md
+++ b/src/data/roadmaps/full-stack/content/monit@y1SFX7uvWaCy4OYBnECLu.md
@@ -6,4 +6,3 @@ Visit the following resources to learn more:
 
 - [@official@Monit](https://mmonit.com/monit/)
 - [@official@Monit Documentation](https://mmonit.com/monit/documentation/)
-- [@video@Monit - Opensource Self Healing Server Monitoring](https://www.youtube.com/watch?v=3cA5lNje1Ow)

--- a/src/data/roadmaps/python/content/pipenv@IWq-tfkz-pSC1ztZl60vM.md
+++ b/src/data/roadmaps/python/content/pipenv@IWq-tfkz-pSC1ztZl60vM.md
@@ -1,6 +1,6 @@
 # pipenv
 
-Pipeline Environment (pipenv) is a tool that aims to bring the best of all packaging worlds (bundled, requirements.txt, [setup.py](http://setup.py), setup.cfg, etc.) to the Python world. It automatically creates and manages a virtualenv for your projects, as well as adds/removes packages from your Pipfile as you install/uninstall packages. It also generates the ever-important Pipfile.lock, which is used to produce deterministic builds.
+Pipeline Environment (pipenv) is a tool that aims to bring the best of all packaging worlds (bundled, requirements.txt, [setup.py](https://docs.python.org/3.11/distutils/setupscript.html), setup.cfg, etc.) to the Python world. It automatically creates and manages a virtualenv for your projects, as well as adds/removes packages from your Pipfile as you install/uninstall packages. It also generates the ever-important Pipfile.lock, which is used to produce deterministic builds.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Issues
- Fixes #9338 
- Fixes #9330 

Changes
- Remove invalid video link in the Monit description of Frontend roadmap
- Update `setup.py` link in the pipenv description of Python roadmap