### PR TITLE
update: change links to CSS course

### DIFF
--- a/src/data/roadmaps/css/content/css@9ZUXy6s9IAIEM5GHk_bXR.md
+++ b/src/data/roadmaps/css/content/css@9ZUXy6s9IAIEM5GHk_bXR.md
@@ -4,7 +4,7 @@ CSS (Cascading Style Sheets) is a language used to describe the presentation of 
 
 Visit the following resources to learn more:
 
-- [@course@Responsive Web Design Certification - Co-Learn HTML & CSS with guided projects](https://www.freecodecamp.org/learn/2022/responsive-web-design/)
+- [@course@Responsive Web Design Certification - Co-Learn HTML & CSS with guided projects](https://www.freecodecamp.org/learn/responsive-web-design-v9/)
 - [@course@Web.dev by Google — Learn CSS](https://web.dev/learn/css/)
 - [@article@Visit Dedicated JavaScript Roadmap](https://roadmap.sh/css)
 - [@video@CSS Complete Course](https://www.youtube.com/watch?v=n4R2E7O-Ngo)

--- a/src/data/roadmaps/frontend/content/css@ZhJhf1M2OphYbEmduFq-9.md
+++ b/src/data/roadmaps/frontend/content/css@ZhJhf1M2OphYbEmduFq-9.md
@@ -5,7 +5,7 @@ CSS (Cascading Style Sheets) styles HTML documents, controlling layout, colors, 
 Visit the following resources to learn more:
 
 - [@roadmap@Visit the Dedicated CSS Roadmap](https://roadmap.sh/css)
-- [@course@Responsive Web Design Certification - Co-Learn HTML & CSS with guided projects](https://www.freecodecamp.org/learn/2022/responsive-web-design/)
+- [@course@Responsive Web Design Certification - Co-Learn HTML & CSS with guided projects](https://www.freecodecamp.org/learn/responsive-web-design-v9/)
 - [@article@Web.dev by Google — Learn CSS](https://web.dev/learn/css/)
 - [@video@CSS Complete Course](https://youtu.be/n4R2E7O-Ngo)
 - [@video@HTML & CSS Full Course - Beginner to Pro](https://www.youtube.com/watch?v=G3e-cpL7ofc)


### PR DESCRIPTION
links for the Responsive Web Design course in the CSS and Frontend roadmaps now point to the latest version of the course