### PR TITLE
fix : remove a link to a non existing page

### DIFF
--- a/src/data/roadmaps/golang/content/commands--docs@ywiNCAAvpSVXTwWwguxSZ.md
+++ b/src/data/roadmaps/golang/content/commands--docs@ywiNCAAvpSVXTwWwguxSZ.md
@@ -4,5 +4,4 @@ Go provides built-in documentation tools including `go doc` for terminal documen
 
 Visit the following resources to learn more:
 
-- [@official@Go Doc](https://go.dev/godoc)
 - [@article@A Guide to Effective Go Documentation](https://nirdoshgautam.medium.com/a-guide-to-effective-go-documentation-952f346d073f)


### PR DESCRIPTION
removed a link to a non existing page that was supposdely leading an official documenatation for go doc