### PR TITLE
content(docker): add descriptions for Linux fundamentals topics

### DIFF
--- a/src/data/roadmaps/docker/content/package-managers@mw-weCutd2ECKlx2DE_ZJ.md
+++ b/src/data/roadmaps/docker/content/package-managers@mw-weCutd2ECKlx2DE_ZJ.md
@@ -1,1 +1,10 @@
 # Package Managers
+
+Package managers are tools used to install, update, and manage software packages on Linux systems. Since most Docker images are based on Linux distributions, understanding package managers like `apt` (Debian/Ubuntu), `yum`/`dnf` (RHEL/CentOS/Fedora), and `apk` (Alpine Linux) is essential for building Docker images. In a Dockerfile, you typically use `RUN` instructions with package managers to install the dependencies your application needs, and it is a best practice to clean up package caches afterward to keep image sizes small.
+
+Visit the following resources to learn more:
+
+- [@article@APT Package Manager Guide](https://ubuntu.com/server/docs/package-management)
+- [@article@Alpine Linux Package Management](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper)
+- [@video@Linux Package Managers Explained](https://www.youtube.com/watch?v=-iSMFoPPbKU)
+- [@feed@Explore top posts about Docker](https://app.daily.dev/tags/docker?ref=roadmapsh)

--- a/src/data/roadmaps/docker/content/programming-languages@XxT9UUjbKW1ARyERSLH_W.md
+++ b/src/data/roadmaps/docker/content/programming-languages@XxT9UUjbKW1ARyERSLH_W.md
@@ -1,1 +1,11 @@
 # Programming Languages
+
+Having proficiency in at least one programming language is essential before working with Docker, as containers are ultimately used to package and run applications. Whether you work with Python, JavaScript, Go, Java, or any other language, understanding how your application is built, its dependencies, and its runtime requirements directly informs how you write Dockerfiles and structure container images. Knowledge of your language's package management, build tools, and runtime environment helps you create efficient, minimal Docker images tailored to your application's needs.
+
+Visit the following resources to learn more:
+
+- [@roadmap@Python Roadmap](https://roadmap.sh/python)
+- [@roadmap@JavaScript Roadmap](https://roadmap.sh/javascript)
+- [@roadmap@Java Roadmap](https://roadmap.sh/java)
+- [@roadmap@Go Roadmap](https://roadmap.sh/golang)
+- [@feed@Explore top posts about Docker](https://app.daily.dev/tags/docker?ref=roadmapsh)

--- a/src/data/roadmaps/docker/content/shell-commands@W5kX5jn49hghRgkEw6_S3.md
+++ b/src/data/roadmaps/docker/content/shell-commands@W5kX5jn49hghRgkEw6_S3.md
@@ -1,1 +1,10 @@
 # Shell Commands
+
+Shell commands are the fundamental way to interact with Linux-based systems that Docker containers typically run on. Understanding commands like `ls`, `cd`, `cp`, `mv`, `rm`, `chmod`, `chown`, `ps`, `top`, `grep`, `find`, and `cat` is essential for working inside containers, writing Dockerfiles, and debugging running containers. When you use `docker exec` to access a running container or write `RUN` instructions in a Dockerfile, you rely on these shell commands to install dependencies, configure environments, and manage files within the container's filesystem.
+
+Visit the following resources to learn more:
+
+- [@article@Linux Command Line Basics](https://www.freecodecamp.org/news/the-linux-commands-handbook/)
+- [@article@Shell Commands Every Developer Should Know](https://www.codecademy.com/article/command-line-commands)
+- [@video@Linux Commands for Beginners](https://www.youtube.com/watch?v=ZtqBQ68cfJc)
+- [@feed@Explore top posts about Docker](https://app.daily.dev/tags/docker?ref=roadmapsh)

--- a/src/data/roadmaps/docker/content/shell-scripting@InlMtuaUJ9EXO-OD9x1jj.md
+++ b/src/data/roadmaps/docker/content/shell-scripting@InlMtuaUJ9EXO-OD9x1jj.md
@@ -1,1 +1,10 @@
 # Shell Scripting
+
+Shell scripting involves writing scripts using shell languages like Bash to automate tasks and workflows. In the context of Docker, shell scripts are commonly used in Dockerfiles as part of `RUN` instructions to set up the container environment, install packages, or configure applications. They are also used as entrypoint or startup scripts (via `ENTRYPOINT` or `CMD`) to initialize services when a container starts. Understanding variables, conditionals, loops, and functions in shell scripting helps you write more efficient Dockerfiles and manage complex container setups.
+
+Visit the following resources to learn more:
+
+- [@article@Shell Scripting Tutorial](https://www.shellscript.sh/)
+- [@article@Bash Scripting Tutorial for Beginners](https://linuxconfig.org/bash-scripting-tutorial-for-beginners)
+- [@video@Bash Scripting Full Course](https://www.youtube.com/watch?v=tK9Oc6AEnR4)
+- [@feed@Explore top posts about Docker](https://app.daily.dev/tags/docker?ref=roadmapsh)

--- a/src/data/roadmaps/docker/content/users--groups-permissions@uKjB2qntFTpPuYUT9sdxd.md
+++ b/src/data/roadmaps/docker/content/users--groups-permissions@uKjB2qntFTpPuYUT9sdxd.md
@@ -1,1 +1,10 @@
 # Users / Groups Permissions
+
+Linux users, groups, and file permissions control access to files and resources on the system. In Docker, understanding these concepts is important because containers run processes as specific users, and the permissions model determines what files a containerized application can read, write, or execute. By default, containers run as root, which poses security risks, so it is a best practice to create non-root users in your Dockerfile using `RUN useradd` and switch to them with the `USER` instruction. Commands like `chmod`, `chown`, and `chgrp` help you set the correct permissions on files and directories within your container images.
+
+Visit the following resources to learn more:
+
+- [@article@Linux File Permissions Explained](https://www.redhat.com/en/blog/linux-file-permissions-explained)
+- [@article@Users and Groups in Linux](https://wiki.archlinux.org/title/Users_and_groups)
+- [@official@Dockerfile USER Instruction](https://docs.docker.com/reference/dockerfile/#user)
+- [@feed@Explore top posts about Docker](https://app.daily.dev/tags/docker?ref=roadmapsh)


### PR DESCRIPTION
## Summary

- Added content descriptions and resource links for 5 empty topic pages in the Docker roadmap's Linux fundamentals section: **Shell Commands**, **Shell Scripting**, **Package Managers**, **Users / Groups Permissions**, and **Programming Languages**.
- Each topic now includes a concise explanation of the concept in the context of Docker, along with curated external resources for further learning.
- Follows the existing content style and formatting conventions used throughout the roadmap.

## Details

These 5 files previously contained only a title heading with no description or resources. This PR fills them in following the project's content guidelines:

| File | Description Added |
|------|------------------|
| `shell-commands` | Core Linux commands needed for Dockerfiles and container debugging |
| `shell-scripting` | Bash scripting for Dockerfile RUN instructions and entrypoint scripts |
| `package-managers` | apt, yum/dnf, apk usage in Docker image builds |
| `users--groups-permissions` | Linux permissions model and non-root container best practices |
| `programming-languages` | Why language proficiency matters for writing Dockerfiles |

## Test plan

- [ ] Verify each content file renders correctly on the Docker roadmap topic popups
- [ ] Confirm all external links are accessible and relevant
- [ ] Check formatting matches existing content style