### PR TITLE
Add content for GitHub Pages in frontend roadmap

### DIFF
--- a/src/data/roadmaps/frontend/content/github-pages@vpzh9bNXCxgdDFQLsot2_.md
+++ b/src/data/roadmaps/frontend/content/github-pages@vpzh9bNXCxgdDFQLsot2_.md
@@ -1,0 +1,12 @@
+# GitHub Pages
+
+GitHub Pages is a free static site hosting service that takes HTML, CSS, and JavaScript files directly from a GitHub repository and publishes them as a website. It's ideal for hosting project documentation, portfolios, blogs, and other static websites. Pages supports custom domains, HTTPS, and Jekyll for automatic site generation. Each repository can have one project site, while user and organization accounts get one primary site at username.github.io.
+
+Visit the following resources to learn more:
+
+- [@official@GitHub Pages Documentation](https://docs.github.com/en/pages)
+- [@official@GitHub Pages Quickstart](https://docs.github.com/en/pages/quickstart)
+- [@article@Getting Started with GitHub Pages](https://www.freecodecamp.org/news/what-is-github-pages/)
+- [@video@GitHub Pages Tutorial - Host a Website for Free](https://www.youtube.com/watch?v=8hrJ4oN1u_8)
+- [@video@GitHub Pages - Full Tutorial](https://www.youtube.com/watch?v=o5g-lUuFgpg)
+- [@feed@Explore top posts about GitHub](https://app.daily.dev/tags/github?ref=roadmapsh)

--- a/src/data/roadmaps/frontend/content/github-pages@vpzh9bNXCxgdDFQLsot2_.md
+++ b/src/data/roadmaps/frontend/content/github-pages@vpzh9bNXCxgdDFQLsot2_.md
@@ -9,4 +9,3 @@ Visit the following resources to learn more:
 - [@article@Getting Started with GitHub Pages](https://www.freecodecamp.org/news/what-is-github-pages/)
 - [@video@GitHub Pages Tutorial - Host a Website for Free](https://www.youtube.com/watch?v=8hrJ4oN1u_8)
 - [@video@GitHub Pages - Full Tutorial](https://www.youtube.com/watch?v=o5g-lUuFgpg)
-- [@feed@Explore top posts about GitHub](https://app.daily.dev/tags/github?ref=roadmapsh)


### PR DESCRIPTION
This PR adds content to the GitHub Pages topic in the frontend roadmap, which previously had no content.

https://github.com/kamranahmedse/developer-roadmap/tree/master/src/data/roadmaps/frontend/content/rolldown@hE-DbpBpYrfB8tmBEjTnG.md

## Changes Made

- Added comprehensive content for `github-pages@vpzh9bNXCxgdDFQLsot2_.md`
- Included a concise explanation of what GitHub Pages is and its key features
- Added 6 curated learning resources with proper type tags:
  - Official GitHub Pages documentation and quickstart guide
  - Educational article from FreeCodeCamp
  - Two video tutorials
  - Daily.dev feed for GitHub topics

## Checklist

- [x] Content is in English
- [x] Content is concise (single paragraph explanation)
- [x] Maximum of 8 links per topic (added 6)
- [x] No GeeksForGeeks links
- [x] Proper @type@ tags used (@official@, @article@, @video@, @feed@)
- [x] Followed the content structure format from contributing guidelines
- [x] Content adds value to users learning frontend development