### PR TITLE
fix(fde): remove duplicate ghost introduction file resolving devops node bug

### DIFF
--- a/src/data/roadmaps/forward-deployed-engineer/content/introduction@LRBwP7EQj4byox7yKdPAj.md
+++ b/src/data/roadmaps/forward-deployed-engineer/content/introduction@LRBwP7EQj4byox7yKdPAj.md
@@ -1,8 +1,0 @@
-# Introduction
- 
-A Forward Deployed Engineer is a software engineer who works directly inside a customer's environment to build, deploy, and stabilize AI systems. The role originated at Palantir, where engineers called Deltas would embed with clients, sometimes on military bases, to ship code overnight based on feedback from the field that same day. That same idea is now at the center of how companies like OpenAI and Anthropic are bringing AI into large enterprises. The job requires technical depth, the ability to read an unfamiliar codebase quickly, and the communication skills to explain what AI can and cannot do to a non-technical decision maker.
-
-Visit the following resources to learn more:
-
-- [@article@Forward deployed engineer is AI’s hottest job](https://thenewstack.io/forward-deployed-engineer-fde-openai-google/)
-- [@article@Forward-deployed engineer: The complete guide](https://www.rocketlane.com/blogs/forward-deployed-engineer)


### PR DESCRIPTION
### Target Issue
Closes #10110 

### Changes Made
- Deleted `src/data/roadmaps/forward-deployed-engineer/content/introduction@LRBwP7EQj4byox7yKdPAj.md`.

### Context
This ghost file shared an identical node ID (`LRBwP7EQj4byox7yKdPAj`) with the official `devops-skills` content file and its content was an exact duplicate of the correct introduction file ( `introduction@PBtnaTE_5AMOa5mxbhoT2.md` ). 
This collision caused the build script to overwrite or serve the introduction payload instead of the DevOps resources when the DevOps node was clicked in the UI. 

Removing this file completely clears the collision and restores the correct content mapping.