### PR TITLE
Fix typos in Vue Options API and Kotlin Defining Classes content

### DIFF
--- a/src/data/roadmaps/kotlin/content/defining-classess@uiK2GDDnLzVbhq5erNxFL.md
+++ b/src/data/roadmaps/kotlin/content/defining-classess@uiK2GDDnLzVbhq5erNxFL.md
@@ -1,1 +1,1 @@
-# Defining Classess
+# Defining Classes

--- a/src/data/roadmaps/vue/content/options-api@PPUU3Rb73aCpT4zcyvlJE.md
+++ b/src/data/roadmaps/vue/content/options-api@PPUU3Rb73aCpT4zcyvlJE.md
@@ -1,6 +1,6 @@
 # Options API
 
-Vue offers many approaches for how to write components, including the Options API. It is the only API that is available in all versions of Vue. Its primary focus is on providing a consistent, clean, and organized aproach to writing component logic. Each part of a component's logic is given a dedicated section (data, methods, computed, props, life-cycle hooks, etc). By putting the logic in the correct section it has access to the features of the framework automatically. With the official Vue ESLint plugin the order of these sections can be enforced across all components allowing developers to predicatably locate any part of the component, even if they've never looked at the file before.
+Vue offers many approaches for how to write components, including the Options API. It is the only API that is available in all versions of Vue. Its primary focus is on providing a consistent, clean, and organized approach to writing component logic. Each part of a component's logic is given a dedicated section (data, methods, computed, props, life-cycle hooks, etc). By putting the logic in the correct section it has access to the features of the framework automatically. With the official Vue ESLint plugin the order of these sections can be enforced across all components allowing developers to predictably locate any part of the component, even if they've never looked at the file before.
 
 Visit the following resources to learn more:
 


### PR DESCRIPTION
Fixes three objective spelling errors in roadmap content.

**`src/data/roadmaps/vue/content/options-api@PPUU3Rb73aCpT4zcyvlJE.md`**
- `aproach` -> `approach`
- `predicatably` -> `predictably`

**`src/data/roadmaps/kotlin/content/defining-classess@uiK2GDDnLzVbhq5erNxFL.md`**
- `Defining Classess` -> `Defining Classes` (heading text only; left filename slug untouched to avoid breaking URLs)

Diff is two characters per word, no semantic changes.