### PR TITLE
fix: add z-index to sticky project stepper to prevent code block overlap

### DIFF
--- a/src/components/Projects/StatusStepper/ProjectStepper.tsx
+++ b/src/components/Projects/StatusStepper/ProjectStepper.tsx
@@ -112,7 +112,7 @@ export function ProjectStepper(props: ProjectStepperProps) {
     <div
       ref={stickyElRef}
       className={cn(
-        'relative top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
+        'relative z-10 top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
         {
           'sm:-mx-5 sm:rounded-none sm:border-x-0 sm:border-t-0 sm:bg-gray-50':
             isSticky,


### PR DESCRIPTION
## Problem

Code blocks in project page content area paint over the sticky project stepper when scrolling. The stepper is missing a `z-index`, so elements later in the DOM paint on top of it.

![Screenshot](https://github.com/user-attachments/assets/24aa2657-4302-47db-bfc7-8ae46b49c25d)

## Fix

Added `z-10` to the sticky stepper container. This ensures it stays above content when in sticky mode.

**File:** `src/components/Projects/StatusStepper/ProjectStepper.tsx`

Changed the base className from `relative top-0 ...` to `relative z-10 top-0 ...`

Fixes #9736