### PR TITLE
Fix Python file handling resource title

### DIFF
--- a/src/data/roadmaps/python/content/file-handling@Nf3kRDSl_vas6QPXG7eVa.md
+++ b/src/data/roadmaps/python/content/file-handling@Nf3kRDSl_vas6QPXG7eVa.md
@@ -4,7 +4,7 @@ File handling in Python involves reading data from and writing data to files. It
 
 Visit the following resources to learn more:
 
-- [@article@Pyhton File open](https://www.w3schools.com/python/python_file_handling.asp)
+- [@article@Python File open](https://www.w3schools.com/python/python_file_handling.asp)
 - [@article@Working With Files in Python](https://realpython.com/working-with-files-in-python/)
 - [@article@Working With JSON Data in Python](https://realpython.com/python-json/)
 - [@video@Python File Handling for Beginners](https://www.youtube.com/watch?v=BRrem1k3904)


### PR DESCRIPTION
## Summary

- Fixes a typo in the Python file handling resources list.
- Updates `Pyhton File open` to `Python File open`.

## Validation

- Ran `git diff --check`.
- Confirmed the corrected resource title is present in the updated file.