### PR TITLE
Modify devops roadmap resources related to git and version control nodes

### DIFF
--- a/src/data/roadmaps/devops/content/git@uyDm1SpOQdpHjq9zBAdck.md
+++ b/src/data/roadmaps/devops/content/git@uyDm1SpOQdpHjq9zBAdck.md
@@ -5,5 +5,6 @@ Git is a distributed version control system that tracks changes in source code d
 Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
-- [@course@Git by Example - Learn Version Control with Bite-sized Lessons](https://antonz.org/git-by-example/)
-- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=vA5TTz6BXhY)
+- [@article@Tutorial: Git for Absolutely Everyone](https://thenewstack.io/tutorial-git-for-absolutely-everyone/)
+- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)

--- a/src/data/roadmaps/devops/content/version-control-systems@LvhFmlxz5uIy7k_nzx2Bv.md
+++ b/src/data/roadmaps/devops/content/version-control-systems@LvhFmlxz5uIy7k_nzx2Bv.md
@@ -5,8 +5,6 @@ Version control systems (VCS) are tools that track changes to code and files ove
 Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
-- [@official@Git](https://git-scm.com/)
-- [@official@Mercurial](https://www.mercurial-scm.org/)
-- [@official@Subversion](https://subversion.apache.org/)
-- [@article@What is Version Control?](https://www.atlassian.com/git/tutorials/what-is-version-control)
-- [@video@Version Control System (VCS)](https://www.youtube.com/watch?v=SVkuliabq4g)
+- [@video@What is a Version Control System and why you should always use it](https://www.youtube.com/watch?v=IeXhYROClZk)
+- [@article@What is version control?](https://www.atlassian.com/git/tutorials/what-is-version-control)
+- [@course@Why version control? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.