### PR TITLE
Fix broken resource links and typo in DevOps roadmap

### DIFF
--- a/src/data/roadmaps/devops/content/artifactory@C_sFyIsIIpriZlovvcbSE.md
+++ b/src/data/roadmaps/devops/content/artifactory@C_sFyIsIIpriZlovvcbSE.md
@@ -5,4 +5,4 @@ Artifactory is a universal artifact repository manager developed by JFrog that s
 Visit the following resources to learn more:
 
 - [@official@Artifactory Website](https://jfrog.com/artifactory/)
-- [@video@Key Features of JFrog Artifactory in 5 Minutes](https://www.youtube.com/watch?v=ZCNOtVj7bow)
+- [@video@Key Features of JFrog Artifactory in 5 Minutes](https://www.youtube.com/watch?v=LoTyOSCssvM)

--- a/src/data/roadmaps/devops/content/fluxcd@6gVV_JUgKgwJb4C8tHZn7.md
+++ b/src/data/roadmaps/devops/content/fluxcd@6gVV_JUgKgwJb4C8tHZn7.md
@@ -4,5 +4,5 @@ Flux is an open-source GitOps tool that automatically synchronizes the state of 
 
 Visit the following resources to learn more:
 
-- [@official@Flux CD](https://docs.fluxcd.io/)
+- [@official@Flux CD](https://fluxcd.io/flux/)
 - [@video@Introduction to Flux CD on Kubernetes](https://www.youtube.com/watch?v=X5W_706-jSY)

--- a/src/data/roadmaps/devops/content/sealed-secrets@ZWq23Q9ZNxLNti68oltxA.md
+++ b/src/data/roadmaps/devops/content/sealed-secrets@ZWq23Q9ZNxLNti68oltxA.md
@@ -4,5 +4,5 @@ Sealed Secrets is a Kubernetes-focused tool developed by Bitnami that lets you e
 
 Visit the following resources to learn more:
 
-- [@opensource@bitname/sealed-secrets](https://github.com/bitnami-labs/sealed-secrets)
+- [@opensource@bitnami/sealed-secrets](https://github.com/bitnami-labs/sealed-secrets)
 - [@article@Sealed Secrets](https://fluxcd.io/flux/guides/sealed-secrets/)


### PR DESCRIPTION
Roadmap: DevOps

**Issues**
- The Artifactory node contains a broken YouTube link.
- The FluxCD node links to a migration guide instead of the official documentation.
- The Sealed Secrets node contains a typo in the link text ("_bitname"_).

**Changes**
- Replaced the broken link with a working YouTube resource.
- Updated FluxCD link to official documentation page.
- Corrected the typo (_"bitname" → "bitnami"_).