### PR TITLE
Fix broken resource links and typo in DevOps roadmap

### DIFF
--- a/src/data/roadmaps/devops/content/chef@kv508kxzUj_CjZRb-TeRv.md
+++ b/src/data/roadmaps/devops/content/chef@kv508kxzUj_CjZRb-TeRv.md
@@ -5,5 +5,5 @@ Chef is a configuration management tool that uses Ruby-based scripts called "rec
 Visit the following resources to learn more:
 
 - [@official@Chef Website](https://www.chef.io/products/chef-infra)
+- [@opensource@Chef](https://github.com/chef/chef)
 - [@article@Chef Tutorial](https://www.tutorialspoint.com/chef/index.htm)
-- [@video@chef/chef](https://github.com/chef/chef)

--- a/src/data/roadmaps/devops/content/dynatrace@4aJVaimsuvGIPXMZ_WjaA.md
+++ b/src/data/roadmaps/devops/content/dynatrace@4aJVaimsuvGIPXMZ_WjaA.md
@@ -4,6 +4,6 @@ Dynatrace is an AI-powered observability and application performance monitoring 
 
 Visit the following resources to learn more:
 
-- [@official@Dynatrace Documentation Learn](https://docs.dynatrace.com/docs)
+- [@official@Dynatrace Documentation](https://docs.dynatrace.com/docs)
 - [@video@What is Dynatrace in 15 minutes](https://www.youtube.com/watch?v=qo6vjyE-Ak0)
-- [@video@ynatrace Fundamental Tutorials](https://www.youtube.com/watch?v=F2PvOaM5Iws&list=PLDhScTEBdP8yAgvshsI_TwWvH2FCiOtd5)
+- [@video@Dynatrace Fundamental Tutorials](https://www.youtube.com/watch?v=F2PvOaM5Iws&list=PLDhScTEBdP8yAgvshsI_TwWvH2FCiOtd5)

--- a/src/data/roadmaps/devops/content/jaeger@8rd7T5ahK2I_zh5co-IF-.md
+++ b/src/data/roadmaps/devops/content/jaeger@8rd7T5ahK2I_zh5co-IF-.md
@@ -5,5 +5,5 @@ Jaeger is an open-source distributed tracing platform originally developed by Ub
 Visit the following resources to learn more:
 
 - [@official@Jaeger](https://www.jaegertracing.io/)
-- [@official@Jaeger Documentation](https://www.jaegertracing.io/docs/1.37/)
+- [@official@Jaeger Documentation](https://www.jaegertracing.io/docs/latest)
 - [@opensource@jaegertracing/jaeger](https://github.com/jaegertracing/jaeger)

--- a/src/data/roadmaps/devops/content/nexus@ootuLJfRXarVvm3J1Ir11.md
+++ b/src/data/roadmaps/devops/content/nexus@ootuLJfRXarVvm3J1Ir11.md
@@ -4,5 +4,5 @@ The Nexus Repository Manager is a widely used repository manager software develo
 
 Visit the following resources to learn more:
 
-- [@article@Repository Management Basics](https://learn.sonatype.com/courses/nxrm-admin-100/)
+- [@article@Using Nexus Repository](https://help.sonatype.com/en/using-nexus-repository.html)
 - [@article@Nexus Best Practices](https://help.sonatype.com/repomanager3/nexus-repository-best-practices)

--- a/src/data/roadmaps/devops/content/observability@wNguM6-YEznduz3MgBCYo.md
+++ b/src/data/roadmaps/devops/content/observability@wNguM6-YEznduz3MgBCYo.md
@@ -5,5 +5,4 @@ Observability is the ability to understand the internal state of a system by exa
 Visit the following resources to learn more:
 
 - [@article@Applying Basic vs. Advanced Monitoring Techniques](https://thenewstack.io/applying-basic-vs-advanced-monitoring-techniques/)
-- [@article@Why Legacy Apps Need Your Monitoring Love, Too](https://thenewstack.io/why-legacy-apps-need-your-monitoring-love-too/)
 - [@video@Application Monitoring - 4 Golden Signals](https://www.youtube.com/watch?v=PHcnmTdVPT0)

--- a/src/data/roadmaps/devops/content/papertrail@cjjMZdyLgakyVkImVQTza.md
+++ b/src/data/roadmaps/devops/content/papertrail@cjjMZdyLgakyVkImVQTza.md
@@ -6,4 +6,4 @@ Visit the following resources to learn more:
 
 - [@official@Papertrail Guides](https://www.papertrail.com/solution/guides/)
 - [@official@Papertrail Blog](https://www.papertrail.com/blog/)
-- [@video@SolarWinds Papertrail Overview](https://www.youtube.com/watch?v=gFFtrzoQEfI)
+- [@video@SolarWinds Papertrail Overview](https://www.youtube.com/watch?v=lx3UyNSn8AQ)

--- a/src/data/roadmaps/devops/content/python@TwVfCYMS9jSaJ6UyYmC-K.md
+++ b/src/data/roadmaps/devops/content/python@TwVfCYMS9jSaJ6UyYmC-K.md
@@ -6,5 +6,5 @@ Visit the following resources to learn more:
 
 - [@roadmap@Visit Dedicated Python Roadmap](https://roadmap.sh/python)
 - [@official@Python Website](https://www.python.org/)
-- [@article@Python Crash Course](https://ehmatthes.github.io/pcc/)
+- [@article@Python Crash Course](https://ehmatthes.github.io/pcc_3e/)
 - [@video@Python Full Course for free](https://www.youtube.com/watch?v=ix9cRaBkVe0)


### PR DESCRIPTION
Roadmap: DevOps

**Changes**

- **Chef** - Corrected GitHub link type (OpenSource instead of Video).
- **Dynatrace** - Improve link text and corrected a typo.
- **Jaeger, Nexus, Papertrail, Python** - Replaced outdated links.
- **Observability** - Removed a dead article.