### PR TITLE
fix: add z-index to sticky project stepper to prevent code block overlap

### DIFF
--- a/src/components/Projects/StatusStepper/ProjectStepper.tsx
+++ b/src/components/Projects/StatusStepper/ProjectStepper.tsx
@@ -112,7 +112,7 @@ export function ProjectStepper(props: ProjectStepperProps) {
     <div
       ref={stickyElRef}
       className={cn(
-        'relative top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
+        'relative z-10 top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
         {
           'sm:-mx-5 sm:rounded-none sm:border-x-0 sm:border-t-0 sm:bg-gray-50':
             isSticky,


### PR DESCRIPTION
## Problem

On project pages (e.g. https://roadmap.sh/projects/task-tracker), code blocks in the content area overlap the sticky project stepper component when scrolling.

## Root Cause

The stepper container uses `sm:sticky` but lacks a `z-index`, so elements later in the DOM (code blocks) paint over it.

## Fix

Added `z-10` to the sticky container's class list to ensure it stays on top of scrolling content.

Fixes #9736