### PR TITLE
content(backend): add missing learning resources to Search Engines topic

### DIFF
--- a/src/data/roadmaps/backend/content/search-engines@gKTSe9yQFVbPVlLzWB0hC.md
+++ b/src/data/roadmaps/backend/content/search-engines@gKTSe9yQFVbPVlLzWB0hC.md
@@ -5,3 +5,7 @@ Search engines like Elasticsearch are specialized tools for fast, scalable searc
 Visit the following resources to learn more:
 
 - [@official@Elasticsearch](https://www.elastic.co/elasticsearch/)
+- [@article@What is Elasticsearch? - Official Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html)
+- [@official@Intro to OpenSearch](https://opensearch.org/docs/latest/getting-started/intro/)
+- [@video@Elasticsearch Tutorial for Beginners](https://www.youtube.com/watch?v=ZP0NmfyNsuo)
+- [@feed@Explore top posts about Elasticsearch](https://app.daily.dev/tags/elasticsearch?ref=roadmapsh)


### PR DESCRIPTION
## Summary

The **Search Engines** topic in the Backend roadmap currently lists only a **single resource** — the Elasticsearch homepage. This PR adds four high-quality learning resources so learners have a proper starting point.

## Changes

Added the following resources to `src/data/roadmaps/backend/content/search-engines@gKTSe9yQFVbPVlLzWB0hC.md`:

| Resource | Type | Why it's useful |
|----------|------|-----------------|
| [What is Elasticsearch? - Official Docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) | Article | The official conceptual introduction to how Elasticsearch works |
| [Intro to OpenSearch](https://opensearch.org/docs/latest/getting-started/intro/) | Official | OpenSearch is the popular open-source fork of Elasticsearch; important for learners to know |
| [Elasticsearch Tutorial for Beginners](https://www.youtube.com/watch?v=ZP0NmfyNsuo) | Video | A hands-on beginner tutorial |
| [Explore top posts about Elasticsearch](https://app.daily.dev/tags/elasticsearch?ref=roadmapsh) | Feed | Consistent with the format used across other roadmap topics |

## Verification

All links were checked and resolve with HTTP 200:
- [x] Elasticsearch official docs intro
- [x] OpenSearch intro
- [x] YouTube tutorial
- [x] daily.dev feed (matches the `ref=roadmapsh` convention used elsewhere)
- [x] Followed the existing content format used across the roadmap

## Before / After

**Before** — 1 resource:
- Elasticsearch homepage

**After** — 5 resources covering official docs, a major alternative (OpenSearch), a video tutorial, and a community feed.