### PR TITLE
docs: fix HTML syntax issues in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://roadmap.sh/"><img src="public/img/brand.png" height="128"></a>
   <h2 align="center"><a href="https://roadmap.sh">roadmap.sh</a></h2>
-  <p align="center">Community driven roadmaps, articles and resources for developers<p>
+  <p align="center">Community driven roadmaps, articles and resources for developers</p>
   <p align="center">
     <a href="https://roadmap.sh/roadmaps">
     	<img src="https://img.shields.io/badge/%E2%9C%A8-Roadmaps%20-0a0a0a.svg?style=flat&colorA=0a0a0a" alt="roadmaps" />
@@ -161,8 +161,8 @@ pnpm dev
 
 ## Thanks to all contributors ❤
 
- <a href = "https://github.com/kamranahmedse/developer-roadmap/graphs/contributors">
-   <img src = "https://contrib.rocks/image?repo=kamranahmedse/developer-roadmap"/>
+ <a href="https://github.com/kamranahmedse/developer-roadmap/graphs/contributors">
+   <img src="https://contrib.rocks/image?repo=kamranahmedse/developer-roadmap"/>
  </a>
 
 ## License


### PR DESCRIPTION
## Description

This PR fixes minor HTML syntax issues in the readme.md file:

### Changes Made

1. **Fixed unclosed `<p>` tag** (line 5)
   - Changed: `for developers<p>`
   - To: `for developers</p>`

2. **Fixed HTML attribute formatting** (Contributors section)
   - Changed: `href = "..."` → `href="..."`
   - Changed: `src = "..."` → `src="..."`

### Why

These changes improve:
- HTML validity (properly closed tags)
- Code consistency (standard HTML attribute formatting without extra spaces)
- Compatibility with HTML parsers and markdown renderers

### Checklist

- [x] Fixed unclosed HTML tag
- [x] Fixed HTML attribute formatting
- [x] Verified changes don't affect visual rendering

This is a documentation-only change with no functional impact.