### PR TITLE
fix(qa): update test planning resource URL to canonical path

### DIFF
--- a/src/data/roadmaps/qa/content/test-planning@2U8WRKkuF-YCEWtpgTspF.md
+++ b/src/data/roadmaps/qa/content/test-planning@2U8WRKkuF-YCEWtpgTspF.md
@@ -4,4 +4,4 @@ A Test Plan is a detailed document that describes the test strategy, objectives,
 
 Visit the following resources to learn more:
 
-- [@article@Test Plan: What is, How to Create (with Example)](https://www.guru99.com/what-everybody-ought-to-know-about-test-planing.html)
+- [@article@Test Plan: What is, How to Create (with Example)](https://www.guru99.com/test-planning.html)


### PR DESCRIPTION
The resource link for Test Planning in the QA roadmap was pointing to https://www.guru99.com/what-everybody-ought-to-know-about-test-planing.html, which redirects to the canonical URL https://www.guru99.com/test-planning.html. Updated the link to point directly to the canonical URL.

Closes #9719 