### PR TITLE
Restrict AWS cost workflow to parent repository and fix fork check

### DIFF
--- a/.github/workflows/aws-costs.yml
+++ b/.github/workflows/aws-costs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   aws_costs:
     runs-on: ubuntu-latest
-    if: github.repository == github.event.repository.full_name
+    if: github.event.repository.fork == false
     steps:
       - name: Get Costs
         env:

--- a/.github/workflows/aws-costs.yml
+++ b/.github/workflows/aws-costs.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   aws_costs:
     runs-on: ubuntu-latest
+    if: github.repository == github.event.repository.full_name
     steps:
       - name: Get Costs
         env:


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow for AWS cost reporting. The workflow will now only run on the main repository and not on forks, preventing unnecessary execution in forked repositories.