### PR TITLE
fix: correct spelling of Exercises in AI Data Scientist roadmap

### DIFF
--- a/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
+++ b/src/data/roadmaps/ai-data-scientist/ai-data-scientist.json
@@ -2770,7 +2770,7 @@
       },
       "selected": true,
       "data": {
-        "label": "Algorithmic Excercises",
+        "label": "Algorithmic Exercises",
         "href": "https://leetcode.com/explore/learn/",
         "style": {
           "fontSize": 17,


### PR DESCRIPTION
Found a spelling typo while investigating issue #9982.

   Corrected "Algorithmic Excercises" → "Algorithmic Exercises" 
   in src/data/roadmaps/ai-data-scientist/ai-data-scientist.json (line 2773)