### PR TITLE
feat: update heading format for Model Context Protocol (MCP)

### DIFF
--- a/src/data/roadmaps/frontend/content/mcp@XFy2gj7DmXeaCoc6MZo_j.md
+++ b/src/data/roadmaps/frontend/content/mcp@XFy2gj7DmXeaCoc6MZo_j.md
@@ -1,4 +1,4 @@
-Model Context Protocol (MCP)
+# Model Context Protocol (MCP)
 
 Model Context Protocol (MCP) is a rulebook that tells an AI agent how to pack background information before it sends a prompt to a language model. It lists what pieces go into the prompt—things like the system role, the user’s request, past memory, tool calls, or code snippets—and fixes their order. Clear tags mark each piece, so both humans and machines can see where one part ends and the next begins. Keeping the format steady cuts confusion, lets different tools work together, and makes it easier to test or swap models later. When agents follow MCP, the model gets a clean, complete prompt and can give better answers.
 


### PR DESCRIPTION
The 'MCP' section header shows as 'undefined', changed it to be the correct format