### PR TITLE
Fix spacing in front of two links

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -119,8 +119,7 @@ const repoRank = await getRepositoryRank('nilbuild/developer-roadmap');
               class='font-bold underline'
               target='_blank'
               rel='nofollow'>GitHub pages</a
-            >. The project is open-core and the codebase 
-            <a
+            >. The project is open-core and the codebase <a
               href='https://github.com/nilbuild/developer-roadmap'
               class='font-bold underline'
               target='_blank'>can be found on GitHub</a
@@ -194,8 +193,7 @@ const repoRank = await getRepositoryRank('nilbuild/developer-roadmap');
               class='underline font-bold'
               href='https://twitter.com/kamrify'
               target='_blank'>@kamrify</a
-            > or email me at 
-            <a
+            > or email me at <a
               class='underline font-bold'
               href='mailto:kamranahmed.se@gmail.com'
               target='_blank'>kamranahmed.se@gmail.com</a


### PR DESCRIPTION
There are currently two spacing issues at https://roadmap.sh/about

<img width="1080" height="1221" alt="Screenshot_20260711_093151_Vivaldi" src="https://github.com/user-attachments/assets/d33f5179-087b-4116-b43c-1ef95ed578e9" />

<img width="1080" height="789" alt="Screenshot_20260711_093159_Vivaldi" src="https://github.com/user-attachments/assets/60082171-9151-4525-bbeb-4f7140f970df" />

This commit fixes them.