### PR TITLE
Fix unreachable nodes in Redis roadmap

### DIFF
--- a/src/data/roadmaps/redis/content/more-commands@2SG4Hr9Tuv6cxmGkrKjYZ.md
+++ b/src/data/roadmaps/redis/content/more-commands@2SG4Hr9Tuv6cxmGkrKjYZ.md
@@ -1,1 +1,0 @@
-# More Commands

--- a/src/data/roadmaps/redis/content/usecases--best-practices@Z6yJwUkcDX08HoMyf1LwX.md
+++ b/src/data/roadmaps/redis/content/usecases--best-practices@Z6yJwUkcDX08HoMyf1LwX.md
@@ -1,1 +1,0 @@
-# Usecases / Best Practices


### PR DESCRIPTION
## Problem
The Redis roadmap has **162 markdown files** but only **160 nodes** are clickable/visible on the map, making 100% completion impossible. This is caused by 2 pairs of nodes sharing identical coordinates, causing one in each pair to be unreachable:
- `2SG4Hr9Tuv6cxmGkrKjYZ` is overlapped by `b48EUyFGUeSjtT5fOa_m6`
- `Z6yJwUkcDX08HoMyf1LwX` is overlapped by `vzp7DUpjklzIA0E9WxJQA`

Both unreachable nodes still had markdown files counted towards the total but could never be clicked.

## Fix
- `2SG4Hr9Tuv6cxmGkrKjYZ` has `oldId: "b48EUyFGUeSjtT5fOa_m6"` indicating it is the inactive node, so `more-commands@2SG4Hr9Tuv6cxmGkrKjYZ.md` was deleted
- `Z6yJwUkcDX08HoMyf1LwX` has `oldId: "vzp7DUpjklzIA0E9WxJQA"` indicating it is the inactive node, so `usecases--best-practices@Z6yJwUkcDX08HoMyf1LwX.md` was deleted

## Result
Total markdown files reduced from **162 to 160**, matching the number of clickable nodes and making **100% completion achievable**.

## How to Verify
On the [Redis roadmap](https://roadmap.sh/redis), open the browser search (Ctrl+F) and:
- Search for `more commands` — the 3rd result is not clickable as it is buried under the 4th
- Search for `usecases / best practices` — the 1st result is buried under the 2nd