### PR TITLE
Fix mobile roadmap scaling and navigation with contained pinch-zoom and pan

### DIFF
--- a/src/components/EditorRoadmap/EditorRoadmap.tsx
+++ b/src/components/EditorRoadmap/EditorRoadmap.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import { RefreshCcw } from 'lucide-react';
 import {
   EditorRoadmapRenderer,
   type RoadmapRendererProps,
@@ -11,6 +12,11 @@ import {
 import { httpGet } from '../../lib/http';
 import { getUrlParams } from '../../lib/browser.ts';
 import { RoadmapFloatingChat } from '../FrameRenderer/RoadmapFloatingChat.tsx';
+import {
+  isTouchInteractionDevice,
+  TOUCH_INTERACTION_MEDIA_QUERY,
+} from '../../lib/touch-interaction.ts';
+import { useTouchPanZoom } from './useTouchPanZoom.ts';
 
 type EditorRoadmapProps = {
   resourceId: string;
@@ -32,9 +38,26 @@ export function EditorRoadmap(props: EditorRoadmapProps) {
 
   const [hasSwitchedRoadmap, setHasSwitchedRoadmap] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [isTouchInteractionMode, setIsTouchInteractionMode] = useState(false);
+  const [isTouchHintVisible, setIsTouchHintVisible] = useState(false);
+  const [isTouchHintFading, setIsTouchHintFading] = useState(false);
   const [roadmapData, setRoadmapData] = useState<
     Omit<RoadmapRendererProps, 'resourceId'> | undefined
   >(undefined);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const touchHintFadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const clearTouchHintFadeTimeout = () => {
+    if (touchHintFadeTimeoutRef.current === null) {
+      return;
+    }
+
+    clearTimeout(touchHintFadeTimeoutRef.current);
+    touchHintFadeTimeoutRef.current = null;
+  };
 
   const loadRoadmapData = async () => {
     setIsLoading(true);
@@ -61,20 +84,83 @@ export function EditorRoadmap(props: EditorRoadmapProps) {
     loadRoadmapData().finally();
   }, [resourceId]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(TOUCH_INTERACTION_MEDIA_QUERY);
+    const syncTouchMode = () => {
+      setIsTouchInteractionMode(isTouchInteractionDevice());
+    };
+
+    syncTouchMode();
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', syncTouchMode);
+      return () => {
+        mediaQuery.removeEventListener('change', syncTouchMode);
+      };
+    }
+
+    mediaQuery.addListener(syncTouchMode);
+    return () => {
+      mediaQuery.removeListener(syncTouchMode);
+    };
+  }, []);
+
   const aspectRatio = dimensions.width / dimensions.height;
+  const { hasEnteredZoomMode, reset, handleClickCapture } = useTouchPanZoom({
+    viewportRef,
+    contentRef,
+    enabled: !!roadmapData && !isLoading,
+    maxScale: 6,
+  });
+
+  useEffect(() => {
+    clearTouchHintFadeTimeout();
+
+    if (!isTouchInteractionMode) {
+      setIsTouchHintVisible(false);
+      setIsTouchHintFading(false);
+      return;
+    }
+
+    if (!hasEnteredZoomMode) {
+      setIsTouchHintVisible(true);
+      setIsTouchHintFading(false);
+      return;
+    }
+
+    if (!isTouchHintVisible) {
+      return;
+    }
+
+    setIsTouchHintFading(true);
+    touchHintFadeTimeoutRef.current = setTimeout(() => {
+      setIsTouchHintVisible(false);
+      setIsTouchHintFading(false);
+      touchHintFadeTimeoutRef.current = null;
+    }, 375);
+
+    return () => {
+      clearTouchHintFadeTimeout();
+    };
+  }, [hasEnteredZoomMode, isTouchHintVisible, isTouchInteractionMode]);
 
   if (!roadmapData || isLoading) {
     return (
       <div
         style={
-          !hasSwitchedRoadmap
+          !hasSwitchedRoadmap && !isTouchInteractionMode
             ? ({
                 '--aspect-ratio': aspectRatio,
               } as CSSProperties)
             : undefined
         }
         className={
-          'mt-5 flex aspect-[var(--aspect-ratio)] w-full flex-col justify-center'
+          isTouchInteractionMode
+            ? 'mt-5 flex min-h-[40svh] w-full flex-col justify-center'
+            : 'mt-5 flex aspect-[var(--aspect-ratio)] w-full flex-col justify-center'
         }
       >
         <div className="flex w-full justify-center">
@@ -90,21 +176,73 @@ export function EditorRoadmap(props: EditorRoadmapProps) {
   return (
     <div
       style={
-        !hasSwitchedRoadmap
+        !hasSwitchedRoadmap && !isTouchInteractionMode
           ? ({
               '--aspect-ratio': aspectRatio,
             } as CSSProperties)
           : undefined
       }
       className={
-        'mt-5 flex aspect-[var(--aspect-ratio)] w-full flex-col justify-center'
+        isTouchInteractionMode
+          ? 'mt-5 flex w-full flex-col'
+          : 'mt-5 flex aspect-[var(--aspect-ratio)] w-full flex-col justify-center'
       }
     >
-      <EditorRoadmapRenderer
-        {...roadmapData}
-        dimensions={dimensions}
-        resourceId={resourceId}
-      />
+      <div
+        ref={viewportRef}
+        onClickCapture={handleClickCapture}
+        className={
+          isTouchInteractionMode
+            ? 'relative w-full max-h-[70svh] overflow-hidden overscroll-contain'
+            : 'relative h-full w-full overflow-hidden overscroll-contain'
+        }
+      >
+        {isTouchHintVisible && (
+          <div
+            className={`pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-4 ${
+              isTouchHintFading
+                ? 'opacity-0 transition-opacity duration-[375ms]'
+                : 'opacity-100'
+            }`}
+          >
+            <div className="relative mx-auto flex w-max max-w-full flex-shrink-0 items-center justify-center gap-2 rounded-full bg-stone-900/95 py-2.5 pr-6 pl-5 text-center text-white shadow-2xl backdrop-blur-sm">
+              <span className="text-sm font-semibold text-yellow-400">
+                Pinch to zoom,
+              </span>
+              <span className="text-sm text-white">drag to pan</span>
+            </div>
+          </div>
+        )}
+        {hasEnteredZoomMode && (
+          <div className="pointer-events-none absolute inset-x-0 top-3 z-20 flex justify-center px-3 sm:justify-end">
+            <button
+              type="button"
+              data-reset-zoom-button="true"
+              onClick={reset}
+              className="pointer-events-auto relative mx-auto flex w-max flex-shrink-0 items-center justify-center gap-2 rounded-full bg-stone-900/95 py-2.5 pr-6 pl-5 text-center text-white shadow-2xl backdrop-blur-sm transition-all duration-300 hover:scale-101 hover:bg-stone-800 sm:mx-0"
+            >
+              <RefreshCcw className="h-4 w-4 text-yellow-400" />
+              <span className="text-sm font-semibold text-yellow-400">
+                Reset Zoom
+              </span>
+            </button>
+          </div>
+        )}
+        <div
+          ref={contentRef}
+          className={isTouchInteractionMode ? 'w-full' : 'h-full w-full'}
+          style={{
+            WebkitUserSelect: 'none',
+            userSelect: 'none',
+          }}
+        >
+          <EditorRoadmapRenderer
+            {...roadmapData}
+            dimensions={dimensions}
+            resourceId={resourceId}
+          />
+        </div>
+      </div>
       {hasChat && <RoadmapFloatingChat roadmapId={resourceId} />}
     </div>
   );

--- a/src/components/EditorRoadmap/useTouchPanZoom.ts
+++ b/src/components/EditorRoadmap/useTouchPanZoom.ts
@@ -1,0 +1,332 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+} from 'react';
+import { isTouchInteractionDevice } from '../../lib/touch-interaction.ts';
+
+type TouchPoint = {
+  clientX: number;
+  clientY: number;
+};
+
+type TransformState = {
+  scale: number;
+  x: number;
+  y: number;
+};
+
+type TouchSnapshot = {
+  touches: TouchPoint[];
+  scale: number;
+  x: number;
+  y: number;
+};
+
+type UseTouchPanZoomOptions = {
+  viewportRef: RefObject<HTMLElement | null>;
+  contentRef: RefObject<HTMLElement | null>;
+  enabled?: boolean;
+  minScale?: number;
+  maxScale?: number;
+};
+
+const CLICK_SUPPRESS_MS = 350;
+const GESTURE_THRESHOLD = 6;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getTouchPoints(touches: TouchList): TouchPoint[] {
+  return Array.from(touches).map((touch) => ({
+    clientX: touch.clientX,
+    clientY: touch.clientY,
+  }));
+}
+
+function getDistance(first: TouchPoint, second: TouchPoint) {
+  const deltaX = second.clientX - first.clientX;
+  const deltaY = second.clientY - first.clientY;
+  return Math.hypot(deltaX, deltaY);
+}
+
+function getMidpoint(first: TouchPoint, second: TouchPoint) {
+  return {
+    x: (first.clientX + second.clientX) / 2,
+    y: (first.clientY + second.clientY) / 2,
+  };
+}
+
+export function useTouchPanZoom(options: UseTouchPanZoomOptions) {
+  const {
+    viewportRef,
+    contentRef,
+    enabled = true,
+    minScale = 1,
+    maxScale = 6,
+  } = options;
+  const transformRef = useRef<TransformState>({ scale: 1, x: 0, y: 0 });
+  const touchSnapshotRef = useRef<TouchSnapshot | null>(null);
+  const hasPinchedRef = useRef(false);
+  const suppressClickUntilRef = useRef(0);
+  const [hasEnteredZoomMode, setHasEnteredZoomMode] = useState(false);
+  const [isZoomed, setIsZoomed] = useState(false);
+
+  const clampTransform = useCallback(
+    (nextTransform: TransformState) => {
+      const viewport = viewportRef.current;
+      const content = contentRef.current;
+
+      if (!viewport || !content) {
+        return nextTransform;
+      }
+
+      const viewportWidth = viewport.clientWidth;
+      const viewportHeight = viewport.clientHeight;
+      const contentWidth = content.offsetWidth;
+      const contentHeight = content.offsetHeight;
+
+      if (!viewportWidth || !viewportHeight || !contentWidth || !contentHeight) {
+        return nextTransform;
+      }
+
+      const scaledWidth = contentWidth * nextTransform.scale;
+      const scaledHeight = contentHeight * nextTransform.scale;
+      const minX = scaledWidth > viewportWidth ? viewportWidth - scaledWidth : 0;
+      const minY =
+        scaledHeight > viewportHeight ? viewportHeight - scaledHeight : 0;
+
+      return {
+        scale: nextTransform.scale,
+        x: clamp(nextTransform.x, minX, 0),
+        y: clamp(nextTransform.y, minY, 0),
+      };
+    },
+    [contentRef, viewportRef],
+  );
+
+  const applyTransform = useCallback(
+    (nextTransform: TransformState) => {
+      const content = contentRef.current;
+      const viewport = viewportRef.current;
+      if (!content) {
+        transformRef.current = nextTransform;
+        return;
+      }
+
+      const clampedTransform = clampTransform(nextTransform);
+      transformRef.current = clampedTransform;
+      content.style.transformOrigin = '0 0';
+      const nextIsZoomed =
+        clampedTransform.scale > 1 ||
+        clampedTransform.x !== 0 ||
+        clampedTransform.y !== 0;
+      content.style.willChange = nextIsZoomed ? 'transform' : '';
+      content.style.transform = `translate3d(${clampedTransform.x}px, ${clampedTransform.y}px, 0) scale(${clampedTransform.scale})`;
+      if (viewport) {
+        viewport.style.touchAction = nextIsZoomed ? 'none' : 'auto';
+      }
+      setIsZoomed((currentIsZoomed) =>
+        currentIsZoomed === nextIsZoomed ? currentIsZoomed : nextIsZoomed,
+      );
+    },
+    [clampTransform, contentRef, viewportRef],
+  );
+
+  const reset = useCallback(() => {
+    touchSnapshotRef.current = null;
+    hasPinchedRef.current = false;
+    suppressClickUntilRef.current = 0;
+    setHasEnteredZoomMode(false);
+    applyTransform({ scale: 1, x: 0, y: 0 });
+  }, [applyTransform]);
+
+  const handleClickCapture = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest('[data-reset-zoom-button="true"]')
+      ) {
+        return;
+      }
+
+      if (performance.now() >= suppressClickUntilRef.current) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const content = contentRef.current;
+
+    if (!enabled || !viewport || !content || !isTouchInteractionDevice()) {
+      reset();
+      return;
+    }
+
+    function updateTouchSnapshot(touches: TouchList) {
+      touchSnapshotRef.current = {
+        touches: getTouchPoints(touches),
+        scale: transformRef.current.scale,
+        x: transformRef.current.x,
+        y: transformRef.current.y,
+      };
+    }
+
+    function handleTouchStart(event: TouchEvent) {
+      if (event.touches.length < 1 || event.touches.length > 2) {
+        touchSnapshotRef.current = null;
+        return;
+      }
+
+      if (event.touches.length === 2) {
+        event.preventDefault();
+      }
+
+      updateTouchSnapshot(event.touches);
+    }
+
+    function handleTouchMove(event: TouchEvent) {
+      const touchSnapshot = touchSnapshotRef.current;
+      if (!touchSnapshot) {
+        return;
+      }
+
+      if (event.touches.length === 2 && touchSnapshot.touches.length === 2) {
+        event.preventDefault();
+
+        const currentTouches = getTouchPoints(event.touches);
+        const initialDistance = Math.max(
+          getDistance(touchSnapshot.touches[0], touchSnapshot.touches[1]),
+          1,
+        );
+        const currentDistance = getDistance(currentTouches[0], currentTouches[1]);
+        const nextScale = clamp(
+          touchSnapshot.scale * (currentDistance / initialDistance),
+          minScale,
+          maxScale,
+        );
+
+        const viewportRect = viewport.getBoundingClientRect();
+        const midpoint = getMidpoint(currentTouches[0], currentTouches[1]);
+        const focalX = midpoint.x - viewportRect.left;
+        const focalY = midpoint.y - viewportRect.top;
+        const localX = (focalX - touchSnapshot.x) / touchSnapshot.scale;
+        const localY = (focalY - touchSnapshot.y) / touchSnapshot.scale;
+        const nextTransform = {
+          scale: nextScale,
+          x: focalX - localX * nextScale,
+          y: focalY - localY * nextScale,
+        };
+
+        if (
+          Math.abs(currentDistance - initialDistance) > GESTURE_THRESHOLD ||
+          Math.abs(nextScale - touchSnapshot.scale) > 0.02
+        ) {
+          hasPinchedRef.current = true;
+          setHasEnteredZoomMode(true);
+        }
+
+        applyTransform(nextTransform);
+        if (
+          Math.abs(currentDistance - initialDistance) > GESTURE_THRESHOLD ||
+          Math.abs(nextTransform.x - touchSnapshot.x) > GESTURE_THRESHOLD ||
+          Math.abs(nextTransform.y - touchSnapshot.y) > GESTURE_THRESHOLD
+        ) {
+          suppressClickUntilRef.current = performance.now() + CLICK_SUPPRESS_MS;
+        }
+        return;
+      }
+
+      if (
+        event.touches.length === 1 &&
+        touchSnapshot.touches.length === 1 &&
+        hasPinchedRef.current &&
+        (transformRef.current.scale > 1 ||
+          content.offsetHeight > viewport.clientHeight)
+      ) {
+        event.preventDefault();
+
+        const deltaX = event.touches[0].clientX - touchSnapshot.touches[0].clientX;
+        const deltaY = event.touches[0].clientY - touchSnapshot.touches[0].clientY;
+
+        if (Math.hypot(deltaX, deltaY) > GESTURE_THRESHOLD) {
+          event.preventDefault();
+          suppressClickUntilRef.current = performance.now() + CLICK_SUPPRESS_MS;
+        } else {
+          return;
+        }
+
+        applyTransform({
+          scale: touchSnapshot.scale,
+          x: touchSnapshot.x + deltaX,
+          y: touchSnapshot.y + deltaY,
+        });
+      }
+    }
+
+    function handleTouchEnd(event: TouchEvent) {
+      if (event.touches.length === 0) {
+        touchSnapshotRef.current = null;
+        return;
+      }
+
+      updateTouchSnapshot(event.touches);
+    }
+
+    function handleResize() {
+      applyTransform(transformRef.current);
+    }
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(() => {
+            handleResize();
+          });
+
+    resizeObserver?.observe(viewport);
+    resizeObserver?.observe(content);
+    viewport.addEventListener('touchstart', handleTouchStart, { passive: false });
+    viewport.addEventListener('touchmove', handleTouchMove, { passive: false });
+    viewport.addEventListener('touchend', handleTouchEnd, { passive: true });
+    viewport.addEventListener('touchcancel', handleTouchEnd, { passive: true });
+    window.addEventListener('resize', handleResize);
+    applyTransform(transformRef.current);
+
+    return () => {
+      resizeObserver?.disconnect();
+      viewport.removeEventListener('touchstart', handleTouchStart);
+      viewport.removeEventListener('touchmove', handleTouchMove);
+      viewport.removeEventListener('touchend', handleTouchEnd);
+      viewport.removeEventListener('touchcancel', handleTouchEnd);
+      window.removeEventListener('resize', handleResize);
+      viewport.style.touchAction = '';
+      content.style.willChange = '';
+    };
+  }, [
+    applyTransform,
+    contentRef,
+    enabled,
+    maxScale,
+    minScale,
+    reset,
+    viewportRef,
+  ]);
+
+  return {
+    hasEnteredZoomMode,
+    isZoomed,
+    reset,
+    handleClickCapture,
+  };
+}

--- a/src/lib/touch-interaction.ts
+++ b/src/lib/touch-interaction.ts
@@ -1,0 +1,9 @@
+export const TOUCH_INTERACTION_MEDIA_QUERY = '(hover: none) and (pointer: coarse)';
+
+export function isTouchInteractionDevice() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+
+  return window.matchMedia(TOUCH_INTERACTION_MEDIA_QUERY).matches;
+}


### PR DESCRIPTION
## Summary

This PR adds contained pinch-zoom and pan to the roadmap on touch devices so users no longer have to rely on browser-level zoom to navigate it. Closes #9724 

It does not change the desktop roadmap experience for mouse and keyboard users, and it does not introduce any new dependencies. The feature is gated behind touch-device detection and is intended for smaller, touch-first screens where the default roadmap scale makes nodes difficult to read and tap reliably.

**Live Demo:** [https://roadmap.ritovision.com/ai-engineer](https://roadmap.ritovision.com/ai-engineer)
*Note: the roadmap node renderer in this demo is visually disorganized because the upstream renderer is not publicly available and a quick makeshift fallback was used locally. Focus on the interaction behavior rather than the rendering fidelity.*

## Problem Recap
From #9724:
Roadmap nodes are too small to read and tap on mobile-sized touch screens at the default page scale. In practice, that leaves browser-level zoom as the only workable way to use the roadmap, but that zoom applies to the entire page rather than to the roadmap itself.

That creates a constant mismatch: users need to zoom in to work with the roadmap, then zoom back out whenever they open a node's modal to read it, then zoom back in again to continue navigating the roadmap while also losing their place from having just zoomed out.

This makes roadmap navigation on mobile much more disruptive than the intended desktop interaction.

## What This Adds

- Add a touch-only roadmap viewport that supports pinch-zoom and drag-to-pan on mobile devices while leaving desktop mouse behavior unchanged. This keeps zoom interaction contained to the roadmap instead of relying on browser-level zoom that affects the entire page and must be repeatedly undone to read node modals and continue navigating.

- Clip overflow to keep the zoomed roadmap contained within its frame and prevent panning from spilling the roadmap outside its container and overlapping other page content.

- Cap the viewport height on touch devices to avoid a scroll-lock situation where the roadmap occupies most of the screen and intercepts touch input, leaving the user with almost nowhere to touch the page and scroll normally. The side margins around the roadmap are too narrow to rely on comfortably, so reserving space above and below it via the viewport height cap preserves a practical area for normal page navigation.

- Show a hint explaining how to navigate the roadmap before zoom is activated.

- Provide a floating reset action that restores the roadmap zoom level to the default state

- Suppress accidental clicks after gesture movement.

- Drag-to-pan is gated until the first pinch-zoom to prevent accidental triggering when scrolling the page.

- Implement the interaction at the roadmap viewport wrapper layer so it does not depend on renderer-specific behavior.

## Screenshot Depiction

### Default State
*Notice the roadmap does not span the full viewport height to reserve touch areas for the user to scroll vertically around. Also notice the centered floating UI instructions prompting the user to pinch to begin navigating the roadmap. These will NOT render on desktop like this; the roadmap will span the full natural height and not display the instructional UI.*
<img width="400" height="823" alt="after-zoomed-out" src="https://github.com/user-attachments/assets/106588df-6f55-4ded-8b40-9ca2795ef835" />

<br /><br />

### Contained Zoom In
*Notice the roadmap is zoomed in but the rest of the page remains its normal scale, also notice the "Reset Zoom" button that floats at the top of the roadmap container.*
<img width="400" height="823" alt="after-zoomed-in" src="https://github.com/user-attachments/assets/2c8a5260-b275-4cc2-817d-3219907191b7" />

## Testing

I tested the feature locally on Chrome, Firefox and Edge mobile browsers on Android and the behaviors were stable and consistent for each.

I also tested it on Chrome, Firefox and Edge desktop browsers with mouse and keyboard to ensure no regressions emerged for the desktop experience and found no issues.

Live Demo: [https://roadmap.ritovision.com/ai-engineer](https://roadmap.ritovision.com/ai-engineer)
*Note: the roadmap node renderer in this demo is visually disorganized because the upstream renderer is not publicly available and a quick makeshift fallback was used locally. Focus on the interaction behavior rather than the rendering fidelity.*

## Note on Validation

This feature was developed and tested locally in a setup where the roadmap renderer had to be swapped out because collaborator-only renderer access was not available.

Because the interaction is implemented at the roadmap viewport wrapper layer rather than inside renderer internals, it should carry over cleanly. It should still be verified against the upstream renderer on real touch devices.

## Screenshot Depiction

### Default State
*Notice the roadmap does not span the full viewport height to reserve touch areas for the user to scroll vertically around. Also notice the centered floating UI instructions prompting the user to pinch to begin navigating the roadmap. These will NOT render on desktop like this; the roadmap will span the full natural height and not display the instructional UI.*

<img width="400" height="823" alt="after-zoomed-out" src="https://github.com/user-attachments/assets/106588df-6f55-4ded-8b40-9ca2795ef835" />

<br /><br />

### Contained Zoom In
*Notice the roadmap is zoomed in but the rest of the page remains its normal scale, also notice the "Reset Zoom" button that floats at the top of the roadmap container.*
<img width="400" height="823" alt="after-zoomed-in" src="https://github.com/user-attachments/assets/2c8a5260-b275-4cc2-817d-3219907191b7" />


## Before and After Demonstrations

### Before

https://github.com/user-attachments/assets/71cc0318-82b2-4bd0-b362-c067e33d4c75

### After
***Note**  the roadmap node renderer in this demo is visually disorganized because the upstream renderer is not publicly available and a quick makeshift fallback was used locally. Focus on the seamlessness of zooming in and panning around the roadmap without ever needing to reverse the zoom to read the modal content or the rest of the page.*

[roadmap-after.webm](https://github.com/user-attachments/assets/7d63d984-343d-45e0-85f8-b80dbf077f6d)
