### PR TITLE
docs: fix typo in JavaScript example

### DIFF
--- a/src/data/question-groups/javascript/content/adding-javascript-to-html.md
+++ b/src/data/question-groups/javascript/content/adding-javascript-to-html.md
@@ -77,7 +77,7 @@ Inline JavaScript lets you place your JavaScript code into an HTML element's att
 Using inline JavaScript is suitable for fast and easy tasks. But it can make your HTML code difficult to read, especially if you have a lot of JavaScript code.
 
 ```html
-<button onclick="console.log('A click occured')">
+<button onclick="console.log('A click occurred')">
       Sign up on roadmap.sh
 </button>
 ``` 


### PR DESCRIPTION
## Summary
- Fixes a spelling typo in the inline JavaScript example for adding JavaScript to HTML.

## Why this is useful
- The example is user-facing learning content, so correcting the typo keeps the snippet polished and easier to read.

## Verification
- Ran `git diff --check`
- Verified the touched file no longer contains `A click occured` and now contains `A click occurred`
