### PR TITLE
Fix: update PostgreSQL columns documentation link

### DIFF
--- a/src/data/roadmaps/postgresql-dba/content/columns@cty2IjgS1BWltbYmuxxuV.md
+++ b/src/data/roadmaps/postgresql-dba/content/columns@cty2IjgS1BWltbYmuxxuV.md
@@ -4,5 +4,5 @@ Columns are a fundamental component of PostgreSQL's object model. They are used 
 
 Learn more from the following resources:
 
-- [@official@Columns](https://www.postgresql.org/docs/current/infoschema-columns.html)
+- [@official@Columns](https://www.postgresql.org/docs/current/ddl-alter.html)
 - [@article@PostgreSQL ADD COLUMN](https://www.w3schools.com/postgresql/postgresql_add_column.php)


### PR DESCRIPTION
## What does this PR do?

Fixes the broken link for PostgreSQL columns documentation in the PostgreSQL DBA roadmap.

## Changes

- Updated the link from `https://www.postgresql.org/docs/current/infoschema-columns.html` to `https://www.postgresql.org/docs/current/ddl-alter.html`

## Why

The DDL alter page provides more comprehensive information about columns in PostgreSQL, including how to add, modify, and drop columns, which is more relevant for DBAs than the info schema reference.

## Fixes

Fixes #9690
