### PR TITLE
fix: Variable Replacement does not work properly in team roadmaps, Issue Number: #9557

### DIFF
--- a/src/components/RoadmapHeader.astro
+++ b/src/components/RoadmapHeader.astro
@@ -15,6 +15,7 @@ import { ShareRoadmapButton } from './ShareRoadmapButton';
 import { TabLink } from './TabLink';
 import { PersonalizedRoadmap } from './PersonalizedRoadmap/PersonalizedRoadmap';
 import RoadmapFeedbackAlert from './Roadmaps/RoadmapFeedbackAlert.astro';
+import {markdownToHtml} from '../lib/markdown';
 
 export interface Props {
   title: string;
@@ -116,8 +117,8 @@ const hasProjects = projectCount > 0;
       <h1 class='mb-0.5 text-2xl font-bold sm:mb-3.5 sm:text-5xl'>
         {title}
       </h1>
-      <p class='text-sm text-balance text-gray-500 sm:text-lg'>
-        {description}
+      <p class='text-sm text-balance text-gray-500 sm:text-lg' set:html={markdownToHtml(description)}>
+        
       </p>
     </div>
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -24,10 +24,11 @@ const md = new MarkdownIt({
 
 export function markdownToHtml(markdown: string, isInline = true): string {
   try {
+    const replacedMarkdown = replaceVariables(markdown);
     if (isInline) {
-      return md.renderInline(markdown);
+      return md.renderInline(replacedMarkdown);
     } else {
-      return md.render(markdown);
+      return md.render(replacedMarkdown);
     }
   } catch (e) {
     return markdown;
@@ -86,7 +87,8 @@ export async function markdownToHtmlWithHighlighting(markdown: string) {
       return defaultRender(tokens, idx, options, env, self);
     };
 
-    return markdownItAsync.renderAsync(markdown);
+    return markdownItAsync.renderAsync(replaceVariables(markdown));
+
   } catch (e) {
     return markdown;
   }


### PR DESCRIPTION
The Bug:
The variable '@currentYear@' was not replaced by the new Date().getFullYear().toString() as expected by the replaceVariables function in src/lib/markdown.ts.
It is displayed as raw text '@currentYear@' in the page view. You can check this for yourself using the link above or by looking at the picture below.

The solution:

The markdown in markdownToHtml was not using the replaceVariables function so it was not being replaced

also changed the p tag to use the markdownToHtml function

works as expected now
<img width="1387" height="586" alt="image" src="https://github.com/user-attachments/assets/f9dbcb5c-528e-48d6-bbbe-3bac5adcf256" />
