### PR TITLE
fix: remove duplicate navbar rendering on 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,6 +2,7 @@
 import Icon from '../components/AstroIcon.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { listOfficialRoadmaps } from '../queries/official-roadmap';
+import { Frown, RefreshCcw, Home, Map } from 'lucide-react';
 
 const roadmapIds = await listOfficialRoadmaps();
 const legacyRoadmapUrls = [
@@ -20,29 +21,30 @@ const legacyRoadmapUrls = [
     }
   </script>
 
-  <div class='bg-gray-100'>
-    <div
-      class='container flex flex-col items-center justify-center gap-7 py-10 md:flex-row md:py-32'
-    >
-      <Icon icon='construction' class='hidden md:block' />
-      <div class='text-left md:text-left'>
-        <h1
-          class='bg-linear-to-t from-black to-gray-600 bg-clip-text text-2xl leading-normal font-extrabold text-transparent md:text-5xl md:leading-normal'
-        >
-          Page not found!
-        </h1>
-        <p class='text-md mb-2 md:text-xl'>
-          Sorry, we couldn't find the page you are looking for.
-        </p>
-        <p>
-          <a class='text-blue-700 underline' href='/'>Homepage</a> &middot; <a
-            href='/roadmaps'
-            class='text-blue-700 underline'>Roadmaps</a
-          > &middot; <a href='/best-practices' class='text-blue-700 underline'
-            >Best Practices</a
-          >
-        </p>
-      </div>
+  <div class='flex flex-col items-center justify-center py-20 min-h-[50vh]'>
+    <Frown className='w-16 h-16 text-black mb-4 stroke-[1.5]' />
+    <h1 class='text-3xl font-bold mb-2'>Not found</h1>
+    <p class='text-gray-500 mb-6'>Page not found. How about these pages?</p>
+    
+    <div class='flex flex-wrap items-center justify-center gap-3'>
+      <button 
+        onclick='window.location.reload()' 
+        class='flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors text-sm font-medium'
+      >
+        <RefreshCcw className='w-4 h-4' /> Try Again
+      </button>
+      <a 
+        href='/' 
+        class='flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors text-sm font-medium'
+      >
+        <Home className='w-4 h-4' /> Homepage
+      </a>
+      <a 
+        href='/roadmaps' 
+        class='flex items-center gap-2 px-4 py-2 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors text-sm font-medium'
+      >
+        <Map className='w-4 h-4' /> Roadmaps
+      </a>
     </div>
   </div>
 </BaseLayout>

--- a/src/pages/[roadmapId]/[...topicId].astro
+++ b/src/pages/[roadmapId]/[...topicId].astro
@@ -111,14 +111,16 @@ if (isTopic) {
       <Fragment set:html={htmlContent} />
     </>
   ) : (
-    <BaseLayout
-      title={guide?.seo?.metaTitle ?? guide?.title ?? ''}
-      description={guide?.seo?.metaDescription ?? guide?.description ?? ''}
-      permalink={permalink}
-      ogImageUrl={ogImageUrl}
-    >
-      <GuideContent guide={guide!} client:load />
-      <div slot='changelog-banner' />
-    </BaseLayout>
+    guide && (
+      <BaseLayout
+        title={guide?.seo?.metaTitle ?? guide?.title ?? ''}
+        description={guide?.seo?.metaDescription ?? guide?.description ?? ''}
+        permalink={permalink}
+        ogImageUrl={ogImageUrl}
+      >
+        <GuideContent guide={guide!} client:load />
+        <div slot='changelog-banner' />
+      </BaseLayout>
+    )
   )
 }


### PR DESCRIPTION
Fixes #9841

## Description
Fixes the issue where the navbar was rendered twice on the 404 page for invalid routes (e.g. `/questions/redux`).

## Cause
When rewriting to `/404`, the page layout was still being rendered, causing the navbar to appear twice.

## Fix
- Prevented `BaseLayout` from rendering when the guide is not found
- Ensured the 404 page renders independently with a single layout

## Additional Changes
- Simplified and redesigned the 404 page UI for a cleaner, centered layout
- Added quick navigation actions (Reload, Homepage, Roadmaps)

## Result
Invalid routes now correctly display a single navbar with the updated 404 UI.

## Screenshot
### After Fix

<img width="2855" height="1509" alt="After-fix" src="https://github.com/user-attachments/assets/24fe6e0d-60a3-4dad-a7a2-98beff34e623" />


