### PR TITLE
Fix broken link to s element in html roadmap

### DIFF
--- a/src/data/roadmaps/html/content/s@Hx8mfbfkvRrBqLypE_NL3.md
+++ b/src/data/roadmaps/html/content/s@Hx8mfbfkvRrBqLypE_NL3.md
@@ -4,5 +4,5 @@ The `<s>` element in HTML represents content that is no longer accurate or relev
 
 Visit the following resources to learn more:
 
-- [@article@<s>: The Strikethrough element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/del)
+- [@article@<s>: The Strikethrough element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/s)
 - [@article@HTML s Tag: How it Works with Examples](https://flatcoding.com/tutorials/html/html-s-tag-how-it-works-with-examples/)


### PR DESCRIPTION
**Problem:**
The link to the s element documentation was incorrect, leading users to another element.

**Solution:**
This PR updates the URL to the correct address.
