### PR TITLE
Add OopsSec Store to OWASP Top 10 & Web-Based Attacks resources

### DIFF
--- a/src/data/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
+++ b/src/data/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
@@ -5,4 +5,5 @@ The OWASP Top 10 is a regularly updated list that highlights the most critical s
 Visit the following resources to learn more:
 
 - [@official@OWASP Top Ten](https://owasp.org/www-project-top-ten/)
+- [@opensource@OopsSec Store - Runnable OWASP Top 10 Lab (OWASP VWAD listed)](https://vwad.owasp.org/app/oopssec-store/)
 - [@video@OWASP Top Ten](https://youtube.com/playlist?list=PLyqga7AXMtPOguwtCCXGZUKvd2CDCmUgQ&si=ZYRbcDSRvqTOnDOo)

--- a/src/data/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
+++ b/src/data/roadmaps/cyber-security/content/web-based-attacks-and-owasp10@fyOYVqiBqyKC4aqc6-y0q.md
@@ -5,5 +5,5 @@ The OWASP Top 10 is a regularly updated list that highlights the most critical s
 Visit the following resources to learn more:
 
 - [@official@OWASP Top Ten](https://owasp.org/www-project-top-ten/)
-- [@opensource@OopsSec Store - Runnable OWASP Top 10 Lab (OWASP VWAD listed)](https://vwad.owasp.org/app/oopssec-store/)
+- [@official@OWASP Vulnerable Web Applications Directory (VWAD)](https://vwad.owasp.org/)
 - [@video@OWASP Top Ten](https://youtube.com/playlist?list=PLyqga7AXMtPOguwtCCXGZUKvd2CDCmUgQ&si=ZYRbcDSRvqTOnDOo)


### PR DESCRIPTION
### What

Adds one `@opensource@` resource to the **OWASP Top 10 and Web-Based Attacks** topic in the Cyber Security roadmap.

- OopsSec Store - https://vwad.owasp.org/app/oopssec-store/

### Why

The topic currently links the OWASP Top Ten spec and a video, but no **runnable, hands-on lab** where learners can actually exploit these vulnerabilities. OopsSec Store fills that gap: an MIT-licensed, intentionally vulnerable e-commerce app (XSS, CSRF, IDOR, SQLi, JWT, path traversal, …) that runs in under a minute via `npx create-oss-store` or Docker, with a guided [35-flag CTF roadmap](https://koadt.github.io/oss-oopssec-store/roadmap/) and a walkthrough for every challenge.

It complements the existing OWASP entry the same way VulnHub complements the CTF section -> theory plus a safe, legal environment to practice it.

### Disclosure

Full transparency: I'm the author of this project. I'm submitting it because it fills a missing "practice environment" slot for this topic.  I'm linking the OWASP VWAD directory entry (not my own repo). Happy to adjust the wording/placement or drop it if you feel it doesn't fit.

### Guidelines checklist

- [x] Resource is in English
- [x] Topic stays well under the 8-link limit (3 total)
- [x] Correct type tag (`@opensource@`)
- [x] Personally evaluated (it's the project I maintain)
