### PR TITLE
Rename Gemma2 topic to Gemma

### DIFF
--- a/src/data/roadmaps/ai-engineer/content/gemma2@MNtaY1_kOJHeoWuM-abb4.md
+++ b/src/data/roadmaps/ai-engineer/content/gemma2@MNtaY1_kOJHeoWuM-abb4.md
@@ -1,8 +1,0 @@
-# Gemma2
-
-Gemma2 is a family of open-source large language models (LLMs) developed by Google. These models are designed to be lightweight and high-performing, making them suitable for a variety of tasks, including text generation, question answering, and code completion. Gemma models are available in different sizes, allowing developers to select the best model for their specific resource constraints and performance requirements.
-
-Visit the following resources to learn more:
-
-- [@official@Gemma](https://deepmind.google/models/gemma/)
-- [@official@Gemma explained: What’s new in Gemma 2](https://developers.googleblog.com/gemma-explained-new-in-gemma-2/)

--- a/src/data/roadmaps/ai-engineer/content/gemma@MNtaY1_kOJHeoWuM-abb4.md
+++ b/src/data/roadmaps/ai-engineer/content/gemma@MNtaY1_kOJHeoWuM-abb4.md
@@ -1,0 +1,7 @@
+# Gemma
+
+Gemma is a family of open-source large language models (LLMs) developed by Google. These models are designed to be lightweight and high-performing, making them suitable for a variety of tasks, including text generation, question answering, and code completion. Gemma models are available in different sizes, allowing developers to select the best model for their specific resource constraints and performance requirements.
+
+Visit the following resources to learn more:
+
+- [@official@Gemma](https://deepmind.google/models/gemma/)


### PR DESCRIPTION
## What changed

- Renamed the Gemma topic content and sidebar title from `Gemma2` to `Gemma`.
- Updated the description to refer to the Gemma model family.
- Removed the outdated "Gemma explained: What's new in Gemma 2" free resource.

## Why

The other model entries use model-family names without version numbers. `Gemma2` was the only version-specific label, which made the roadmap inconsistent and tied the topic to an outdated release.

The roadmap node label is managed separately from topic content, so its required title-change request is tracked in #10149.

## Impact

The Gemma sidebar content uses the current family name and no longer recommends the outdated Gemma 2 article.

## Validation

- `git diff --cached --check`
- Searched the AI Engineer roadmap content for remaining `Gemma2`, `Gemma 2`, and removed-resource references.
