### PR TITLE
fix: typo "Databsases" in data-engineer.json

### DIFF
--- a/src/data/roadmaps/data-engineer/data-engineer.json
+++ b/src/data/roadmaps/data-engineer/data-engineer.json
@@ -2190,7 +2190,7 @@
       "draggable": true,
       "deletable": true,
       "data": {
-        "label": "NoSQL Databsases",
+        "label": "NoSQL Databases",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
Fix typo Databsases to Databases