### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/close-feedback-pr.yml
+++ b/.github/workflows/close-feedback-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close PR if it has label "feedback left" and no changes in 7 days
-        uses: actions/github-script@v3
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4.0.0

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add Labels To Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sync-content-to-repo.yml
+++ b/.github/workflows/sync-content-to-repo.yml
@@ -12,7 +12,7 @@ jobs:
   sync-content:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm@v9
         uses: pnpm/action-setup@v4
@@ -21,7 +21,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js Version 20 (LTS)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -44,7 +44,7 @@ jobs:
       
       - name: Create PR
         if: steps.verify-changed-files.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           delete-branch: false
           branch: "chore/sync-content-to-repo-${{ inputs.roadmap_slug }}"

--- a/.github/workflows/sync-repo-to-database.yml
+++ b/.github/workflows/sync-repo-to-database.yml
@@ -11,7 +11,7 @@ jobs:
   sync-roadmap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm@v9
         uses: pnpm/action-setup@v4
@@ -20,7 +20,7 @@ jobs:
           run_install: false
 
       - name: Setup Node.js Version 20 (LTS)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -9,10 +9,10 @@ jobs:
   upgrade-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js Version 20 (LTS)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -28,7 +28,7 @@ jobs:
           pnpm install --lockfile-only
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           delete-branch: false
           branch: "update-deps"


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/sync-repo-to-database.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/upgrade-dependencies.yml`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/sync-content-to-repo.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sync-content-to-repo.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/sync-content-to-repo.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/deployment.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/deployment.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/label-issue.yml`
- Updated `actions/github-script` from `v3` to `v8` in `.github/workflows/close-feedback-pr.yml`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/upgrade-dependencies.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/upgrade-dependencies.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/sync-repo-to-database.yml`
