### PR TITLE
Fix(docs): fix typo "wWhat" to "What" in SSR & CSR video link

### DIFF
--- a/src/data/roadmaps/frontend/content/ssr@Cxspmb14_0i1tfw-ZLxEu.md
+++ b/src/data/roadmaps/frontend/content/ssr@Cxspmb14_0i1tfw-ZLxEu.md
@@ -5,6 +5,6 @@ Server-side rendering (SSR) generates complete HTML on the server before sending
 Visit the following resources to learn more:
 
 - [@article@Server-Side Rendering (SSR)](https://vuejs.org/guide/scaling-up/ssr.html)
-- [@video@wWhat are Server Side Rendering (SSR) & Client Side Rendering (CSR)](https://www.youtube.com/watch?v=ObrSuDYMl1s)
+- [@video@What are Server Side Rendering (SSR) & Client Side Rendering (CSR)](https://www.youtube.com/watch?v=ObrSuDYMl1s)
 - [@video@What is server-side rendering for web development?](https://www.youtube.com/watch?v=okvg3MRAPs0)
 - [@feed@Explore top posts about Web Development](https://app.daily.dev/tags/webdev?ref=roadmapsh)


### PR DESCRIPTION
Fixed a spelling mistake in the video reference by changing "wWhat" to "What" to improve readability and maintain documentation quality.