### PR TITLE
remove the link to an article that doesn't exist

### DIFF
--- a/src/data/roadmaps/ai-engineer/content/top-p@FjV3oD7G2Ocq5HhUC17iH.md
+++ b/src/data/roadmaps/ai-engineer/content/top-p@FjV3oD7G2Ocq5HhUC17iH.md
@@ -4,5 +4,4 @@ Top-P sampling, also known as nucleus sampling, is a technique used in language 
 
 Visit the following resources to learn more:
 
-- [@article@Top-P Sampling: What Is It and Why Does It Matter?](https://www.dataannotation.tech/blog/top-p-sampling)
 - [@video@What are the LLM’s Top-P + Top-K ?](https://www.youtube.com/watch?v=aDmp2Uim0zQ)


### PR DESCRIPTION
The link to the article of Top-P in the AI engineer roadmap redirects to a 404 webpage.
 
<img width="1918" height="1200" alt="image" src="https://github.com/user-attachments/assets/30787f8a-317f-4734-ab0a-44ba60b229cb" />
