### PR TITLE
fixes #9852 : text overflow in code blocks

### DIFF
--- a/src/components/Global/CodeBlock.tsx
+++ b/src/components/Global/CodeBlock.tsx
@@ -25,7 +25,9 @@ const codeBlockClassName = cn(
   '[&_code]:bg-transparent',
   '[&_.line]:px-3',
   '[&_.line]:w-full',
-  '[&_.line]:relative',
+  '[&_.line]:block',
+  '[&_.line]:static',
+  '[&_.line]:z-auto',
   '[&_.line]:min-h-5',
 );
 


### PR DESCRIPTION
the position relative was causing the code lines in the code block component to appear above the other elements so i made the position static and set the z-index to auto to avoid any stacking issues and it was fixed.

fixes #9852
