### PR TITLE
Fix grammatical error in architecture documentation

### DIFF
--- a/src/data/roadmaps/spring-boot/content/architecture@yuXN-rD4AyyPYUYOR50L_.md
+++ b/src/data/roadmaps/spring-boot/content/architecture@yuXN-rD4AyyPYUYOR50L_.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Spring Boot follows a layered architecture in which each layer communicates with the layer directly below or above (hierarchical structure) it. There are four layers in Spring Boot are as follows:
+Spring Boot follows a layered architecture in which each layer communicates with the layer directly below or above (hierarchical structure) it. The four layers in Spring Boot are as follows:
 
 *   **Presentation Layer**: handles the HTTP requests, translates the JSON parameter to object, and authenticates the request and transfer it to the business layer.
 *   **Business Layer**: The business layer handles all the business logic. It consists of service classes and uses services provided by data access layers. It also performs authorization and validation.


### PR DESCRIPTION
### ✨ Summary

This PR addresses a minor grammatical error found in the content.

### 🚀 Motivation and Context

The grammatical error was found on the Spring Boot Roadmap page, available here for reference:

[spring-boot roadmap](https://roadmap.sh/spring-boot)

A redundant verb structure was identified in the section discussing the Architecture of Spring Boot

The incorrect phrasing was:

> "There are four layers in Spring Boot are as follows:"

This structure created a double verb error, affecting readability and correctness.

This PR corrects the statement to the proper grammatical structure:

> "The four layers in Spring Boot are as follows:"

The change ensures the content remains clear and professionally written.