### PR TITLE
Update EC2 instance type from t2.micro to t3.micro

### DIFF
--- a/src/data/projects/ec2-instance.md
+++ b/src/data/projects/ec2-instance.md
@@ -31,7 +31,7 @@ You are required to complete the following tasks:
 - Familiarize yourself with the AWS Management Console.
 - Launch an EC2 instance with the following specifications:
    - Use Ubuntu Server AMI.
-   - Choose a `t2.micro` instance type (eligible for AWS Free Tier).
+   - Choose a `t3.micro` instance type (eligible for AWS Free Tier).
    - Use the default VPC and subnet for your region.
    - Configure the security group to allow inbound traffic on ports `22` (SSH) and `80` (HTTP).
    - Create a new key pair or use an existing one for SSH access.


### PR DESCRIPTION
The t2.micro is not eligible for Free Tier.

See the command output message:

```sh
$ aws ec2 run-instances --image-id ami-0ac1f955d6e62f3f1 --instance-type t2.micro

aws: [ERROR]: An error occurred (InvalidParameterCombination) when calling the RunInstances operation: The specified instance type is not eligible for Free Tier. For a list of Free Tier instance types, run 'describe-instance-types' with the filter 'free-tier-eligible=true'.
```