### PR TITLE
Add PromptTrace to AI Red Teaming lab environments

### DIFF
--- a/src/data/roadmaps/ai-red-teaming/content/lab-environments@MmwwRK4I9aRH_ha7duPqf.md
+++ b/src/data/roadmaps/ai-red-teaming/content/lab-environments@MmwwRK4I9aRH_ha7duPqf.md
@@ -7,5 +7,6 @@ Learn more from the following resources:
 - [@platform@HackAPrompt Playground](https://learnprompting.org/hackaprompt-playground)
 - [@platform@InjectPrompt Playground](https://playground.injectprompt.com/)
 - [@platform@Gandalf AI Prompt Injection Lab](https://gandalf.lakera.ai/)
+- [@platform@PromptTrace](https://prompttrace.airedlab.com)
 - [@platform@Hack The Box: Hacking Labs](https://www.hackthebox.com/hacker/hacking-labs)
 - [@platform@TryHackMe: Learn Cyber Security](https://tryhackme.com/)


### PR DESCRIPTION
Adds [PromptTrace](https://prompttrace.airedlab.com) to the **Lab Environments** node of the AI Red Teaming roadmap.

It sits naturally alongside the existing LLM-specific practice platforms in that node (HackAPrompt, InjectPrompt, Gandalf): PromptTrace is a free, hands-on platform with interactive labs and a progressive gauntlet where you practice prompt injection, jailbreaks, RAG poisoning, and tool/function-call abuse against real LLMs, plus the corresponding defenses.

- Free, no paywall to start
- Progressive difficulty (beginner → advanced) suited to learners on this roadmap
- Directly covers several adjacent nodes here (prompt-injection, jailbreak-techniques, prompt-hacking, safety-filter-bypasses)