### PR TITLE
Fix SvelteKit label under SSR

### DIFF
--- a/src/data/roadmaps/frontend/frontend.json
+++ b/src/data/roadmaps/frontend/frontend.json
@@ -3564,7 +3564,7 @@
       },
       "selected": false,
       "data": {
-        "label": "Svelte Kit",
+        "label": "SvelteKit",
         "style": {
           "fontSize": 17,
           "justifyContent": "flex-start",


### PR DESCRIPTION
## Summary
- Rename the Frontend roadmap SSR node label from `Svelte Kit` to `SvelteKit`.
- Keeps SSR framework naming consistent with other entries (e.g. `Next.js`, `Nuxt.js`).

Fixes #10021

## Test plan
- [x] Check `Frontend` roadmap  SSR section shows `Svelte` with `SvelteKit` (one word) under it.

Made with [Cursor](https://cursor.com)