### PR TITLE
Update blockchain roadmap title to Arbitrum

### DIFF
--- a/src/data/roadmaps/blockchain/content/arbitrum@A_yVDg-6b42ynmh71jk1V.md
+++ b/src/data/roadmaps/blockchain/content/arbitrum@A_yVDg-6b42ynmh71jk1V.md
@@ -1,4 +1,4 @@
-# undefined
+# Arbitrum
 
 Arbitrum is a Layer-2 scaling solution designed to improve the speed and reduce the costs of transactions on the Ethereum blockchain. It operates by executing transactions off-chain and then posting the results back to the main Ethereum chain, leveraging optimistic rollups to achieve higher throughput and lower gas fees compared to directly interacting with Ethereum. This allows for more complex and scalable decentralized applications (dApps) to be built and used without being constrained by the limitations of the base layer.
 


### PR DESCRIPTION
Change the title from undefined to Arbitrum for clarity in the blockchain roadmap.