### PR TITLE
docs: add spec-driven development video to vibe coding planning resources

### DIFF
--- a/src/data/roadmaps/vibe-coding/content/plan-before-you-code@pfgsxuQ-D7dTMPNWKG9OY.md
+++ b/src/data/roadmaps/vibe-coding/content/plan-before-you-code@pfgsxuQ-D7dTMPNWKG9OY.md
@@ -6,4 +6,5 @@ Visit the following resources to learn more:
 
 - [@article@From vibe coding to vibe planning](https://tessl.io/blog/from-vibe-coding-to-vibe-planning/)
 - [@article@Advance Planning for AI Project Evaluation](https://towardsdatascience.com/advance-planning-for-ai-project-evaluation/?utm_source=roadmap&utm_medium=Referral&utm_campaign=TDS+roadmap+integration)
+- [@video@Spec-Driven Development: AI Assisted Coding Explained](https://www.youtube.com/watch?v=mViFYTwWvcM)
 - [@video@Vibe Planning: The Smarter Way to Code with AI Agents](https://www.youtube.com/watch?v=B4uD9z6i_IU)


### PR DESCRIPTION
## Summary
- add a new `@video@` resource to the `Plan before you Code` topic in the Vibe Coding roadmap
- resource added: Spec-Driven Development: AI Assisted Coding Explained

## Why
- this video fits the planning/spec-first guidance of this topic
- keeps resource formatting consistent with existing roadmap content
