### PR TITLE
fix(backend): correct inaccurate RethinkDB description and add learning resources

### DIFF
--- a/src/data/roadmaps/backend/content/rethinkdb@5T0ljwlHL0545ICCeehcQ.md
+++ b/src/data/roadmaps/backend/content/rethinkdb@5T0ljwlHL0545ICCeehcQ.md
@@ -1,8 +1,10 @@
 # RethinkDB
 
-RethinkDB is an open-source, distributed NoSQL database for real-time applications. Features changefeed for automatic data update notifications, JSON document model, rich queries with joins and aggregations. Supports horizontal scaling through sharding and replication. Development ceased in 2016.
+RethinkDB is an open-source, distributed NoSQL database for real-time applications. Features changefeed for automatic data update notifications, JSON document model, rich queries with joins and aggregations. Supports horizontal scaling through sharding and replication. After the original company shut down in 2016, the project was open-sourced and is now maintained by the community, with releases continuing as recently as 2023.
 
 Visit the following resources to learn more:
 
 - [@course@RethinkDB Crash Course](https://www.youtube.com/watch?v=pW3PFtchHDc)
 - [@official@RethinkDB Website](https://rethinkdb.com/)
+- [@official@Ten-minute Guide with RethinkDB](https://rethinkdb.com/docs/guide/)
+- [@feed@Explore top posts about RethinkDB](https://app.daily.dev/tags/rethinkdb?ref=roadmapsh)


### PR DESCRIPTION
## Summary

The RethinkDB content in the Backend roadmap contained a factually incorrect statement and was missing useful learning resources.

## Changes

### 1. Corrected inaccurate description

The description previously stated:

> Development ceased in 2016.

This is **incorrect**. While the original RethinkDB company (the startup) shut down in 2016, the project was open-sourced and is **actively maintained by the community**. The latest release, **v2.4.4, was published in December 2023**.

Source: [RethinkDB official blog](https://rethinkdb.com/blog/) and [GitHub releases](https://github.com/rethinkdb/rethinkdb).

Updated text:
> After the original company shut down in 2016, the project was open-sourced and is now maintained by the community, with releases continuing as recently as 2023.

### 2. Added learning resources

The topic previously only had 2 resources. Added:
- **Ten-minute Guide with RethinkDB** (official docs) — a practical getting-started tutorial
- **Explore top posts about RethinkDB** (feed) — consistent with other roadmap topics

## Verification

- [x] Verified the latest release date via the official RethinkDB blog (v2.4.4, Dec 2023)
- [x] Confirmed the official guide URL is live (https://rethinkdb.com/docs/guide/)
- [x] Followed the existing content format used across the roadmap

## Affected file

`src/data/roadmaps/backend/content/rethinkdb@5T0ljwlHL0545ICCeehcQ.md`