### PR TITLE
Modify qa engineer roadmap resources related to git and version control nodes

### DIFF
--- a/src/data/roadmaps/qa/content/git@WrqKdOTRUiOnc1aIhTZeB.md
+++ b/src/data/roadmaps/qa/content/git@WrqKdOTRUiOnc1aIhTZeB.md
@@ -4,9 +4,7 @@ Git is a free and open source distributed version control system designed to han
 
 Visit the following resources to learn more:
 
-- [@official@Git](https://git-scm.com/)
-- [@article@Learn Git with Tutorials, News and Tips - Atlassian](https://www.atlassian.com/git)
-- [@article@Git Cheat Sheet](https://cs.fyi/guide/git-cheatsheet)
+- [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
+- [@article@Tutorial: Git for Absolutely Everyone](https://thenewstack.io/tutorial-git-for-absolutely-everyone/)
 - [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
-- [@video@Complete Git and GitHub Tutorial](https://www.youtube.com/watch?v=apGV9Kg7ics)
-- [@feed@Explore top posts about Git](https://app.daily.dev/tags/git?ref=roadmapsh)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)

--- a/src/data/roadmaps/qa/content/version-control-system@s8o5fXu3XHrMduh8snLwu.md
+++ b/src/data/roadmaps/qa/content/version-control-system@s8o5fXu3XHrMduh8snLwu.md
@@ -4,7 +4,7 @@ Version control/source control systems allow developers to track and control cha
 
 Visit the following resources to learn more:
 
-- [@official@Git](https://git-scm.com/)
-- [@official@Mercurial](https://www.mercurial-scm.org/)
-- [@article@What is Version Control?](https://www.atlassian.com/git/tutorials/what-is-version-control)
-- [@feed@Explore top posts about QA](https://app.daily.dev/tags/qa?ref=roadmapsh)
+- [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
+- [@video@What is a Version Control System and why you should always use it](https://www.youtube.com/watch?v=IeXhYROClZk)
+- [@article@What is version control?](https://www.atlassian.com/git/tutorials/what-is-version-control)
+- [@course@Why version control? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.