### PR TITLE
fix: unnecessary brackets

### DIFF
--- a/src/data/roadmaps/golang/content/mocks-and-stubs@LjLbm4JEZ19howOkju7zQ.md
+++ b/src/data/roadmaps/golang/content/mocks-and-stubs@LjLbm4JEZ19howOkju7zQ.md
@@ -4,7 +4,7 @@ Mocks and stubs replace dependencies with controlled implementations for isolate
 
 Visit the following resources to learn more:
 
-- [@article@Test-Driven Development in Golang: Stubbing vs Mocking vs Not Mocking]((https://blog.stackademic.com/test-driven-development-in-golang-stubbing-vs-mocking-vs-not-mocking-5f23f25b3a63))
+- [@article@Test-Driven Development in Golang: Stubbing vs Mocking vs Not Mocking](https://blog.stackademic.com/test-driven-development-in-golang-stubbing-vs-mocking-vs-not-mocking-5f23f25b3a63)
 - [@article@Mock Solutions for Golang Unit Test](https://laiyuanyuan-sg.medium.com/mock-solutions-for-golang-unit-test-a2b60bd3e157)
 - [@article@Writing unit tests in Golang Part 2: Mocking](https://medium.com/nerd-for-tech/writing-unit-tests-in-golang-part-2-mocking-d4fa1701a3ae)
 - [@video@Mocks (Mocking), Stubs, and Fakes in Software Testing](https://www.youtube.com/watch?v=Ir7dl7XX9r4)


### PR DESCRIPTION
Minor fixes about article url.
it included unnecessary bracket, so we're navigated to wrong page.