### PR TITLE
Update HTML Priority Hints article link to fetchpriority attribute

### DIFF
--- a/src/data/roadmaps/html/content/priority-hints@znqYy9Tgfpe-qakjRr7KU.md
+++ b/src/data/roadmaps/html/content/priority-hints@znqYy9Tgfpe-qakjRr7KU.md
@@ -4,4 +4,4 @@ Priority Hints in HTML allow developers to indicate the relative priority of fet
 
 Visit the following resources to learn more:
 
-- [@article@Priority header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Priority)
+- [@article@fetchpriority HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority)


### PR DESCRIPTION
The article link for HTML Priority Hints was linking to MDN's priority header but this is not what the summary is talking about.

The two concepts are linked - but the Priority header article doesn't explain this (maybe it used to?)

This Cloudflare article provides a more detailed explanation of how the HTML `fetchpriority` attribute is linked to the HTTP Priority header. However I'm not sure if this is within the scope of a HTML roadmap.

https://blog.cloudflare.com/better-http-3-prioritization-for-a-faster-web/