### PR TITLE
Modify resouces related to software architect roadmap git node

### DIFF
--- a/src/data/roadmaps/software-architect/content/git@ZEzYb-i55hBe9kK3bla94.md
+++ b/src/data/roadmaps/software-architect/content/git@ZEzYb-i55hBe9kK3bla94.md
@@ -5,7 +5,6 @@ Git is a distributed version control system designed to handle projects of any s
 Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
-- [@article@Git Cheat Sheet](https://cs.fyi/guide/git-cheatsheet)
 - [@article@Tutorial: Git for Absolutely Everyone](https://thenewstack.io/tutorial-git-for-absolutely-everyone/)
 - [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
-- [@feed@Explore top posts about Git](https://app.daily.dev/tags/git?ref=roadmapsh)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
I removed several resource links that I believe provide low learning value for beginners. Some of these links pointed to official documentation, which tends to be quite dry and more suited for experienced users. Others led to aggregator websites that simply list resources, many of which are not beginner-friendly. A few also directed to general Git feeds, which I don’t think are particularly helpful or engaging for learners at this stage. I added several resources that I think provide best learning value for beginners.