### PR TITLE
Modify git-github roadmap resouces

### DIFF
--- a/src/data/roadmaps/git-github/content/basic-git-usage@PtU5Qwfzn3N1i3oRlCGoR.md
+++ b/src/data/roadmaps/git-github/content/basic-git-usage@PtU5Qwfzn3N1i3oRlCGoR.md
@@ -1,14 +1,9 @@
 # Basic Git Usage
 
-Starting with a new project, you'll use `git init` to initialize a repository and then make changes using `git add`. Once ready, commit your work with `git commit`. If mistakes occur, `git reset` can help correct them. You'll also interact with remote repositories, whether private or public, by adding remotes (git remote add) and managing their connections through commands like `git fetch`, `git push`, and `git pull`.
+Starting with a new project, you'll use `git init` to initialize a repository and then make changes using `git add`. Once ready, commit your work with `git commit`.
 
 Visit the following resources to learn more:
 
-- [@video@Git Tutorial for Beginners: Learn Git in 1 Hour](https://www.youtube.com/watch?v=8JJ101D3knE&t=1135s)
-- [@article@Git ignore](https://www.atlassian.com/git/tutorials/saving-changes/gitignore)
-- [@article@Git remote](https://www.atlassian.com/git/tutorials/syncing)
-- [@article@Git Cheat Sheet](https://education.github.com/git-cheat-sheet-education.pdf)
-- [@official@Git Branching - Basic Branching and Merging](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
-- [@official@Creating a new repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-new-repository)
-- [@official@Setting repository visibility](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/setting-repository-visibility)
-- [@official@Pushing commits to a remote repository](https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository)
+- [@article@Creating a Repository](https://www.atlassian.com/git/tutorials/setting-up-a-repository/git-init#:~:text=The%20git%20init%20command%20creates,run%20in%20a%20new%20project.)
+- [@course@Creating Repository (Interactive Lesson)](https://inter-git.com/lessons/creating-repository)
+- [@video@How git works: in 4 minutes](https://youtu.be/e9lnsKot_SQ?si=kUaBf-n5_hPs1RaZ)

--- a/src/data/roadmaps/git-github/content/creating-branch@OegitQ5Ngjvd3ZfMpfrkM.md
+++ b/src/data/roadmaps/git-github/content/creating-branch@OegitQ5Ngjvd3ZfMpfrkM.md
@@ -6,3 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Git branch documentation](https://git-scm.com/docs/git-branch)
 - [@article@Git branch](https://www.atlassian.com/git/tutorials/using-branches)
+- [@video@Git Branches Tutorial](https://youtu.be/e2IbNHi4uCI?si=YWJ2H_ocTaVoKkGt)

--- a/src/data/roadmaps/git-github/content/learn-the-basics@HlUUGj3dOZ68t4gIjerXh.md
+++ b/src/data/roadmaps/git-github/content/learn-the-basics@HlUUGj3dOZ68t4gIjerXh.md
@@ -5,9 +5,6 @@ A Version Control System (VCS) is a tool that helps developers manage changes to
 Visit the following resources to learn more:
 
 - [@article@What is version control?](https://www.atlassian.com/git/tutorials/what-is-version-control)
-- [@article@What is Git? - The Complete Guide to Git](https://www.datacamp.com/blog/all-about-git)
-- [@article@Version Control (Git) - The Missing Semester of Your CS Education](https://missing.csail.mit.edu/2020/version-control/)
+- [@video@Version Control System Introduction](https://youtu.be/zbKdDsNNOhg?si=FVygHoRqjDhPzkDx)
 - [@video@What is Git? Explained in 2 Minutes!](https://www.youtube.com/watch?v=2ReR1YJrNOM)
-- [@official@GUI Clients](https://git-scm.com/downloads/guis)
-- [@official@Getting Started - Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [@official@Creating an account on GitHub](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I updated resources for several nodes in the git-github roadmap. I also removed a misleading description from one topic. The description was intended to cover basic Git usage, but it included unrelated advanced concepts that should be learned later and are not part of Git fundamentals.

Additionally, I removed several links from some nodes because they were unrelated to the current topic and could be misleading or confusing for learners at this stage. These topics are covered in later nodes of the roadmap.

I also removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.