### PR TITLE
fix: replace broken link in Linux roadmap

### DIFF
--- a/src/data/roadmaps/linux/content/tr@O9Vci_WpUY-79AkA4HDx3.md
+++ b/src/data/roadmaps/linux/content/tr@O9Vci_WpUY-79AkA4HDx3.md
@@ -5,4 +5,4 @@ The `tr` command in Linux is a command-line utility that translates or substitut
 Visit the following resources to learn more:
 
 - [@article@tr Command in Linux: 6 Useful Examples](https://linuxhandbook.com/tr-command/)
-- [@article@Linux tr Command: Character Translating](https://labex.io/tutorials/linux-linux-tr-command-character-translating-388064)
+- [@article@Linux tr Command with Practical Examples](https://labex.io/tutorials/linux-linux-tr-command-with-practical-examples-422963)


### PR DESCRIPTION
**Issue**
Article link on the tr command page is broken.

**Change**
This PR replaces it with a valid link from the same domain.