### PR TITLE
docs: add missing explanations to Python roadmap content

### DIFF
--- a/src/data/roadmaps/python/content/black@DS6nuAUhUYcqiJDmQisKM.md
+++ b/src/data/roadmaps/python/content/black@DS6nuAUhUYcqiJDmQisKM.md
@@ -1,5 +1,7 @@
 # black
 
+Black is a python code formatter that automatically formats code according to a consistent style. By removing formatting decisions from developers, Black helps maintain uniform codebases, improves readability, and reduces time spent on style discussions during code reviews.
+
 Visit the following resources to learn more:
 
 - [@official@Getting Started with Black](https://black.readthedocs.io/en/stable/getting_started.html)

--- a/src/data/roadmaps/python/content/exceptions@fNTb9y3zs1HPYclAmu_Wv.md
+++ b/src/data/roadmaps/python/content/exceptions@fNTb9y3zs1HPYclAmu_Wv.md
@@ -1,5 +1,7 @@
 # Exceptions
 
+Exceptions are runtime errors that occur during program execution in Python. Instead of immediately stopping the program, Python allows developers to handle these errors using `try`, `except`, `else`, and `finally` blocks. Proper exception handling helps manage unexpected situations such as invalid input, missing files, or network failures, improving program reliability and allowing applications to fail gracefully.
+
 Visit the following resources to learn more:
 
 - [@official@Exceptions Documentation](https://docs.python.org/3/tutorial/errors.html#exceptions)

--- a/src/data/roadmaps/python/content/fast-api@XeQSmvAsGSTi8dd7QVHxn.md
+++ b/src/data/roadmaps/python/content/fast-api@XeQSmvAsGSTi8dd7QVHxn.md
@@ -1,5 +1,7 @@
 # FastAPI
 
+FastAPI is a modern Python web framework used for building APIs with high performance and automatic documentation. It leverages Python type hints for request validation, serialization, and editor support, making API development faster and less error-prone. FastAPI is commonly used for backend services, microservices, and machine learning model deployment due to its speed and ease of use.
+
 Visit the following resources to learn more:
 
 - [@official@FastAPI Documentation](https://fastapi.tiangolo.com/)

--- a/src/data/roadmaps/python/content/ruff@6cB0pvUO1-gvCtgqozP-Q.md
+++ b/src/data/roadmaps/python/content/ruff@6cB0pvUO1-gvCtgqozP-Q.md
@@ -1,5 +1,7 @@
 # ruff
 
+Ruff is a fast Python linter and code quality tool written in Rust that combines the functionality of multiple linting and formatting tools into a single, high-performance utility. It helps detect errors, enforce coding standards, and improve code quality while running significantly faster than traditional Python linters.
+
 Visit the following resources to learn more:
 
 - [@official@Ruff documentation](https://docs.astral.sh/ruff/)

--- a/src/data/roadmaps/python/content/tuples@i7xIGiXU-k5UIKHIhQPjE.md
+++ b/src/data/roadmaps/python/content/tuples@i7xIGiXU-k5UIKHIhQPjE.md
@@ -1,5 +1,7 @@
 # Tuples
 
+A tuple is an ordered and immutable collection of elements in Python. Unlike lists, tuples cannot be modified after creation, making them useful for storing fixed data such as coordinates, configuration values, or records that should remain unchanged. Tuples support indexing, iteration, and unpacking, and because they are immutable, they can also be used as dictionary keys or returned safely from functions as multiple values.
+
 Visit the following resources to learn more:
 
 - [@official@Tuples Documentation](https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences)

--- a/src/data/roadmaps/python/content/typing@o1wi39VnjnFfWIC8XcuAK.md
+++ b/src/data/roadmaps/python/content/typing@o1wi39VnjnFfWIC8XcuAK.md
@@ -1,5 +1,7 @@
 # Typing
 
+The `typing` module provides support for type hints in Python, allowing developers to specify expected data types for variables, function parameters, and return values. Type hints improve code readability, enable better editor support and static analysis, and help catch potential bugs early without changing how Python executes programs at runtime.
+
 Visit the following resources to learn more:
 
 - [@official@Typing Module](https://docs.python.org/3/library/typing.html)


### PR DESCRIPTION
Add single-paragraph explanations to 6 Python roadmap topics:
- black, exceptions, FastAPI, ruff, tuples, typing