### PR TITLE
Add Forward Deployed Engineer path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Ruby Roadmap](https://roadmap.sh/ruby)
 - [Ruby on Rails Roadmap](https://roadmap.sh/ruby-on-rails)
 - [Scala Roadmap](https://roadmap.sh/scala)
-- [Forward Deployed Engineer](https://roadmap.sh/forward-deployed-engineer)
+- [Forward Deployed Engineer Roadmap](https://roadmap.sh/forward-deployed-engineer)
 
 
 There are also interactive best practices:

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ Here is the list of available roadmaps with more being actively worked upon.
 - [Ruby Roadmap](https://roadmap.sh/ruby)
 - [Ruby on Rails Roadmap](https://roadmap.sh/ruby-on-rails)
 - [Scala Roadmap](https://roadmap.sh/scala)
+- [Forward Deployed Engineer](https://roadmap.sh/forward-deployed-engineer)
 
 
 There are also interactive best practices:


### PR DESCRIPTION
## Description

I have updated the readme.md file with adding the missing path `Forward Deployed Engineer` roadmap with link

## File change

```tsx
    readme.md
```