### PR TITLE
Add Ingero to MLOps Monitoring & Observability resources

### DIFF
--- a/src/data/roadmaps/mlops/content/monitoring--observability@fR4Qr_ifoBLTpxdkJ50rB.md
+++ b/src/data/roadmaps/mlops/content/monitoring--observability@fR4Qr_ifoBLTpxdkJ50rB.md
@@ -4,6 +4,7 @@ Monitoring and observability involve tracking the performance and health of mach
 
 Visit the following resources to learn more:
 
+- [@opensource@ingero-io/ingero](https://github.com/ingero-io/ingero)
 - [@article@What’s the Difference Between Observability and Monitoring?](https://aws.amazon.com/compare/the-difference-between-monitoring-and-observability/)
 - [@article@Observability and Instrumentation: What They Are and Why They Matter](https://newrelic.com/blog/best-practices/observability-instrumentation)
 - [@video@What is observability?](https://www.youtube.com/watch?v=--17See0KHs)


### PR DESCRIPTION
Adds [Ingero](https://github.com/ingero-io/ingero) as an `@opensource@` resource to the MLOps Monitoring & Observability topic.

Ingero is an open-source, eBPF-based GPU observability agent. It traces CUDA Runtime and Driver API calls via Linux kernel uprobes and correlates them with host kernel events (CPU scheduling, memory pressure, I/O) to build causal chains explaining GPU training/inference slowdowns.

**Why this belongs here:** The current MLOps monitoring resources cover general observability concepts but don't include any GPU-specific tooling. GPU workload monitoring is a growing gap in MLOps — standard tools (Prometheus, Grafana, DCGM) report utilization counters but can't explain *why* a GPU workload is slow. Ingero fills this gap with production-safe kernel-level tracing (<2% overhead).