### PR TITLE
Fix Go roadmap: Iterating Maps link caption text fix + adding badge article

### DIFF
--- a/src/data/roadmaps/golang/content/iterating-maps@Q6ic-AGG_gnXEOdmqom89.md
+++ b/src/data/roadmaps/golang/content/iterating-maps@Q6ic-AGG_gnXEOdmqom89.md
@@ -4,5 +4,5 @@ Use `for range` to iterate over maps, returns key and value pairs. Iteration ord
 
 Visit the following resources to learn more:
 
-- [Iterating Over Maps in Go: Methods, Order, and Best Practices](https://leapcell.io/blog/iterating-over-maps-in-go-methods-order-and-best-practices)
--[https://freshman.tech/snippets/go/iterate-over-map/](https://freshman.tech/snippets/go/iterate-over-map/)
+- [@article@Iterating Over Maps in Go: Methods, Order, and Best Practices](https://leapcell.io/blog/iterating-over-maps-in-go-methods-order-and-best-practices)
+- [@article@How to iterate over and order a map in Go](https://freshman.tech/snippets/go/iterate-over-map/)


### PR DESCRIPTION
This PR addresses links formatting in "Iterating Maps" section of Go Roadmap
<img width="896" height="533" alt="Bildschirmfoto 2025-11-11 um 19 24 33" src="https://github.com/user-attachments/assets/38137ae6-45be-423c-a240-ee5d29b47b27" />
