### PR TITLE
fix: typos and grammatical fixes in about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -78,8 +78,8 @@ const repoRank = await getRepositoryRank('kamranahmedse/developer-roadmap');
               class='font-bold underline'
               >the {repoRank} most starred opensource project on GitHub</a
             > and gets visited by hundreds of thousands of developers every month.
-            We also have newsletter with 150,000+ developers. All the roadmaps are
-            created and reviewed by community and several subject matter experts.
+            We also have a newsletter with 150,000+ developers. All the roadmaps are
+            created and reviewed by the community and several subject matter experts.
             Also, anyone can suggest changes to any roadmap and we have a process
             to review and approve them.
           </p>
@@ -94,9 +94,9 @@ const repoRank = await getRepositoryRank('kamranahmedse/developer-roadmap');
             developers whenever they plan on learning something new. We started
             with roadmaps, guides, videos and other visual content but we plan
             on introducing best practices, best-practices for certain tasks, quizzes
-            to test your knowledge and prepare yourself for the interviews,
+            to test your knowledge and prepare yourself for interviews,
             project ideas to work on while following the roadmaps, public
-            profiles to share your progress and interact with the other learners
+            profiles to share your progress and interact with other learners
             and so on.
           </p>
         </div>
@@ -119,12 +119,12 @@ const repoRank = await getRepositoryRank('kamranahmedse/developer-roadmap');
               class='font-bold underline'
               target='_blank'
               rel='nofollow'>GitHub pages</a
-            >. The project is open-core and the codebase
+            >. The project is open-core and the codebase 
             <a
               href='https://github.com/kamranahmedse/developer-roadmap'
               class='font-bold underline'
               target='_blank'>can be found on GitHub</a
-            >
+            >.
           </p>
         </div>
 
@@ -194,7 +194,7 @@ const repoRank = await getRepositoryRank('kamranahmedse/developer-roadmap');
               class='underline font-bold'
               href='https://twitter.com/kamrify'
               target='_blank'>@kamrify</a
-            > or email me at
+            > or email me at 
             <a
               class='underline font-bold'
               href='mailto:kamranahmed.se@gmail.com'


### PR DESCRIPTION
Minor typos and grammatical fixes in the 'About' page.

The 'What are the plans for roadmap.sh?' section can be written up much better (e.g. the term 'best practices' is written twice right after eachother).