### PR TITLE
Fix roadmap resource titles with HTML tags

### DIFF
--- a/scripts/sync-content-to-repo.ts
+++ b/scripts/sync-content-to-repo.ts
@@ -3,7 +3,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { slugify } from '../src/lib/slugger';
 import type { OfficialRoadmapDocument } from '../src/queries/official-roadmap';
-import type { OfficialRoadmapTopicContentDocument } from '../src/queries/official-roadmap-topic';
+import {
+  formatOfficialRoadmapTopicResourceLink,
+  type OfficialRoadmapTopicContentDocument,
+} from '../src/queries/official-roadmap-topic';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -106,7 +109,11 @@ function prepareTopicContent(topic: OfficialRoadmapTopicContentDocument) {
 
   let content = description;
   if (resources.length > 0) {
-    content += `\n\nVisit the following resources to learn more:\n\n${resources.map((resource) => `- [@${resource.type}@${resource.title}](${resource.url})`).join('\n')}`;
+    const resourceLinks = resources
+      .map(formatOfficialRoadmapTopicResourceLink)
+      .join('\n');
+
+    content += `\n\nVisit the following resources to learn more:\n\n${resourceLinks}`;
   }
 
   return content;

--- a/src/queries/official-roadmap-topic.ts
+++ b/src/queries/official-roadmap-topic.ts
@@ -63,6 +63,21 @@ export async function getOfficialRoadmapTopic(
   }
 }
 
+export function escapeMarkdownLinkText(text: string) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/</g, '\\<')
+    .replace(/>/g, '\\>')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]');
+}
+
+export function formatOfficialRoadmapTopicResourceLink(
+  resource: Pick<OfficialRoadmapTopicResource, 'type' | 'title' | 'url'>,
+) {
+  return `- [@${resource.type}@${escapeMarkdownLinkText(resource.title)}](${resource.url})`;
+}
+
 export function prepareOfficialRoadmapTopicContent(
   topic: OfficialRoadmapTopicContentDocument,
 ) {
@@ -70,7 +85,11 @@ export function prepareOfficialRoadmapTopicContent(
 
   let content = description;
   if (resources.length > 0) {
-    content += `\n\nVisit the following resources to learn more:\n\n${resources.map((resource) => `- [@${resource.type}@${resource.title}](${resource.url})`).join('\n')}`;
+    const resourceLinks = resources
+      .map(formatOfficialRoadmapTopicResourceLink)
+      .join('\n');
+
+    content += `\n\nVisit the following resources to learn more:\n\n${resourceLinks}`;
   }
 
   return content;


### PR DESCRIPTION
## Summary
- Escape angle brackets and markdown brackets in roadmap resource titles before rendering them as markdown links
- Reuse the same formatter when syncing official topic content back to the repo

## Why
Resource titles such as `<a>: The Anchor element` on the HTML roadmap can be parsed as HTML inside generated markdown links, so the displayed resource title is broken or missing.

Closes #10035

## Testing
- Ran `git diff --check`
- Could not run the project test suite locally because Node.js / npm / pnpm are not available in this environment