### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of positive behavior:
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints
+- Gracefully accepting constructive criticism
+
+Examples of unacceptable behavior:
+- Trolling, insulting or derogatory comments
+- Public or private harassment
+- Publishing others' private information
+
+## Enforcement
+
+Instances of abusive behavior may be reported to project maintainers.
+
+## Attribution
+
+Adapted from [Contributor Covenant](https://www.contributor-covenant.org) v2.0.


### PR DESCRIPTION
This PR adds a `CODE_OF_CONDUCT.md` file to help foster a welcoming and inclusive community.

## Changes
- Added `CODE_OF_CONDUCT.md` based on the [Contributor Covenant](https://www.contributor-covenant.org/) v2.0
- Includes our pledge, community standards, and enforcement guidelines

## Why
Having a clear code of conduct helps set expectations for community behavior and makes the project more welcoming to new contributors.

The document follows the widely-adopted Contributor Covenant standard used by thousands of open-source projects including Kubernetes, React, and Rails.