### PR TITLE
fix: URL-encode topic search terms to fix C# roadmap navigation

### DIFF
--- a/src/components/TopicDetail/CreateCourseModal.tsx
+++ b/src/components/TopicDetail/CreateCourseModal.tsx
@@ -24,7 +24,7 @@ export function CreateCourseModal(props: CreateCourseModalProps) {
           const formData = new FormData(e.target as HTMLFormElement);
           const subject = formData.get('subject');
 
-          window.location.href = `/ai/course/search?term=${subject}&src=topic`;
+          window.location.href = `/ai/course/search?term=${encodeURIComponent(String(subject))}&src=topic`;
           onClose();
         }}
       >

--- a/src/components/TopicDetail/TopicDetail.tsx
+++ b/src/components/TopicDetail/TopicDetail.tsx
@@ -669,7 +669,7 @@ export function TopicDetail(props: TopicDetailProps) {
                           return (
                             <li key={subject}>
                               <TopicDetailLink
-                                url={`/ai/course/search?term=${subject}&src=topic`}
+                                url={`/ai/course/search?term=${encodeURIComponent(subject)}&src=topic`}
                                 type="course"
                                 title={subject}
                                 onClick={(e) => {
@@ -693,7 +693,7 @@ export function TopicDetail(props: TopicDetailProps) {
                           return (
                             <li key={guide}>
                               <TopicDetailLink
-                                url={`/ai/guide/search?term=${guide}&src=topic`}
+                                url={`/ai/guide/search?term=${encodeURIComponent(guide)}&src=topic`}
                                 type="article"
                                 title={guide}
                                 onClick={(e) => {

--- a/src/components/TopicDetail/TopicDetailAI.tsx
+++ b/src/components/TopicDetail/TopicDetailAI.tsx
@@ -200,7 +200,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                       return;
                     }
                   }}
-                  href={`/ai/course/search?term=${subject}&src=topic`}
+                  href={`/ai/course/search?term=${encodeURIComponent(subject)}&src=topic`}
                   className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black"
                 >
                   <BookOpenIcon className="size-3.5" />
@@ -226,7 +226,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                       return;
                     }
                   }}
-                  href={`/ai/guide/search?term=${guide}&src=topic`}
+                  href={`/ai/guide/search?term=${encodeURIComponent(guide)}&src=topic`}
                   className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black"
                 >
                   <FileTextIcon className="size-3.5" />
@@ -251,7 +251,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                     return;
                   }
                 }}
-                href={`/ai/course/search?term=${roadmapTreeMapping?.text}&difficulty=beginner&src=topic`}
+                href={`/ai/course/search?term=${encodeURIComponent(roadmapTreeMapping?.text || '')}&difficulty=beginner&src=topic`}
                 className="flex items-center gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black [&>svg:last-child]:hidden"
               >
                 {nodeTextParts.slice(-2).map((text, index) => {


### PR DESCRIPTION
## Summary
- Wraps topic/guide search terms with `encodeURIComponent()` in `TopicDetail.tsx`, `CreateCourseModal.tsx`, and `TopicDetailAI.tsx`
- The `#` in "C#" was being interpreted as a URL fragment separator, breaking search URLs (e.g. `term=C# Basics` → browser sees `term=C` + fragment `# Basics&src=topic`)
- Other components (`AICourse.tsx`, `AIGuide.tsx`) already use `encodeURIComponent()` — this makes it consistent

## Test plan
- [ ] Navigate to Backend roadmap → click C# → click C# Basics → verify the search URL is `/ai/course/search?term=C%23%20Basics&src=topic` and loads correctly
- [ ] Verify other topic links (without special characters) still work as expected

Fixes #9723