### PR TITLE
feat: add learning resources to ai-data-scientist roadmap topics

### DIFF
--- a/src/data/roadmaps/ai-data-scientist/content/coding@XLDWuSt4tI4gnmqMFdpmy.md
+++ b/src/data/roadmaps/ai-data-scientist/content/coding@XLDWuSt4tI4gnmqMFdpmy.md
@@ -1,3 +1,11 @@
 # Coding
 
 Programming is a fundamental skill for data scientists. You need to be able to write code to manipulate data, build models, and deploy solutions. The most common programming languages used in data science are Python and R. Python is a general-purpose programming language that is easy to learn and has a large number of libraries for data manipulation and machine learning. R is a programming language and free software environment for statistical computing and graphics. It is widely used for statistical analysis and data visualization.
+
+Visit the following resources to learn more:
+
+- [@official@The Python Tutorial](https://docs.python.org/3/tutorial/)
+- [@official@The R Manuals (CRAN)](https://cran.r-project.org/manuals.html)
+- [@course@Python for Data Science, AI & Development](https://www.coursera.org/learn/python-for-applied-data-science-ai)
+- [@course@Kaggle Learn: Python](https://www.kaggle.com/learn/python)
+- [@article@Introduction to Data Science with Python (Harvard)](https://pll.harvard.edu/course/introduction-data-science-python)

--- a/src/data/roadmaps/ai-data-scientist/content/econometrics@Gd2egqKZPnbPW1W2jw4j8.md
+++ b/src/data/roadmaps/ai-data-scientist/content/econometrics@Gd2egqKZPnbPW1W2jw4j8.md
@@ -1,3 +1,9 @@
 # Econometrics
 
 Econometrics is the application of statistical methods to economic data. It is a branch of economics that aims to give empirical content to economic relations. More precisely, it is "the quantitative analysis of actual economic phenomena based on the concurrent development of theory and observation, related by appropriate methods of inference." Econometrics can be described as something that allows economists "to sift through mountains of data to extract simple relationships."
+
+Visit the following resources to learn more:
+
+- [@official@Econometrics (MIT OpenCourseWare)](https://ocw.mit.edu/courses/14-382-econometrics-spring-2017/)
+- [@course@Econometrics: Methods and Applications](https://www.coursera.org/learn/erasmus-econometrics)
+- [@article@Lecture Notes and Short Texts in Econometrics](https://economicsnetwork.ac.uk/teaching/Lecture%20Notes%20and%20Short%20Texts/Econometrics)

--- a/src/data/roadmaps/ai-data-scientist/content/exploratory-data-analysis@l1027SBZxTHKzqWw98Ee-.md
+++ b/src/data/roadmaps/ai-data-scientist/content/exploratory-data-analysis@l1027SBZxTHKzqWw98Ee-.md
@@ -1,3 +1,10 @@
 # Exploratory Data Analysis
 
 Exploratory Data Analysis (EDA) is an approach to analyzing data sets to summarize their main characteristics, often with visual methods. EDA is used to understand what the data can tell us beyond the formal modeling or hypothesis testing task. It is a crucial step in the data analysis process.
+
+Visit the following resources to learn more:
+
+- [@official@pandas User Guide: Essential Basic Functionality](https://pandas.pydata.org/docs/user_guide/basics.html)
+- [@course@Exploratory Data Analysis with Python and Pandas](https://www.coursera.org/projects/exploratory-data-analysis-python-pandas)
+- [@article@Exploratory Data Analysis in Python](https://towardsdatascience.com/exploratory-data-analysis-in-python-c9a77dfa39ce/)
+- [@article@Step-by-Step Exploratory Data Analysis (EDA) using Python](https://www.analyticsvidhya.com/blog/2022/07/step-by-step-exploratory-data-analysis-eda-using-python/)

--- a/src/data/roadmaps/ai-data-scientist/content/statistics@4WZL_fzJ3cZdWLLDoWN8D.md
+++ b/src/data/roadmaps/ai-data-scientist/content/statistics@4WZL_fzJ3cZdWLLDoWN8D.md
@@ -1,3 +1,10 @@
 # Statistics
 
 Statistics is the science of collecting, analyzing, interpreting, presenting, and organizing data. It is a branch of mathematics that deals with the collection, analysis, interpretation, presentation, and organization of data. It is used in a wide range of fields, including science, engineering, medicine, and social science. Statistics is used to make informed decisions, to predict future events, and to test hypotheses. It is also used to summarize data, to describe relationships between variables, and to make inferences about populations based on samples.
+
+Visit the following resources to learn more:
+
+- [@course@Statistics and Probability (Khan Academy)](https://www.khanacademy.org/math/statistics-probability)
+- [@book@OpenIntro Statistics (free textbook)](https://www.openintro.org/book/os/)
+- [@course@Statistics with Python Specialization](https://www.coursera.org/specializations/statistics-with-python)
+- [@video@StatQuest with Josh Starmer](https://www.youtube.com/@statquest)


### PR DESCRIPTION
## Summary
- Four topics in the `ai-data-scientist` roadmap (Coding, Statistics, Econometrics, Exploratory Data Analysis) had explanatory copy but no resource links, leaving them without the "Visit the following resources to learn more" section other topics have.
- Adds official docs, free courses, and articles for each, following the style guide in `contributing.md` (`@official@`/`@course@`/`@article@`/`@book@`/`@video@` types, max 8 links per topic, no GeeksforGeeks).
- No changes to existing explanatory paragraphs — only additive.

## Test plan
- [x] Verified each linked resource resolves and matches the topic
- [x] Checked link formatting/type tags against existing filled-out topics (e.g. `data-analyst/content/what-is-data-analytics`) for consistency
- [ ] Maintainer review of resource choices