### PR TITLE
Add Factory Floor to Claude Code community tools

### DIFF
--- a/src/data/roadmaps/claude-code/content/community-tools@e12uqC2SEzaMfmBbz7VZf.md
+++ b/src/data/roadmaps/claude-code/content/community-tools@e12uqC2SEzaMfmBbz7VZf.md
@@ -6,3 +6,5 @@ Visit the following resources to learn more:
 
 - [@official@Conductor](https://docs.conductor.build/)
 - [@article@A Hands-On Review of Conductor, an AI Parallel Runner App](https://thenewstack.io/a-hands-on-review-of-conductor-an-ai-parallel-runner-app/)
+- [@opensource@Factory Floor](https://github.com/alltuner/factoryfloor)
+- [@article@Factory Floor: Parallel Development with Git Worktrees and Claude Code](https://factory-floor.com)


### PR DESCRIPTION
## Summary

Adds [Factory Floor](https://github.com/alltuner/factoryfloor) to the Claude Code roadmap's community tools section.

Factory Floor is an open-source macOS workspace for parallel development with Claude Code. It uses git worktrees to let developers run multiple Claude Code agents simultaneously on isolated branches of the same repo, each in its own terminal with a GPU-rendered Ghostty surface. It fits naturally alongside Conductor in the community tools section as another tool that extends Claude Code workflows.

- [@opensource@Factory Floor](https://github.com/alltuner/factoryfloor) - links to the GitHub repo
- [@article@Factory Floor: Parallel Development with Git Worktrees and Claude Code](https://factory-floor.com) - links to the project website