### PR TITLE
feat(claude-code): add MCP vs Skills video to skills topics

### DIFF
--- a/src/data/roadmaps/claude-code/content/skills-for-mcp@U22jPxfQWbu7-54OcsqkV.md
+++ b/src/data/roadmaps/claude-code/content/skills-for-mcp@U22jPxfQWbu7-54OcsqkV.md
@@ -7,3 +7,4 @@ Visit the following resources to learn more:
 - [@official@The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf?hsLang=en)
 - [@opensource@Anthropic Skills Guide](https://github.com/darraghh1/my-claude-setup/blob/main/docs/research/anthropic-skills-guide.md)
 - [@article@Claude Skills Library](https://mcpservers.org/claude-skills)
+- [@video@MCP vs Skills: Which Is Right for Your AI Agent and LLMs?](https://www.youtube.com/watch?v=goU9VIXA8II)

--- a/src/data/roadmaps/claude-code/content/skills@OJIfG7DRO4jgQEcberkNx.md
+++ b/src/data/roadmaps/claude-code/content/skills@OJIfG7DRO4jgQEcberkNx.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@official@Extend Claude with skills](https://code.claude.com/docs/en/skills#extend-claude-with-skills)
 - [@official@The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf?hsLang=en)
 - [@video@Claude Code Skills & skills.sh - Crash Course](https://www.youtube.com/watch?v=rcRS8-7OgBo)
+- [@video@MCP vs Skills: Which Is Right for Your AI Agent and LLMs?](https://www.youtube.com/watch?v=goU9VIXA8II)

--- a/src/data/roadmaps/claude-code/content/skills@iVa6piQwdPHIDkSRX8OSy.md
+++ b/src/data/roadmaps/claude-code/content/skills@iVa6piQwdPHIDkSRX8OSy.md
@@ -9,3 +9,4 @@ Visit the following resources to learn more:
 - [@official@Extend Claude with skills](https://code.claude.com/docs/en/skills)
 - [@official@The Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf?hsLang=en)
 - [@video@Claude Code Skills & skills.sh - Crash Course](https://www.youtube.com/watch?v=rcRS8-7OgBo)
+- [@video@MCP vs Skills: Which Is Right for Your AI Agent and LLMs?](https://www.youtube.com/watch?v=goU9VIXA8II)


### PR DESCRIPTION
## Summary
- Adds the IBM Technology video [MCP vs Skills: Which Is Right for Your AI Agent and LLMs?](https://www.youtube.com/watch?v=goU9VIXA8II) by Cedric Clyburn to three skills-related topics in the Claude Code roadmap.
- The video covers when to use Model Context Protocol versus Skills for extending AI agents, which is directly relevant to the Skills and Skills for MCP topics.
- Files changed:
  - `skills@iVa6piQwdPHIDkSRX8OSy.md` — main Skills topic
  - `skills@OJIfG7DRO4jgQEcberkNx.md` — Skills overview topic
  - `skills-for-mcp@U22jPxfQWbu7-54OcsqkV.md` — Skills for MCP topic

## Test plan
- [x] Verified the YouTube link resolves correctly
- [x] Followed the existing `@video@` tag format used by other resources
- [x] No changes to existing content — purely additive
- [ ] Maintainer review