### PR TITLE
fix: keep sticky project stepper above code blocks

### DIFF
--- a/src/components/Projects/StatusStepper/ProjectStepper.tsx
+++ b/src/components/Projects/StatusStepper/ProjectStepper.tsx
@@ -112,7 +112,7 @@ export function ProjectStepper(props: ProjectStepperProps) {
     <div
       ref={stickyElRef}
       className={cn(
-        'relative top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
+        'relative top-0 z-10 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
         {
           'sm:-mx-5 sm:rounded-none sm:border-x-0 sm:border-t-0 sm:bg-gray-50':
             isSticky,


### PR DESCRIPTION
﻿## Summary
- add a z-index to the sticky project status stepper so code blocks stay underneath it while scrolling

## Testing
- pnpm exec prettier --check src/components/Projects/StatusStepper/ProjectStepper.tsx
- git diff --check
- pnpm run build *(fails on current repo checkout because Vite cannot resolve @roadmapsh/editor from src/components/GenerateRoadmap/GenerateRoadmap.tsx, unrelated to this change)*

Fixes #9736
