### PR TITLE
Fix: Correct capitalization of WordPress in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Angular Roadmap](https://roadmap.sh/angular)
 - [Node.js Roadmap](https://roadmap.sh/nodejs)
 - [PHP Roadmap](https://roadmap.sh/php)
-- [Wordpress Roadmap](https://roadmap.sh/wordpress)
+- [WordPress Roadmap](https://roadmap.sh/wordpress)
 - [Laravel Roadmap](https://roadmap.sh/laravel)
 - [GraphQL Roadmap](https://roadmap.sh/graphql)
 - [Android Roadmap](https://roadmap.sh/android)


### PR DESCRIPTION
Fixed incorrect capitalization of "Wordpress" to "WordPress".
WordPress is a registered trademark and requires a capital P.