### PR TITLE
fix: go roadmap excessive spaces and missing @article@ tag

### DIFF
--- a/src/data/roadmaps/golang/content/call-by-value@z8-8nt-3GA7uN-cvOI-Qn.md
+++ b/src/data/roadmaps/golang/content/call-by-value@z8-8nt-3GA7uN-cvOI-Qn.md
@@ -5,5 +5,5 @@ Go creates copies of values when passing to functions, not references to origina
 Visit the following resources to learn more:
 
 - [@article@Golang Call by Reference and Call by Value](https://www.scaler.com/topics/golang/golang-call-by-reference-and-call-by-value)
-- [Go Call by Value](https://www.includehelp.com/golang/go-call-by-value.aspx)
-- [Parameter Passing in Golang: The Ultimate Truth](https://dev.to/mahdifardi/parameter-passing-in-golang-the-ultimate-truth-1h0o)
+- [@article@Go Call by Value](https://www.includehelp.com/golang/go-call-by-value.aspx)
+- [@article@Parameter Passing in Golang: The Ultimate Truth](https://dev.to/mahdifardi/parameter-passing-in-golang-the-ultimate-truth-1h0o)

--- a/src/data/roadmaps/golang/content/comma-ok-idiom@dMdOz2kUc8If3LcLZEfYf.md
+++ b/src/data/roadmaps/golang/content/comma-ok-idiom@dMdOz2kUc8If3LcLZEfYf.md
@@ -4,6 +4,6 @@ Pattern for safely testing map key existence or type assertion success using `va
 
 Visit the following resources to learn more:
 
-- [@article@The Comma Ok Idiom ](https://dev.to/saurabh975/comma-ok-in-go-l4f)
+- [@article@The Comma Ok Idiom](https://dev.to/saurabh975/comma-ok-in-go-l4f)
 - [@article@How the Comma Ok Idiom and Package System Work in Go](https://www.freecodecamp.org/news/how-the-comma-ok-idiom-and-package-system-work-in-go/)
 - [@article@Statement Idioms in Go](https://medium.com/@nateogbonna/statement-idioms-in-go-writing-clean-idiomatic-go-code-6fe92e6e8ab4)

--- a/src/data/roadmaps/golang/content/performance-and-debugging@profiling-tools.md
+++ b/src/data/roadmaps/golang/content/performance-and-debugging@profiling-tools.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Debugging Performance](https://go.dev/wiki/Performance)
 - [@article@Unlocking Hidden Performance Bottlenecks in Golang](https://dev.to/aryanmehrotra/unlocking-hidden-performance-bottlenecks-in-golang-using-gofr-the-underrated-power-of-pprof-2dc7)
-- [@article@Advanced Profiling & Debugging for Go at Scale ](https://renaldid.medium.com/advanced-techniques-for-profiling-and-debugging-go-applications-at-scale-c1ce7a67e39f)
+- [@article@Advanced Profiling & Debugging for Go at Scale](https://renaldid.medium.com/advanced-techniques-for-profiling-and-debugging-go-applications-at-scale-c1ce7a67e39f)

--- a/src/data/roadmaps/golang/content/raw-string-literals@nzPe6XVqhtOZFbea6f2Hg.md
+++ b/src/data/roadmaps/golang/content/raw-string-literals@nzPe6XVqhtOZFbea6f2Hg.md
@@ -5,4 +5,4 @@ Enclosed in backticks (\`) and interpret characters literally without escape seq
 Visit the following resources to learn more:
 
 - [@official@Strings in Go](https://go.dev/blog/strings#what-is-a-string)
-- [@article@Golang Quick Reference: Strings. Introduction ](https://medium.com/@golangda/golang-quick-reference-strings-0d68bb036c29)
+- [@article@Golang Quick Reference: Strings. Introduction](https://medium.com/@golangda/golang-quick-reference-strings-0d68bb036c29)

--- a/src/data/roadmaps/golang/content/strings@ZxZpReGdPq8ziSlYmf2nj.md
+++ b/src/data/roadmaps/golang/content/strings@ZxZpReGdPq8ziSlYmf2nj.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@String](https://go.dev/blog/strings)
 - [@official@Go Speculation](https://go.dev/ref/spec)
-- [@article@Golang Quick Reference: Strings. Introduction ](https://medium.com/@golangda/golang-quick-reference-strings-0d68bb036c29)
+- [@article@Golang Quick Reference: Strings. Introduction](https://medium.com/@golangda/golang-quick-reference-strings-0d68bb036c29)


### PR DESCRIPTION
- In section call by value added missing "@article@" 
- removed some excessive spaces before closing ']' in link markup