### PR TITLE
Add Agno to AI Agents roadmap

### DIFF
--- a/src/data/roadmaps/ai-agents/content/agno@AgnoHQ.md
+++ b/src/data/roadmaps/ai-agents/content/agno@AgnoHQ.md
@@ -1,0 +1,10 @@
+# Agno
+
+Agno (formerly phidata) is an open-source Python library for building AI agents and agentic systems. It provides a simple yet powerful way to create intelligent agents with access to tools, memory, and knowledge bases. Agents can be configured with different LLM providers (OpenAI, Anthropic, Ollama, etc.) and can be combined into multi-agent teams. Agno supports function calling, vector databases, and easy integration with web search, file storage, and databases.
+
+Visit the following resources to learn more:
+
+- [@official@Agno](https://agno.com/)
+- [@official@Agno Documentation](https://docs.agno.com/)
+- [@github@Agno GitHub](https://github.com/agno-agi/agno)
+- [@article@Getting Started with Agno](https://docs.agno.com/introduction)


### PR DESCRIPTION
Added Agno (formerly phidata) to the AI Agents roadmap. Agno is an open-source Python library for building AI agents and agentic systems.