### PR TITLE
fix: update broken Go roadmap links in rust and mlops roadmaps

### DIFF
--- a/src/data/roadmaps/mlops/mlops.json
+++ b/src/data/roadmaps/mlops/mlops.json
@@ -799,7 +799,7 @@
           {
             "id": "hdkeX4rocCNh8KqHSh7S3",
             "label": "Go Roadmap",
-            "url": "https://roadmap.sh/go"
+            "url": "https://roadmap.sh/golang"
           }
         ]
       },

--- a/src/data/roadmaps/rust/rust.json
+++ b/src/data/roadmaps/rust/rust.json
@@ -6261,7 +6261,7 @@
           {
             "id": "EW8A9X-9ELclN0pdvRE1G",
             "label": "Go Roadmap",
-            "url": "https://roadmap.sh/go"
+            "url": "https://roadmap.sh/golang"
           }
         ]
       },


### PR DESCRIPTION
## Summary
Updated Go roadmap links in roadmap content from `https://roadmap.sh/go` to `https://roadmap.sh/golang`.

The Go Roadmap link in the Related Roadmaps section of both the Rust and MLOps roadmaps was pointing to `/go` which returns a 404. Updated both to `/golang`.

## Changes
- Updated Go roadmap link in `src/data/roadmaps/mlops/mlops.json`
- Updated Go roadmap link in `src/data/roadmaps/rust/rust.json`
- No logic or rendering changes; content link update only