### PR TITLE
tweak hard coded url for /roadmaps page

### DIFF
--- a/src/components/Roadmaps/RoadmapsPage.tsx
+++ b/src/components/Roadmaps/RoadmapsPage.tsx
@@ -566,7 +566,7 @@ const groups: GroupType[] = [
       },
       {
         title: 'AWS',
-        link: '/aws-review-best-practices',
+        link: '/aws-best-practices',
         type: 'best-practice',
         otherGroups: ['Web Development', 'DevOps'],
       },


### PR DESCRIPTION
Hello there! I stumbled upon the awesome work on roadmap.sh and found a very subtle typo on the `/roadmaps` page.  Taking the opportunity to contribute back real quick.

Here is the repro steps.
1. Navigate to [roadmap.sh/roadm](https://roadmap.sh/roadmaps).
2. Click on `AWS` under the Best Practices section.
3. You'll see the URL `https://roadmap.sh/aws-review-best-practices` and the page won't load.

This _should_ be directed to `/aws-best-practices` to align with the URL in `astro-config.mjs`.  

This PR make a very quick change to `RoadmapsPage.tsx`