### PR TITLE
Fix linux roadmap content

### DIFF
--- a/src/data/roadmaps/linux/content/checking-service-status@xk5Xgi797HlVjdZJRfwX1.md
+++ b/src/data/roadmaps/linux/content/checking-service-status@xk5Xgi797HlVjdZJRfwX1.md
@@ -1,8 +1,9 @@
-# Creating Services
+# Service Status
 
-Creating Linux services involves setting up background applications using systemd service files. Services run continuously performing essential tasks like web servers, databases, and mail servers. Create `.service` files in `/etc/systemd/system/` with Unit, Service, and Install sections. Control services using `systemctl` commands. Best practice: avoid running services as root for security.
+Service status shows the current state of Linux services including network processes, backend servers, and background applications. Use `systemctl status service_name` to check service states through systemd manager. Example: `systemctl status apache2.service` shows Apache web server status. Essential for diagnosing problems, maintaining performance, and preventing service downtimes.
 
 Visit the following resources to learn more:
 
-- [@article@How to Create a systemd Service in Linux](https://linuxhandbook.com/create-systemd-services/)
-- [@article@A Beginner's Guide to Creating Linux Services](https://www.fosslinux.com/111815/a-guide-to-creating-linux-services-with-systemd.htm)
+- [@article@Service Management in Linux: A Comprehensive Guide](https://medium.com/@thesureshvadde/service-management-in-linux-a-comprehensive-guide-cb4c7e81dfa9)
+- [@article@Use Systemctl Status Command to Check Service Status](https://linuxhandbook.com/systemctl-check-service-status/)
+- [@article@How to Check All Running Services in Linux](https://www.2daygeek.com/how-to-check-all-running-services-in-linux/)

--- a/src/data/roadmaps/linux/content/creating-new-services@34UUrc8Yjc_8lvTL8itc3.md
+++ b/src/data/roadmaps/linux/content/creating-new-services@34UUrc8Yjc_8lvTL8itc3.md
@@ -1,9 +1,8 @@
-# Service Status
+# Creating Services
 
-Service status shows the current state of Linux services including network processes, backend servers, and background applications. Use `systemctl status service_name` to check service states through systemd manager. Example: `systemctl status apache2.service` shows Apache web server status. Essential for diagnosing problems, maintaining performance, and preventing service downtimes.
+Creating Linux services involves setting up background applications using systemd service files. Services run continuously performing essential tasks like web servers, databases, and mail servers. Create `.service` files in `/etc/systemd/system/` with Unit, Service, and Install sections. Control services using `systemctl` commands. Best practice: avoid running services as root for security.
 
 Visit the following resources to learn more:
 
-- [@article@Service Management in Linux: A Comprehensive Guide](https://medium.com/@thesureshvadde/service-management-in-linux-a-comprehensive-guide-cb4c7e81dfa9)
-- [@article@Use Systemctl Status Command to Check Service Status](https://linuxhandbook.com/systemctl-check-service-status/)
-- [@article@How to Check All Running Services in Linux](https://www.2daygeek.com/how-to-check-all-running-services-in-linux/)
+- [@article@How to Create a systemd Service in Linux](https://linuxhandbook.com/create-systemd-services/)
+- [@article@A Beginner's Guide to Creating Linux Services](https://www.fosslinux.com/111815/a-guide-to-creating-linux-services-with-systemd.htm)


### PR DESCRIPTION
**Issues**
In Linux roadmap, "Creating New Services" and "Checking Service Status" node titles do not align with their descriptions.

**Changes**
This PR swaps the contents of the two files.