### PR TITLE
Modify resouces related to android roadmap git node

### DIFF
--- a/src/data/roadmaps/android/content/git@rqSZ2ATeHbOdIQE9Jlb0B.md
+++ b/src/data/roadmaps/android/content/git@rqSZ2ATeHbOdIQE9Jlb0B.md
@@ -5,5 +5,6 @@
 Visit the following resources to learn more:
 
 - [@roadmap@Git and GitHub Roadmap](https://roadmap.sh/git-github)
-- [@official@Git](https://git-scm.com/)
-- [@official@Git Documentation](https://git-scm.com/docs)
+- [@article@Tutorial: Git for Absolutely Everyone](https://thenewstack.io/tutorial-git-for-absolutely-everyone/)
+- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.