### PR TITLE
feat: add Buildkite as CI/CD tool to DevOps roadmap

### DIFF
--- a/roadmaps/devops/content/buildkite@Yt7mK9nPqL2dX5vR0cWe3.md
+++ b/roadmaps/devops/content/buildkite@Yt7mK9nPqL2dX5vR0cWe3.md
@@ -1,0 +1,10 @@
+# Buildkite
+
+Buildkite is a CI/CD platform that runs build agents on your own infrastructure while providing a hosted web interface for pipeline management. It combines the security and flexibility of self-hosted agents with the convenience of a SaaS dashboard, making it popular for teams with strict data residency requirements or large-scale build workloads.
+
+Visit the following resources to learn more:
+
+- [@official@Buildkite Website](https://buildkite.com/)
+- [@official@Buildkite Documentation](https://buildkite.com/docs)
+- [@official@Getting Started with Buildkite](https://buildkite.com/docs/tutorials/getting-started)
+- [@video@Buildkite Overview](https://www.youtube.com/watch?v=_lBPiA7fUvQ)

--- a/roadmaps/devops/content/buildkite@Yt7mK9nPqL2dX5vR0cWe3.md
+++ b/roadmaps/devops/content/buildkite@Yt7mK9nPqL2dX5vR0cWe3.md
@@ -7,4 +7,4 @@ Visit the following resources to learn more:
 - [@official@Buildkite Website](https://buildkite.com/)
 - [@official@Buildkite Documentation](https://buildkite.com/docs)
 - [@official@Getting Started with Buildkite](https://buildkite.com/docs/tutorials/getting-started)
-- [@video@Buildkite Overview](https://www.youtube.com/watch?v=_lBPiA7fUvQ)
+- [@video@Buildkite YouTube Channel](https://www.youtube.com/@Buildkite)


### PR DESCRIPTION
## Summary

- Adds content for Buildkite (`roadmaps/devops/content/buildkite@Yt7mK9nPqL2dX5vR0cWe3.md`) as a CI/CD tool in the DevOps roadmap
- Buildkite combines self-hosted agents with a hosted dashboard, and is widely used by Anthropic, OpenAI, Meta, Nvidia, Uber, and others
- Closes #10187

## Test plan

- [ ] Content file follows the existing format (title, description, resource links with type annotations)
- [ ] Links are valid and point to official Buildkite documentation
- [ ] Node ID in filename is updated to match the real ID once the visual node is added via the roadmap editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)