### PR TITLE
docs: fix 'Programing' typo in Bash roadmap content

### DIFF
--- a/src/data/roadmaps/shell-bash/content/arithmetic-expansion@LHoR6krZTuJW5BGiKf_AT.md
+++ b/src/data/roadmaps/shell-bash/content/arithmetic-expansion@LHoR6krZTuJW5BGiKf_AT.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@Arithmetic Expansion (Bash Reference Manual)](https://www.gnu.org/software/bash/manual/html_node/Arithmetic-Expansion.html)
 - [@article@Bash Math Operations (Bash Arithmetic) Explained {+11 Examples}](https://phoenixnap.com/kb/bash-math)
-- [@video@Arithmetic Expressions - Bash Programing Tutorial 4](https://www.youtube.com/watch?v=rjuB3X8MOQc)
+- [@video@Arithmetic Expressions - Bash Programming Tutorial 4](https://www.youtube.com/watch?v=rjuB3X8MOQc)

--- a/src/data/roadmaps/shell-bash/content/arithmetic@60ika3rjs42VIk-3AcOdq.md
+++ b/src/data/roadmaps/shell-bash/content/arithmetic@60ika3rjs42VIk-3AcOdq.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@Bash Math Operations (Bash Arithmetic) Explained](https://phoenixnap.com/kb/bash-math)
 - [@article@Bash Operators](https://www.w3schools.com/bash/bash_operators.php)
-- [@video@Arithmetic Expressions - Bash Programing Tutorial](https://www.youtube.com/watch?v=rjuB3X8MOQc)
+- [@video@Arithmetic Expressions - Bash Programming Tutorial](https://www.youtube.com/watch?v=rjuB3X8MOQc)

--- a/src/data/roadmaps/shell-bash/content/comparison@XUDkgfURAsI_A3v3EPZA_.md
+++ b/src/data/roadmaps/shell-bash/content/comparison@XUDkgfURAsI_A3v3EPZA_.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [@article@Other Comparison Operators](https://tldp.org/LDP/abs/html/comparison-ops.html)
 - [@article@Bash Operators](https://www.w3schools.com/bash/bash_operators.php)
 - [@article@Shell Scripting: Comparison Operators and If Statements](https://medium.com/@kadimasam/shell-scripting-comparison-operators-and-if-statements-9e0277fd60b8)
-- [@video@Comparison Operators and Square Brackets - Bash Programing Tutorial](https://www.youtube.com/watch?v=XSLj65wnP90)
+- [@video@Comparison Operators and Square Brackets - Bash Programming Tutorial](https://www.youtube.com/watch?v=XSLj65wnP90)

--- a/src/data/roadmaps/shell-bash/content/logical@tRwO9DC_ZUD4g5iSVC40u.md
+++ b/src/data/roadmaps/shell-bash/content/logical@tRwO9DC_ZUD4g5iSVC40u.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@How to program with Bash: Logical operators and shell expansions](https://opensource.com/article/19/10/programming-bash-logical-operators-shell-expansions)
 - [@article@Using Logical Operators in Bash: A Comprehensive Guide](https://tecadmin.net/bash-logical-operators/)
-- [@video@Logical Operators - Bash Programing Tutorial 8](https://www.youtube.com/watch?v=sDRHmbRlNT8)
+- [@video@Logical Operators - Bash Programming Tutorial 8](https://www.youtube.com/watch?v=sDRHmbRlNT8)


### PR DESCRIPTION
Fixed several occurrences of 'Programing' (should be 'Programming') in the Bash roadmap tutorial links.