### PR TITLE
Remove broken link and add official Hibernate Transactions docs to Spring Boot Transactions section

### DIFF
--- a/src/data/roadmaps/spring-boot/content/transactions@H9Z0EvKT_148vD0mR-dUf.md
+++ b/src/data/roadmaps/spring-boot/content/transactions@H9Z0EvKT_148vD0mR-dUf.md
@@ -6,4 +6,5 @@ In hibernate framework, we have Transaction interface that defines the unit of w
 
 Visit the following resources to learn more:
 
+- [@official@Hibernate Transactions](https://docs.hibernate.org/orm/current/userguide/html_single/#transactions)
 - [@article@Hibernate Transaction Management](https://www.javaguides.net/2018/12/hibernate-transaction-management-tutorial.html)

--- a/src/data/roadmaps/spring-boot/content/transactions@H9Z0EvKT_148vD0mR-dUf.md
+++ b/src/data/roadmaps/spring-boot/content/transactions@H9Z0EvKT_148vD0mR-dUf.md
@@ -7,4 +7,3 @@ In hibernate framework, we have Transaction interface that defines the unit of w
 Visit the following resources to learn more:
 
 - [@article@Hibernate Transaction Management](https://www.javaguides.net/2018/12/hibernate-transaction-management-tutorial.html)
-- [@article@Hibernate Transaction](https://www.w3schools.blog/hibernate-transaction-management)


### PR DESCRIPTION
This PR removes a broken external link in the Spring Boot Transactions section and replaces it with the official Hibernate Transactions documentation. The previous link was no longer accessible. The new resource is the official, up-to-date reference from Hibernate, providing reliable information on transaction management concepts and usage.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eeb0ab49-c2ee-4e6b-847a-4af8475c6bba" />
