### PR TITLE
close icon on user progress modal fixed

### DIFF
--- a/src/components/UserProgress/UserProgressModal.tsx
+++ b/src/components/UserProgress/UserProgressModal.tsx
@@ -230,7 +230,7 @@ export function UserProgressModal(props: ProgressMapProps) {
 
           <button
             type="button"
-            className={`absolute top-3 right-2.5 ml-auto inline-flex items-center rounded-lg bg-gray-100 bg-transparent p-1.5 text-sm text-gray-400 hover:text-gray-900 lg:hidden`}
+            className={`absolute top-3 right-2.5 ml-auto inline-flex items-center rounded-lg bg-gray-100 bg-transparent p-1.5 text-sm text-gray-400 hover:text-gray-900`}
             onClick={onClose}
           >
             <X className="h-4 w-4" />


### PR DESCRIPTION
fixes: #9491

Before:
<img width="1139" height="400" alt="image" src="https://github.com/user-attachments/assets/4945ccdb-f64c-4376-b1ae-19fa0f91b1c4" />

Now:
<img width="1764" height="347" alt="image" src="https://github.com/user-attachments/assets/410aae10-7e55-4812-9bee-16dc27fd3999" />
