### PR TITLE
improvement: Go roadmap provided links to official documentation for …

### DIFF
--- a/src/data/roadmaps/golang/content/goto-discouraged@O29VoTfPiU8GZ_c16ZJIp.md
+++ b/src/data/roadmaps/golang/content/goto-discouraged@O29VoTfPiU8GZ_c16ZJIp.md
@@ -4,6 +4,8 @@ Go includes `goto` statement but discourages its use. Can only jump to labels wi
 
 Visit the following resources to learn more:
 
+- [@official@Label scopes](https://go.dev/ref/spec#Label_scopes)
+- [@official@Goto statements](https://go.dev/ref/spec#Goto_statements)
 - [@article@Goto Statement Usage](https://labex.io/tutorials/go-goto-statement-usage-149074)
 - [@article@GoLang — Jumping in the code using goto](https://medium.com/@rajasoni1995/golang-jumping-in-the-code-using-goto-a36116831396)
 - [@article@Goto Hell With Labels in Golang](https://programmingpercy.tech/blog/goto-hell-with-labels-in-golang/)


### PR DESCRIPTION
<img width="709" height="665" alt="Bildschirmfoto 2025-11-17 um 21 57 25" src="https://github.com/user-attachments/assets/ccbd344a-3d16-42c5-baa2-1d709556e774" />

In this change proposed 2 links to official documentation which contains general information about labels and goto statement