### PR TITLE
docs(dart): replace overview link with full Functions guide.

### DIFF
--- a/src/data/roadmaps/flutter/content/functions@Pek6vOO-qKCetTznCGv6f.md
+++ b/src/data/roadmaps/flutter/content/functions@Pek6vOO-qKCetTznCGv6f.md
@@ -4,4 +4,4 @@ Dart is a true object-oriented language, so even functions are objects and have 
 
 Visit the following resources to learn more:
 
-- [@official@Functions](https://dart.dev/guides/language/language-tour#functions)
+- [@official@Functions](https://dart.dev/language/functions)


### PR DESCRIPTION
Switches from the language-tour anchor to the dedicated Functions page to provide complete documentation instead of a summary.