### PR TITLE
fix: prevent duplicate navbar on 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,7 @@
 ---
 import Icon from '../components/AstroIcon.astro';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import Navigation from '../components/Navigation/Navigation.astro';
 import { listOfficialRoadmaps } from '../queries/official-roadmap';
 
 const roadmapIds = await listOfficialRoadmaps();
@@ -19,6 +20,8 @@ const legacyRoadmapUrls = [
       window.location.pathname = window.location.pathname.slice(0, -1);
     }
   </script>
+
+  <Navigation slot='page-header' />
 
   <div class='bg-gray-100'>
     <div


### PR DESCRIPTION
## Fix: Duplicate Navbar on 404 Page

Fixes #9841

### Problem
When visiting invalid routes like `/questions/redux`, the 404 page renders two identical navbars. This happens because `Astro.rewrite('/404')` causes the 404 page's `BaseLayout` to render its default `<Navigation />` in addition to the one from the rewriting page's context.

### Solution
Explicitly fill the `page-header` slot in `404.astro` with a single `<Navigation />` component. This overrides `BaseLayout`'s default slot content, ensuring only one navbar renders regardless of whether the page is accessed directly or via `Astro.rewrite()`.

### Changes
- `src/pages/404.astro`: Added `import Navigation` and `<Navigation slot='page-header' />`

### Testing
- Visited `/questions/redux` → single navbar ✓
- Visited `/nonexistent-roadmap` → single navbar ✓
- Visited valid pages (`/`, `/frontend`) → no regression ✓
