### PR TITLE
Bump content sync workflows to Node 24 and pnpm 11

### DIFF
--- a/.github/workflows/cleanup-orphaned-content.yml
+++ b/.github/workflows/cleanup-orphaned-content.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm@v9
+      - name: Setup pnpm@v11
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
           run_install: false
 
-      - name: Setup Node.js Version 20 (LTS)
+      - name: Setup Node.js Version 24 (LTS)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Dependencies and Run Cleanup

--- a/.github/workflows/sync-content-to-repo.yml
+++ b/.github/workflows/sync-content-to-repo.yml
@@ -14,16 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm@v9
+      - name: Setup pnpm@v11
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
           run_install: false
 
-      - name: Setup Node.js Version 20 (LTS)
+      - name: Setup Node.js Version 24 (LTS)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Dependencies and Sync Content

--- a/.github/workflows/sync-repo-to-database.yml
+++ b/.github/workflows/sync-repo-to-database.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup pnpm@v9
+      - name: Setup pnpm@v11
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11
           run_install: false
 
-      - name: Setup Node.js Version 20 (LTS)
+      - name: Setup Node.js Version 24 (LTS)
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Get all roadmap files


### PR DESCRIPTION
## Summary
- Update `cleanup-orphaned-content`, `sync-content-to-repo`, and `sync-repo-to-database` workflows to Node.js 24 (LTS)
- Bump `pnpm/action-setup` version from 9 to 11 in the same workflows

## Test plan
- [ ] `sync-content-to-repo` runs successfully on its schedule/dispatch
- [ ] `sync-repo-to-database` runs successfully and syncs roadmap files
- [ ] `cleanup-orphaned-content` completes without dependency install errors