### PR TITLE
fix: prevent duplicate navbar rendering

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -214,9 +214,11 @@ const gaPageIdentifier = Astro.url.pathname
     <slot name='course-announcement'>
       <CourseAnnouncement client:load />
     </slot>
-    <slot name='page-header'>
-      <Navigation />
-    </slot>
+    {Astro.slots.has('page-header') ? (
+        <slot name='page-header' />
+      ) : (
+        <Navigation />
+      )}
 
     <slot />
 


### PR DESCRIPTION
### Fix Duplicate Navbar Rendering

- Fixed duplicate navbar issue caused by slot fallback behavior in BaseLayout
- Added condition to check if `page-header` slot is provided before rendering default Navigation
- Ensures navbar is rendered only once across all pages

### Impact
- Resolves duplicate navbar issue on 404 page and similar cases