### PR TITLE
docs: fix typo in AI Engineer roadmap tokens URL

### DIFF
--- a/src/data/roadmaps/ai-engineer/content/tokens@2WbVpRLqwi3Oeqk1JPui4.md
+++ b/src/data/roadmaps/ai-engineer/content/tokens@2WbVpRLqwi3Oeqk1JPui4.md
@@ -5,4 +5,4 @@ Tokens are fundamental units of text that LLMs process, created by breaking text
 Visit the following resources to learn more:
 
 - [@article@Explaining Tokens — the Language and Currency of AI](https://blogs.nvidia.com/blog/ai-tokens-explained/)
-- [@article@Understanding Tokens and Parameters in Model Training: A Deep Dive](ttps://www.functionize.com/blog/understanding-tokens-and-parameters-in-model-training)
+- [@article@Understanding Tokens and Parameters in Model Training: A Deep Dive](https://www.functionize.com/blog/understanding-tokens-and-parameters-in-model-training)


### PR DESCRIPTION
This PR fixes a small typo in the AI Engineer roadmap content. Specifically, it corrects a broken link in the "Tokens" section where the `h` was missing from the `https://` prefix.

## Changes
 - Fixed URL typo in `src/data/roadmaps/ai-engineer/content/tokens@2WbVpRLqwi3Oeqk1JPui4.md`
- Changed `ttps://www.functionize.com/...` to `https://www.functionize.com/...`

## Checklist
- [x] Followed the style guide for content.
- [x] Verified the link is now working correctly.