### PR TITLE
Fixed typo in SQL roadmap under DML title

### DIFF
--- a/src/data/roadmaps/sql/content/data-manipulation-language-dml@WMSXi-eez_hHGDM8kUdWz.md
+++ b/src/data/roadmaps/sql/content/data-manipulation-language-dml@WMSXi-eez_hHGDM8kUdWz.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@article@What is DML?](https://satoricyber.com/glossary/dml-data-manipulation-language)
 - [@article@What is DML?(Wiki)](https://en.wikipedia.org/wiki/Data_manipulation_language)
-- [@article@Difference Between DMS & DML](https://appmaster.io/blog/difference-between-ddl-and-dml)
+- [@article@Difference Between DDL & DML](https://appmaster.io/blog/difference-between-ddl-and-dml)


### PR DESCRIPTION
There is a typo in SQL Roadmap, under "DML" title. The link redirects to a page that tells the difference between DDL and DML but "DMS & DML" is written on the page, and I fixed that typo.

<img width="580" height="491" alt="typo" src="https://github.com/user-attachments/assets/eaf39d7a-903b-4922-a254-55e66553a776" />
