### PR TITLE
fix(golang): Replace bad links in "encoding/json" node

### DIFF
--- a/src/data/roadmaps/golang/content/encodingjson@uB1fE15OprBcwN7p7ffJF.md
+++ b/src/data/roadmaps/golang/content/encodingjson@uB1fE15OprBcwN7p7ffJF.md
@@ -4,5 +4,6 @@ This package provides robust and efficient functionalities for marshaling (encod
 
 Visit the following resources to learn more:
 
-- [@official@Empty Interface](https://go.dev/tour/methods/14)
-- [@article@Understanding the empty interface in Go](https://dev.to/flrnd/understanding-the-empty-interface-in-go-4652)
+- [@official@Encoding/json package](https://pkg.go.dev/encoding/json)
+- [@article@Go by Example: JSON](https://gobyexample.com/json)
+- [@article@How To Use JSON in Go](https://www.digitalocean.com/community/tutorials/how-to-use-json-in-go)


### PR DESCRIPTION
I've noticed that "encoding/json" node has links from the previous "Empty Interfaces" node. Official documentation and GoByExample are definitely valuable for learners, the one from the digitalocean is optional, imo. 


P.S. There is another typo like this somewhere in the previous nodes, just can't remember where.