### PR TITLE
fix: encode AI topic search terms

### DIFF
--- a/src/components/AIChat/AIChatCouse.tsx
+++ b/src/components/AIChat/AIChatCouse.tsx
@@ -33,7 +33,7 @@ export function AIChatCourse(props: AIChatCourseProps) {
     return null;
   }
 
-  const courseSearchUrl = `/ai/course?term=${course?.keyword}&difficulty=${course?.difficulty}`;
+  const courseSearchUrl = `/ai/course?term=${encodeURIComponent(course?.keyword)}&difficulty=${course?.difficulty}`;
 
   return (
     <div className="relative my-6 flex flex-wrap gap-1 first:mt-0 last:mb-0">

--- a/src/components/TopicDetail/CreateCourseModal.tsx
+++ b/src/components/TopicDetail/CreateCourseModal.tsx
@@ -24,7 +24,7 @@ export function CreateCourseModal(props: CreateCourseModalProps) {
           const formData = new FormData(e.target as HTMLFormElement);
           const subject = formData.get('subject');
 
-          window.location.href = `/ai/course/search?term=${subject}&src=topic`;
+          window.location.href = `/ai/course/search?term=${encodeURIComponent(String(subject ?? ''))}&src=topic`;
           onClose();
         }}
       >

--- a/src/components/TopicDetail/TopicDetail.tsx
+++ b/src/components/TopicDetail/TopicDetail.tsx
@@ -669,7 +669,7 @@ export function TopicDetail(props: TopicDetailProps) {
                           return (
                             <li key={subject}>
                               <TopicDetailLink
-                                url={`/ai/course/search?term=${subject}&src=topic`}
+                                url={`/ai/course/search?term=${encodeURIComponent(subject)}&src=topic`}
                                 type="course"
                                 title={subject}
                                 onClick={(e) => {
@@ -693,7 +693,7 @@ export function TopicDetail(props: TopicDetailProps) {
                           return (
                             <li key={guide}>
                               <TopicDetailLink
-                                url={`/ai/guide/search?term=${guide}&src=topic`}
+                                url={`/ai/guide/search?term=${encodeURIComponent(guide)}&src=topic`}
                                 type="article"
                                 title={guide}
                                 onClick={(e) => {

--- a/src/components/TopicDetail/TopicDetailAI.tsx
+++ b/src/components/TopicDetail/TopicDetailAI.tsx
@@ -200,7 +200,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                       return;
                     }
                   }}
-                  href={`/ai/course/search?term=${subject}&src=topic`}
+                  href={`/ai/course/search?term=${encodeURIComponent(subject)}&src=topic`}
                   className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black"
                 >
                   <BookOpenIcon className="size-3.5" />
@@ -226,7 +226,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                       return;
                     }
                   }}
-                  href={`/ai/guide/search?term=${guide}&src=topic`}
+                  href={`/ai/guide/search?term=${encodeURIComponent(guide)}&src=topic`}
                   className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black"
                 >
                   <FileTextIcon className="size-3.5" />
@@ -251,7 +251,7 @@ export function TopicDetailAI(props: TopicDetailAIProps) {
                     return;
                   }
                 }}
-                href={`/ai/course/search?term=${roadmapTreeMapping?.text}&difficulty=beginner&src=topic`}
+                href={`/ai/course/search?term=${encodeURIComponent(roadmapTreeMapping?.text || '')}&difficulty=beginner&src=topic`}
                 className="flex items-center gap-1 rounded-md border border-gray-300 bg-gray-100 px-2 py-1 hover:bg-gray-200 hover:text-black [&>svg:last-child]:hidden"
               >
                 {nodeTextParts.slice(-2).map((text, index) => {


### PR DESCRIPTION
## Summary
- encode AI course and guide search terms before building topic-detail URLs
- cover the topic detail links, the AI tutor panel, the topic search modal, and AI chat course links
- prevent `C#` and similar terms from being truncated at `#` when opening AI course search pages

## Validation
- `git diff --check`
- `node -e "const samples=[''C# Basics'',''ASP.NET > C#'',''C#'']; for (const s of samples) console.log(s + '' => '' + encodeURIComponent(s))"`

Fixes #9723
