### PR TITLE
Modify resouces related to blockchain roadmap git node

### DIFF
--- a/src/data/roadmaps/blockchain/content/git@gpS5CckcQZX3TMFQ2jtIL.md
+++ b/src/data/roadmaps/blockchain/content/git@gpS5CckcQZX3TMFQ2jtIL.md
@@ -5,9 +5,6 @@ Git is a distributed version control system that tracks changes to files in a pr
 Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Git Roadmap](https://roadmap.sh/git-github)
-- [@official@Git](https://git-scm.com/)
-- [@official@Git Documentation](https://git-scm.com/doc)
-- [@article@Learn Git with Tutorials, News and Tips - Atlassian](https://www.atlassian.com/git)
-- [@article@Git Cheat Sheet](https://cs.fyi/guide/git-cheatsheet)
+- [@article@Tutorial: Git for Absolutely Everyone](https://thenewstack.io/tutorial-git-for-absolutely-everyone/)
 - [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
-- [@feed@Explore top posts about Git](https://app.daily.dev/tags/git?ref=roadmapsh)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.