### PR TITLE
Fix typo in GraphQL roadmap under Root Fields

### DIFF
--- a/src/data/roadmaps/graphql/content/root-fields@AlJlHZD3_SPoLNaqdM-pB.md
+++ b/src/data/roadmaps/graphql/content/root-fields@AlJlHZD3_SPoLNaqdM-pB.md
@@ -4,4 +4,4 @@ Root fields are the top-level fields available to clients in GraphQL queries and
 
 Visit the following resources to learn more:
 
-- [@official@Get Started with Root Feilds](https://graphql.org/learn/execution/#root-fields-resolvers)
+- [@official@Get Started with Root Fields](https://graphql.org/learn/execution/#root-fields-resolvers)


### PR DESCRIPTION
I fixed a typo in the GraphQL roadmap from "Feilds" to "Fields".

<img width="577" height="272" alt="grafik" src="https://github.com/user-attachments/assets/f0197938-d8f5-4a1c-87bd-0d3699270a46" />
