### PR TITLE
fix(#6462): add z-index to project stepper

### DIFF
--- a/src/components/Projects/StatusStepper/ProjectStepper.tsx
+++ b/src/components/Projects/StatusStepper/ProjectStepper.tsx
@@ -112,7 +112,7 @@ export function ProjectStepper(props: ProjectStepperProps) {
     <div
       ref={stickyElRef}
       className={cn(
-        'relative top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
+        'relative top-0 -mx-4 my-5 overflow-hidden rounded-none border border-x-0 bg-white transition-all z-40 sm:sticky sm:mx-0 sm:rounded-lg sm:border-x',
         {
           'sm:-mx-5 sm:rounded-none sm:border-x-0 sm:border-t-0 sm:bg-gray-50':
             isSticky,


### PR DESCRIPTION
Fixes issue #6462: Code blocks overlap sticky project stepper on project pages.

The sticky project stepper was being covered by code blocks when scrolling because it lacked a proper z-index value. Added z-40 class to ensure the stepper stays above content elements while remaining below modals and other overlay components.