### PR TITLE
add resources links to blockchain roadmap git node

### DIFF
--- a/src/data/roadmaps/blockchain/content/git@gpS5CckcQZX3TMFQ2jtIL.md
+++ b/src/data/roadmaps/blockchain/content/git@gpS5CckcQZX3TMFQ2jtIL.md
@@ -4,10 +4,7 @@ Git is a distributed version control system that tracks changes to files in a pr
 
 Visit the following resources to learn more:
 
-- [@roadmap@Visit Dedicated Git Roadmap](https://roadmap.sh/git-github)
-- [@official@Git](https://git-scm.com/)
-- [@official@Git Documentation](https://git-scm.com/doc)
-- [@article@Learn Git with Tutorials, News and Tips - Atlassian](https://www.atlassian.com/git)
-- [@article@Git Cheat Sheet](https://cs.fyi/guide/git-cheatsheet)
-- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=SWYqp7iY_Tc)
-- [@feed@Explore top posts about Git](https://app.daily.dev/tags/git?ref=roadmapsh)
+- [@roadmap@Visit Dedicated Git & GitHub Roadmap](https://roadmap.sh/git-github)
+- [@article@Git by Example - Learn Version Control with Bite-sized Lessons](https://antonz.org/git-by-example/)
+- [@video@Git & GitHub Crash Course For Beginners](https://www.youtube.com/watch?v=vA5TTz6BXhY)
+- [@course@Why use Git? (Interactive Lesson)](https://inter-git.com/lessons/introduction)


### PR DESCRIPTION
add resources links to blockchain roadmap git node, remove links to low quality resources which points to new feeds, git documentation which are very technical for beginners.