### PR TITLE
fix: add reminder to change env before development

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,7 @@ Run the development server with:
 ```bash
 pnpm dev
 ```
+> Make sure to rename `.env.example` to `.env` before running the app.
 
 ## Contribution
 


### PR DESCRIPTION
It's can be a bit frustrating if new contributors can't figure out how to run roadmap locally so I added a small reminder.