### PR TITLE
fix: correct typo in Medium article URL (double 'h' in https)

### DIFF
--- a/src/data/roadmaps/data-engineer/content/data-engineering-lifecycle@Ouph2bHeLQsrHl45ar4Cs.md
+++ b/src/data/roadmaps/data-engineer/content/data-engineering-lifecycle@Ouph2bHeLQsrHl45ar4Cs.md
@@ -12,5 +12,5 @@ It involves 4 steps:
 Visit the following resources to learn more:
 
 - [@book@Fundamentals of Data Engineering](https://www.oreilly.com/library/view/fundamentals-of-data/9781098108298/)
-- [@article@Data Engineering Lifecycle](hhttps://medium.com/towards-data-engineering/data-engineering-lifecycle-d1e7ee81632e)
+- [@article@Data Engineering Lifecycle](https://medium.com/towards-data-engineering/data-engineering-lifecycle-d1e7ee81632e)
 - [@video@Getting Into Data Engineering](https://www.youtube.com/watch?v=hZu_87l62J4)


### PR DESCRIPTION
## What

The URL linking to the Medium article in the Data Engineering Lifecycle 
bubble had a typo: double `h` at the beginning (`hhttps://`), making 
the link non-functional on all platforms.

## Fix

`hhttps://medium.com/...` -> `https://medium.com/...`