### PR TITLE
fix: go roadmap pointers dead link to willworth clean up

### DIFF
--- a/src/data/roadmaps/golang/content/pointers-basics@P0fUxEbb3bVYg35VWyg8R.md
+++ b/src/data/roadmaps/golang/content/pointers-basics@P0fUxEbb3bVYg35VWyg8R.md
@@ -5,4 +5,3 @@ Variables storing memory addresses of other variables. Declared with `*Type`, de
 Visit the following resources to learn more:
 
 - [@official@Pointers](https://go.dev/tour/moretypes/1)
-- [@article@Complete Guide to Pointers in Go: From Basics to Best Practices](https://www.willworth.dev/Go-Pointers)

--- a/src/data/roadmaps/golang/content/pointers@naBjKGrTBzlpapXzLHfvG.md
+++ b/src/data/roadmaps/golang/content/pointers@naBjKGrTBzlpapXzLHfvG.md
@@ -6,4 +6,3 @@ Visit the following resources to learn more:
 
 - [@official@Pointers](https://go.dev/tour/moretypes/1)
 - [@article@Understanding Value and Pointer Receivers in Golang](https://medium.com/the-bug-shots/understanding-value-and-pointer-receivers-in-golang-82dd73a3eef9)
-- [@article@Complete Guide to Pointers in Go: From Basics to Best Practices](https://www.willworth.dev/Go-Pointers)

--- a/src/data/roadmaps/golang/content/with-maps--slices@oAvCO3GOKktkbmPahkPlT.md
+++ b/src/data/roadmaps/golang/content/with-maps--slices@oAvCO3GOKktkbmPahkPlT.md
@@ -7,4 +7,3 @@ Visit the following resources to learn more:
 - [@official@Maps](https://go.dev/blog/maps)
 - [@official@Pointers](https://go.dev/tour/moretypes/1)
 - [@article@Slice Arrays Correctly](https://labex.io/tutorials/go-how-to-slice-arrays-correctly-418936)
-- [@article@Complete Guide to Pointers in Go: From Basics to Best Practices](https://www.willworth.dev/Go-Pointers)


### PR DESCRIPTION
https://willworth.dev/Go-Memory leads to this page: 

<img width="1533" height="474" alt="Bildschirmfoto 2025-11-22 um 11 54 50" src="https://github.com/user-attachments/assets/1a05b49c-5311-4226-b47d-1e253d07c495" />
